### PR TITLE
Improved and resolved all conflicts from PR #60 and #61

### DIFF
--- a/echopype/convert/azfp.py
+++ b/echopype/convert/azfp.py
@@ -486,6 +486,7 @@ class ConvertAZFP:
             # Largest number of counts along the range dimension among the different channels
             longest_range_bin = np.max(self.unpacked_data['num_bins'])
             range_bin = np.arange(longest_range_bin)
+            # TODO: replace the following with an explicit check of length of range across channels
             try:
                 np.array(N)
             # Exception occurs when N is not rectangular, so it must be padded with nan values to make it rectangular

--- a/echopype/model/azfp.py
+++ b/echopype/model/azfp.py
@@ -101,17 +101,6 @@ class ModelAZFP(ModelBase):
         # TODO: need to update sample_thickness, absorption, range
 
     @property
-    def sample_thickness(self):
-        if not self._sample_thickness:  # if this is empty
-            return self.calc_sample_thickness()
-        else:
-            return self._sample_thickness
-
-    @sample_thickness.setter
-    def sample_thickness(self, sth):
-        self._sample_thickness = sth
-
-    @property
     def range(self):
         if not self._range:  # if this is empty
             return self.calc_range()
@@ -138,6 +127,11 @@ class ModelAZFP(ModelBase):
 
         This will call ``calc_sound_speed`` since sound speed is `not` part of the raw AZFP .01A data file.
         """
+        # TODO: Change this to return the mean across all ping_time:
+        #  sth = self.sound_speed * ds_beam.sample_interval / 2
+        #  return sth.mean(dim='ping_time')
+        #  Change all methods in modelbase.py that uses self.sample_thickness
+
         with xr.open_dataset(self.file_path, group="Beam") as ds_beam:
             return self.sound_speed * ds_beam.sample_interval / 2
 
@@ -315,7 +309,7 @@ class ModelAZFP(ModelBase):
 
         # Save TVG and ABS for noise estimation use
         self.TVG = TVG
-        self.ABS = ABS
+        self.ABS = ABS.mean(dim='ping_time')
 
         self.Sv.name = "Sv"
         if save:

--- a/echopype/model/azfp.py
+++ b/echopype/model/azfp.py
@@ -18,8 +18,8 @@ class ModelAZFP(ModelBase):
         self.pressure = pressure           # pressure in [dbars] (approximately equal to depth in meters)
         self.temperature = temperature     # temperature in [Celsius]
         self.sound_speed = sound_speed     # sound speed in [m/s]
-        self._sample_thickness = None
-        self._range = None
+        # self._sample_thickness = None
+        # self._range = None
         self._seawater_absorption = None
 
     # TODO: consider moving some of these properties to the parent class,
@@ -99,17 +99,6 @@ class ModelAZFP(ModelBase):
     def sound_speed(self, ss):
         self._sound_speed = ss
         # TODO: need to update sample_thickness, absorption, range
-
-    @property
-    def range(self):
-        if not self._range:  # if this is empty
-            return self.calc_range()
-        else:
-            return self._range
-
-    @range.setter
-    def range(self, rr):
-        self._range = rr
 
     @property
     def seawater_absorption(self):
@@ -314,7 +303,7 @@ class ModelAZFP(ModelBase):
         self.Sv.name = "Sv"
         if save:
             print("{} saving calibrated Sv to {}".format(dt.datetime.now().strftime('%H:%M:%S'), self.Sv_path))
-            self.Sv.to_dataset(name="Sv").to_netcdf(path=self.Sv_path, mode="w")
+            self.Sv.to_netcdf(path=self.Sv_path, mode="w")
 
         # Close opened resources
         ds_env.close()
@@ -328,4 +317,4 @@ class ModelAZFP(ModelBase):
             self.TS.name = "TS"
             if save:
                 print("{} saving calibrated TS to {}".format(dt.datetime.now().strftime('%H:%M:%S'), self.TS_path))
-                self.TS.to_dataset(name="TS").to_netcdf(path=self.TS_path, mode="w")
+                self.TS.to_netcdf(path=self.TS_path, mode="w")

--- a/echopype/model/ek60.py
+++ b/echopype/model/ek60.py
@@ -21,15 +21,15 @@ class ModelEK60(ModelBase):
         return self._piece
 
     @piece.setter
-    def piece(self, piece):
+    def piece(self, p):
         with xr.open_dataset(self.file_path, group="Beam") as ds_beam:
-            pieces = list(range(int(ds_beam.pieces)))
-            if len(pieces) == 1:
-                raise ValueError("Your data does not have changing ranges")
-            if piece in pieces:
-                self._piece = piece
+            pp = list(range(int(ds_beam.pieces)))
+            if len(pp) == 1:
+                print('Your data does not have changing ranges')
+            if p in pp:
+                self._piece = p
             else:
-                raise ValueError(f"\'piece\' must be one of: {pieces}")
+                print(f"\'piece\' must be one of: {pp}")
 
     def get_biggest_piece(self):
         """Get the index of the biggest piece (which piece has the most pings)
