### PR TITLE
Use tox, the "test automation tool", on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__/
 *.png
 *.tex
 *~
+
+*.egg-info/
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
   - "3.6"
+install: pip install tox-travis
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: python
 python:
   - "3.6"
 script:
-  - pytest
+  - tox

--- a/echopype/version.py
+++ b/echopype/version.py
@@ -66,4 +66,4 @@ MINOR = _version_minor
 MICRO = _version_micro
 VERSION = __version__
 PACKAGE_DATA = {'echopype': [pjoin('data', '*')]}
-REQUIRES = ["numpy"]
+REQUIRES = ["numpy", "pandas"]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ opts = dict(name="echopype",
             packages=PACKAGES,
             package_data=PACKAGE_DATA,
             install_requires=REQUIRES,
-            requires=REQUIRES)
+            requires=REQUIRES,
+            test_requires=['tox'])
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ ver_file = os.path.join('echopype', 'version.py')
 with open(ver_file) as f:
     exec(f.read())
 
-opts = dict(name=echopype,
+opts = dict(name="echopype",
             maintainer=MAINTAINER,
             maintainer_email=MAINTAINER_EMAIL,
             description=DESCRIPTION,

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py36
+
+[testenv]
+deps = travis-tox
+commands = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,5 @@
 envlist = py36
 
 [testenv]
-deps = travis-tox
+deps = pytest
 commands = pytest


### PR DESCRIPTION
tox is suggested by pytest as a tool for testing your code for packaging errors.  Basically, run `pytest` most of the time to test code, then run `tox` to test how it's packaged and to test against multiple python versions.   Pull request also changes .travis.yml to use tox.