### PR TITLE
Add auto-generated API reference to documentation

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,20 +1,10 @@
 API reference
 ==============
 
+This page provides an auto-generated summary of echopype’s API.
 
-File conversion tools
-----------------------
+.. automodapi:: echopype.convert
+   :no-inheritance-diagram:
 
-.. autosummary::
-   :toctree: generated/
-
-   echopype.convert.ek60.ConvertEK60
-
-
-Echo data models
--------------------
-
-.. autosummary::
-   :toctree: generated/
-
-   echopype.model.ek60
+.. automodapi:: echopype.model
+   :no-inheritance-diagram:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,7 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
-import echopype
+# import echopype
 
 # -- Path setup --------------------------------------------------------------
 
@@ -17,6 +17,7 @@ import echopype
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../../'))
+# sys.path.append(os.path.join(os.path.abspath(os.pardir)))
 
 
 # -- Project information -----------------------------------------------------
@@ -26,33 +27,33 @@ copyright = '2018-, Wu-Jung Lee'
 author = 'Wu-Jung Lee'
 
 # The short X.Y version
-version = echopype.__version__
+# version = echopype.__version__
+
 # The full version, including alpha/beta/rc tags
-release = echopype.__version__
+# release = echopype.__version__
 
 
 # -- General configuration ---------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#
-# needs_sphinx = '1.0'
+needs_sphinx = '1.3'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
+    'sphinx_automodapi.automodapi',
+    'numpydoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
-    'sphinx.ext.githubpages',
+    'sphinx.ext.githubpages'
 ]
 
-autosummary_generate = True
+numpydoc_show_class_members = False
 
-numpydoc_class_members_toctree = True
-# numpydoc_show_class_members = False
+# autosummary_generate = True
+# numpydoc_class_members_toctree = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ scientists to make discovery using these new data.
    usage
    data-format
    resources
+   api
 
 
 

--- a/echopype/convert/__init__.py
+++ b/echopype/convert/__init__.py
@@ -1,1 +1,6 @@
+"""
+Include code to unpack manufacturer-specific data files into an interoperable netCDF format.
+"""
+
 from .ek60 import ConvertEK60
+from .set_nc_groups import SetGroups

--- a/echopype/convert/ek60.py
+++ b/echopype/convert/ek60.py
@@ -27,7 +27,7 @@ del get_versions
 
 
 class ConvertEK60(object):
-    """Class for converting EK60 .raw files."""
+    """Class for converting EK60 `.raw` files."""
 
     def __init__(self, _filename=""):
 
@@ -111,7 +111,7 @@ class ConvertEK60(object):
 
     @staticmethod
     def _read_config_header(chunk):
-        """Reading EK60 .raw configuration header information from the byte string passed in as a chunk.
+        """Reading EK60 `.raw` configuration header information from the byte string passed in as a chunk.
 
         This method unpacks info from configuration header into self.config_header
 
@@ -139,7 +139,7 @@ class ConvertEK60(object):
 
     @staticmethod
     def _read_config_transducer(chunk):
-        """Reading EK60 .raw configuration transducer information from the byte string passed in as a chunk.
+        """Reading EK60 `.raw` configuration transducer information from the byte string passed in as a chunk.
 
         This method unpacks info from transducer header info self.config_transducer
 
@@ -181,7 +181,7 @@ class ConvertEK60(object):
     def read_header(self, file_handle):
         """Read header and transducer config from EK60 raw data file.
 
-        This method calls private methods _read_config_header() and _read_config_transducer() to
+        This method calls private methods `_read_config_header()` and `_read_config_transducer()` to
         populate self.config_header and self.config_transducer.
         """
 
@@ -257,15 +257,19 @@ class ConvertEK60(object):
 
         Parameters
         ----------
-        input_file
+        input_file : str
             EK60 raw data file name
         transducer_count : int
             number of transducers
 
         Returns
         -------
-            data contained in each sample, in the following sequence:
-            channel, ntp_time, sample_data, power_data, angle_data
+        channel : int
+            number of channels in the sample
+        ntp_time : float
+            Network Time Protocol time
+        sample_data, power_data, angle_data : list
+            data and metadata contained in each sample
         """
         # log.trace('Processing one sample from input_file: %r', input_file)
         # print('Processing one sample from input_file')
@@ -337,7 +341,7 @@ class ConvertEK60(object):
         return metadata  # this may be removed?
 
     def load_ek60_raw(self):
-        """Method to parse the *.raw file.
+        """Method to parse the `.raw` file.
         """
         print('%s  converting file: %s' % (dt.now().strftime('%H:%M:%S'), os.path.basename(self.filename)))
 