@@ -88,6 +88,14 @@ class ModelEK60(ModelBase):
                     except KeyError:
                         raise(f'{sel} is not a valid input')
 
+    def calc_sample_thickness(self):
+        ds_env = xr.open_dataset(self.file_path, group="Environment")
+        ds_beam = xr.open_dataset(self.file_path, group="Beam")
+        sth = ds_env.sound_speed_indicative * ds_beam.sample_interval / 2  # sample thickness
+        ds_env.close()
+        ds_beam.close()
+        return sth
+
     def calc_range(self):
         """Calculates range in meters using parameters stored in the .nc file.
         """
@@ -99,8 +107,6 @@ class ModelEK60(ModelBase):
 
     def calibrate(self, save=False):
         """Perform echo-integration to get volume backscattering strength (Sv) from EK60 power data.
-
-        TODO: need to write a separate method for calculating TS as have been done for AZFP data.
 
         Parameters
         -----------
@@ -126,9 +132,7 @@ class ModelEK60(ModelBase):
                             (32 * np.pi ** 2))
 
         # Get TVG and absorption
-        range_meter = range_bin * self.sample_thickness - \
-            self.tvg_correction_factor * self.sample_thickness  # DataArray [frequency x range_bin]
-        range_meter = range_meter.where(range_meter > 0, other=0)  # set all negative elements to 0
+        range_meter = self.range
         TVG = np.real(20 * np.log10(range_meter.where(range_meter != 0, other=1)))
         ABS = 2 * ds_env.absorption_indicative * range_meter
 
@@ -142,6 +146,7 @@ class ModelEK60(ModelBase):
 
         # Save calibrated data into the calling instance and
         # ... to a separate .nc file in the same directory as the data filef.Sv = Sv
+        self.Sv = Sv
         if save:
             print('%s  saving calibrated Sv to %s' % (dt.datetime.now().strftime('%H:%M:%S'), self.Sv_path))
             Sv.to_netcdf(path=self.Sv_path, mode="w")
@@ -149,3 +154,6 @@ class ModelEK60(ModelBase):
         # Close opened resources
         ds_env.close()
         ds_beam.close()
+
+    # TODO: Need to write a separate method for calculating TS as have been done for AZFP data.
+

--- a/echopype/model/ek60.py
+++ b/echopype/model/ek60.py
@@ -88,6 +88,15 @@ class ModelEK60(ModelBase):
                     except KeyError:
                         raise(f'{sel} is not a valid input')
 
+    def calc_range(self):
+        """Calculates range in meters using parameters stored in the .nc file.
+        """
+        with xr.open_dataset(self.file_path, group="Beam") as ds_beam:
+            range_meter = ds_beam.range_bin * self.sample_thickness - \
+                        self.tvg_correction_factor * self.sample_thickness  # DataArray [frequency x range_bin]
+            range_meter = range_meter.where(range_meter > 0, other=0)
+            return range_meter
+
     def calibrate(self, save=False):
         """Perform echo-integration to get volume backscattering strength (Sv) from EK60 power data.
 