@@ -463,7 +467,7 @@ class ConvertEK60(object):
             self.tr_data_dict = tr_data_dict
 
     def raw2nc(self):
-        """Save data from RAW to netCDF format.
+        """Save data from `.raw` to netCDF format.
         """
 
         # Subfunctions to set various dictionaries

--- a/echopype/convert/set_nc_groups.py
+++ b/echopype/convert/set_nc_groups.py
@@ -1,3 +1,7 @@
+"""
+Functions to unpack Simrad EK60 .raw and save to .nc.
+"""
+
 from __future__ import absolute_import, division, print_function
 import os
 import numpy as np

--- a/echopype/model/__init__.py
+++ b/echopype/model/__init__.py
@@ -1,12 +1,12 @@
 """
-Base echo data model.
+Include methods to manipulate echo data that is already converted to netCDF.
+Currently the operations include:
 
-Include methods to do the following:
 - calibration
 - noise removal
-- calculate MVBS
+- calculating mean volume backscattering strength (MVBS)
 
-The current version supports EK60 .raw data.
+The current version supports EK60 `.raw` data.
 """
 
 from .ek60 import EchoData

--- a/echopype/model/ek60.py
+++ b/echopype/model/ek60.py
@@ -10,7 +10,7 @@ import xarray as xr
 
 
 class EchoData(object):
-    """Base class for echo data."""
+    """Class for manipulating echo data that is already converted to netCDF."""
 
     def __init__(self, file_path=""):
         self.file_path = file_path  # this passes the input through file name test
@@ -115,7 +115,7 @@ class EchoData(object):
         These parameters are used in methods remove_noise(), noise_estimates(), get_MVBS().
 
         Parameters
-        -----------
+        ----------
         r_data_sz : int
             number of range_bin entries in data
         p_data_sz : int
@@ -128,7 +128,7 @@ class EchoData(object):
             thickness of each data sample, determined by sound speed and pulse duration
 
         Returns
-        --------
+        -------
         r_tile_sz : int
             modified tile size along the range dimension [m], determined by sample_thickness
         p_idx : list of int
@@ -171,7 +171,7 @@ class EchoData(object):
         Reference: De Robertis & Higginbottom, 2017, ICES Journal of Marine Sciences
 
         Parameters
-        ------------
+        ----------
         noise_est_range_bin_size : float, optional
             meters per tile for noise estimation [m]
         noise_est_ping_size : int, optional
@@ -228,8 +228,7 @@ class EchoData(object):
         proc_data.close()
 
     def noise_estimates(self, noise_est_range_bin_size=None, noise_est_ping_size=None):
-        """
-        Obtain noise estimates from the minimum mean calibrated power level along each column of tiles.
+        """Obtain noise estimates from the minimum mean calibrated power level along each column of tiles.
 
         The tiles here are defined by class attributes noise_est_range_bin_size and noise_est_ping_size.
         This method contains redundant pieces of code that also appear in method remove_noise(),
@@ -237,14 +236,14 @@ class EchoData(object):
         noise removal is actually performed.
 
         Parameters
-        ------------
+        ----------
         noise_est_range_bin_size : float
             meters per tile for noise estimation [m]
         noise_est_ping_size : int
             number of pings per tile for noise estimation
 
         Returns
-        ---------
+        -------
         noise_est : xarray DataSet
             noise estimates as a DataArray with dimension [ping_time x range_bin]
             ping_time and range_bin are taken from the first element of each tile along each of the dimensions
@@ -299,7 +298,7 @@ class EchoData(object):
         in the original Sv or Sv_clean DataArray.
 
         Parameters
-        ------------
+        ----------
         source : str
             source used to calculate MVBS, can be ``Sv`` or ``Sv_clean``,
             where ``Sv`` and ``Sv_clean`` are the original and denoised volume


### PR DESCRIPTION
- use [`sphinx-automodapi`](https://sphinx-automodapi.readthedocs.io/en/latest/)
- follow numpy docstring format, good reference [here](http://hplgit.github.io/teamods/sphinx_api/html/sphinx_api.html#simple-formatting-rules)