--- a/echopype/model/modelbase.py
+++ b/echopype/model/modelbase.py
@@ -25,6 +25,7 @@ class ModelBase(object):
         self.TS = None  # calibrated target strength
         self.MVBS = None  # mean volume backscattering strength
         self.SNR = 10  # min signal-to-noise ratio
+        # TODO: check how this differs from setting noise_floor in unpacking
         self.Sv_threshold = -120  # min Sv threshold
         
     @property

--- a/echopype/model/modelbase.py
+++ b/echopype/model/modelbase.py
@@ -141,9 +141,8 @@ class ModelBase(object):
         #  or a list of numbers.
 
         # Adjust noise_est_range_bin_size because range_bin_size may be an inconvenient value
-        sth = sample_thickness.mean(dim='ping_time')  # use mean sample thickness from all pings [m]
-        num_r_per_tile = (np.round(r_tile_sz / sth).astype(int)).values.max()  # num of range_bin per tile
-        r_tile_sz = (num_r_per_tile * sth).values
+        num_r_per_tile = (np.round(r_tile_sz / sample_thickness).astype(int)).values.max()  # num of range_bin per tile
+        r_tile_sz = (num_r_per_tile * sample_thickness).values
 
         # TODO: double check this, but edits from @cyrf0006 seems correct
         num_tile_range_bin = np.ceil(r_data_sz / num_r_per_tile).astype(int)
@@ -271,7 +270,7 @@ class ModelBase(object):
         Sv_clean = Sv_clean.to_dataset()
         Sv_clean['noise_est_range_bin_size'] = ('frequency', self.noise_est_range_bin_size)
         Sv_clean.attrs['noise_est_ping_size'] = self.noise_est_ping_size
-        Sv_clean['sample_thickness'] = ('frequency', self.sample_thickness.mean(dim='ping_time'))
+        Sv_clean['sample_thickness'] = ('frequency', self.sample_thickness)
 
         # Save as object attributes as a netCDF file
         self.Sv_clean = Sv_clean
@@ -336,7 +335,7 @@ class ModelBase(object):
         noise_est = noise_est.to_dataset(name='noise_est')
         noise_est['noise_est_range_bin_size'] = ('frequency', self.noise_est_range_bin_size)
         noise_est.attrs['noise_est_ping_size'] = self.noise_est_ping_size
-        noise_est['sample_thickness'] = ('frequency', self.sample_thickness.mean(dim='ping_time'))
+        noise_est['sample_thickness'] = ('frequency', self.sample_thickness)
 
         # Close opened resources
         proc_data.close()
@@ -370,8 +369,6 @@ class ModelBase(object):
         # TODO: Not sure what @cyrf0006 means below, but need to resolve the issues surrounding
         #  potentially having different sample_thickness for each frequency. This is the same
         #  issue that needs to be resolved in ``get_tile_params`` and all calling methods.
-        #  Another required fix alogn the same line is to revise calc_sample_thickness such that
-        #  there will be no need to do self.sample_thickness.mean(dim='ping_time')
         #  --- Below are comments from @cyfr0006 ---
         #  -FC here problem because self.MVBS_range_bin_size is size 4 while MVBS_range_bin_size is size 1
         #  if (MVBS_range_bin_size is not None) and (self.MVBS_range_bin_size != MVBS_range_bin_size):
@@ -426,7 +423,7 @@ class ModelBase(object):
         MVBS = MVBS.to_dataset()
         MVBS['noise_est_range_bin_size'] = ('frequency', self.MVBS_range_bin_size)
         MVBS.attrs['noise_est_ping_size'] = self.MVBS_ping_size
-        MVBS['sample_thickness'] = ('frequency', self.sample_thickness.mean(dim='ping_time'))
+        MVBS['sample_thickness'] = ('frequency', self.sample_thickness)
 
         # Save results in object and as a netCDF file
         self.MVBS = MVBS

--- a/echopype/model/modelbase.py
+++ b/echopype/model/modelbase.py
@@ -8,6 +8,7 @@ import datetime as dt
 import numpy as np
 import xarray as xr
 
+
 class ModelBase(object):
     """Class for manipulating echo data that is already converted to netCDF."""
 
@@ -55,7 +56,7 @@ class ModelBase(object):
                                         os.path.splitext(os.path.basename(self.file_path))[0] + '_TS.nc')
             self.MVBS_path = os.path.join(os.path.dirname(self.file_path),
                                           os.path.splitext(os.path.basename(self.file_path))[0] + '_MVBS.nc')
-
+            print('inside setter function')
             # Raise error if the file format convention does not match
             if self.toplevel.sonar_convention_name != 'SONAR-netCDF4':
                 raise ValueError('netCDF file convention not recognized.')
@@ -74,12 +75,10 @@ class ModelBase(object):
         return self._sample_thickness
 
     def calc_range(self):
-        # TODO: this should be specific for EK60, note tvg_correction_factor only exists for EK60
-        with xr.open_dataset(self.file_path, group="Beam") as ds_beam:
-            range_meter = ds_beam.range_bin * self.sample_thickness - \
-                        self.tvg_correction_factor * self.sample_thickness  # DataArray [frequency x range_bin]
-            range_meter = range_meter.where(range_meter > 0, other=0)
-            return range_meter
+        """Base method to be overridden for calculating range for different sonar models.
+        """
+        # issue warning when subclass methods not available
+        print('Range calculation has not been implemented for this sonar model!')
 
     def calibrate(self):
         """Base method to be overridden for calibration and echo-integration for different sonar models.

--- a/echopype/model/modelbase.py
+++ b/echopype/model/modelbase.py
@@ -24,11 +24,12 @@ class ModelBase(object):
         self.Sv_clean = None  # denoised volume backscattering strength
         self.TS = None  # calibrated target strength
         self.MVBS = None  # mean volume backscattering strength
-        self.SNR = 10  # min signal-to-noise ratio
-        # TODO: check how this differs from setting noise_floor in unpacking
-        self.Sv_threshold = -120  # min Sv threshold
-
         self._sample_thickness = None
+        self._range = None
+
+    # TODO: Set noise_est_range_bin_size, noise_est_ping_size,
+    #  MVBS_range_bin_size, and MVBS_ping_size all to be properties
+    #  and provide getter/setter
 
     @property
     def sample_thickness(self):
@@ -40,6 +41,17 @@ class ModelBase(object):
     @sample_thickness.setter
     def sample_thickness(self, sth):
         self._sample_thickness = sth
+
+    @property
+    def range(self):
+        if not self._range:  # if this is empty
+            return self.calc_range()
+        else:
+            return self._range
+
+    @range.setter
+    def range(self, rr):
+        self._range = rr
 
     @property
     def file_path(self):

--- a/echopype/model/modelbase.py
+++ b/echopype/model/modelbase.py
@@ -324,7 +324,7 @@ class ModelBase(object):
         proc_data['power_cal'] = 10 ** ((proc_data.Sv - self.ABS - self.TVG) / 10)
         proc_data.coords['add_idx'] = ('ping_time', add_idx)
         noise_est = 10 * np.log10(proc_data.power_cal.groupby('add_idx').mean('ping_time').
-                                  groupby_bins('range_bin', range_bin_tile_bin_edge).mean(['range_bin']).
+                                  groupby_bins('range_bin', range_bin_tile_bin_edge).mean('range_bin').
                                   min('range_bin_bins'))
 
         # Set noise estimates coordinates and other attributes
@@ -401,10 +401,10 @@ class ModelBase(object):
         proc_data.coords['add_idx'] = ('ping_time', add_idx)
         if source == 'Sv':
             MVBS = proc_data.Sv.groupby('add_idx').mean('ping_time').\
-                groupby_bins('range_bin', range_bin_tile_bin_edge).mean(['range_bin'])
+                groupby_bins('range_bin', range_bin_tile_bin_edge).mean('range_bin')
         elif source == 'Sv_clean':
             MVBS = proc_data.Sv_clean.groupby('add_idx').mean('ping_time').\
-                groupby_bins('range_bin', range_bin_tile_bin_edge).mean(['range_bin'])
+                groupby_bins('range_bin', range_bin_tile_bin_edge).mean('range_bin')
         else:
             raise ValueError('Unknown source, cannot calculate MVBS')
         

--- a/echopype/tests/test_azfp_model.py
+++ b/echopype/tests/test_azfp_model.py
@@ -21,16 +21,18 @@ def test_model_AZFP():
 
     tmp_echo = EchoData(tmp_convert.nc_path)
     tmp_echo.calibrate(save=True)
-    tmp_echo.calibrate_ts(save=True)
+    tmp_echo.calibrate_TS(save=True)
     tmp_echo.get_MVBS()
 
+    # TODO: atol=1e-3 is a large number, need to track down which part
+    #  of the calculation contributes to this large discrepancy.
     # Test Sv data
     with xr.open_dataset(tmp_echo.Sv_path) as ds_Sv:
-        assert np.allclose(Sv_test.Sv, ds_Sv.Sv, atol=1)
+        assert np.allclose(Sv_test.Sv, ds_Sv.Sv, atol=1e-3)
 
     # Test TS data
     with xr.open_dataset(tmp_echo.TS_path) as ds_TS:
-        assert np.allclose(TS_test.TS, ds_TS.TS, atol=1)
+        assert np.allclose(TS_test.TS, ds_TS.TS, atol=1e-3)
 
     Sv_test.close()
     TS_test.close()

--- a/echopype/tests/test_ek60_model.py
+++ b/echopype/tests/test_ek60_model.py
@@ -1,8 +1,8 @@
 import os
 import numpy as np
 import xarray as xr
-from echopype.convert.ek60 import ConvertEK60
-from echopype.model.ek60 import ModelEK60
+from echopype.convert import Convert
+from echopype.model import EchoData
 
 # ek60_raw_path = './echopype/test_data/ek60/2015843-D20151023-T190636.raw'   # Varying ranges
 ek60_raw_path = './echopype/test_data/ek60/DY1801_EK60-D20180211-T164025.raw'     # Constant ranges
@@ -18,11 +18,11 @@ def test_noise_estimates_removal():
 
     # Noise estimation via EchoData method =========
     # Unpack data and convert to .nc file
-    tmp = ConvertEK60(ek60_raw_path)
+    tmp = Convert(ek60_raw_path)
     tmp.raw2nc()
 
     # Read .nc file into an EchoData object and calibrate
-    e_data = ModelEK60(nc_path)
+    e_data = EchoData(nc_path)
     e_data.calibrate(save=True)
     noise_est = e_data.noise_estimates()
     e_data.remove_noise()
@@ -92,5 +92,3 @@ def test_noise_estimates_removal():
     del e_data
     os.remove(nc_path)
     os.remove(Sv_path)
-
-test_noise_estimates_removal()


### PR DESCRIPTION
This PR includes improvements to both AZFP and EK60 parts of code due to changes in the model module that involves common properties for data from both types of echosounders. 

This PR also resolves all merge conflicts from #60:
- AZFP data unpacking is cleaned up for <4 frequencies of data
- adds an explicit `range` property for both AZFP and EK60 data
- confirms and fixes +1 error in `num_tile_range_bin` when finding tile params
- adds `SNR` and `Sv_threshold` as input params to `remove_noise` for flexibility (in #60 these were set as attributes but this way these settings are more explicit)

Remained to be worked on in later PRs are:
- incorporating all changes to documentation
- tiling params now are still calculated assuming data from all freq are of the same sample_thickness; this is often not true so `get_tile_params` and associated functions need to be fixed
- structural overhaul to model/azfp and model/ek60 for clarity and maintenance, especially on common properties
- improvements to visualization module
