### PR TITLE
Fix bugs in converting and processing files from various EK60 setups

### DIFF
--- a/echopype/convert/ek60.py
+++ b/echopype/convert/ek60.py
@@ -172,39 +172,35 @@ class ConvertEK60(ConvertBase):
 
         # Initialize dictionaries. keys are index for ranges. values are dictionaries with keys for each freq
         uni_cnt_insert = np.cumsum(np.insert(uni_cnt, 0, 0))
-        beam_type = np.array([self.config_datagram['transceivers'][x]['beam_type']
-                              for x in self.config_datagram['transceivers'].keys()])
+        beam_type = np.array([x['beam_type'] for x in self.config_datagram['transceivers'].values()])
         for range_group in range(len(uni)):
             self.ping_time_split[range_group] = np.array(self.ping_time)[uni_cnt_insert[range_group]:
                                                                          uni_cnt_insert[range_group+1]]
             range_bin_freq_lens = np.unique(
-                [x_val[uni_cnt_insert[range_group]].shape for x_key,x_val in self.power_dict.items()])
+                [x_val[uni_cnt_insert[range_group]].shape for x_val in self.power_dict.values()])
+            self.angle_dict_split[range_group] = np.empty(
+                (len(self.power_dict), uni_cnt_insert[range_group + 1] - uni_cnt_insert[range_group],
+                 range_bin_freq_lens.max(), 2))
+            self.angle_dict_split[range_group][:] = np.nan
             if len(range_bin_freq_lens) != 1:  # different frequency channels have different range_bin lengths
-                tmp_power_pad = []
-                for x_key, x in self.power_dict.items():  # pad nan to shorter channels
-                    tmp_data = np.array(x[uni_cnt_insert[range_group]:uni_cnt_insert[range_group + 1]])
-                    tmp_power = np.pad(tmp_data.astype('float64'),
-                                       ((0, 0), (0, range_bin_freq_lens.max()-tmp_data.shape[1])),
+                tmp_power_pad, tmp_angle_pad = [], []
+                for x_p, x_a in zip(self.power_dict.values(), self.angle_dict.values()):  # pad nan to shorter channels
+                    tmp_p_data = np.array(x_p[uni_cnt_insert[range_group]:uni_cnt_insert[range_group + 1]])
+                    tmp_a_data = np.array(x_a[uni_cnt_insert[range_group]:uni_cnt_insert[range_group + 1]])
+                    tmp_power = np.pad(tmp_p_data.astype('float64'),
+                                       ((0, 0), (0, range_bin_freq_lens.max()-tmp_p_data.shape[1])),
+                                       mode='constant', constant_values=(np.nan,))
+                    tmp_angle = np.pad(tmp_a_data.astype('float64'),
+                                       ((0, 0), (0, range_bin_freq_lens.max()-tmp_a_data.shape[1]), (0, 0)),
                                        mode='constant', constant_values=(np.nan,))
                     tmp_power_pad.append(tmp_power)
+                    tmp_angle_pad.append(tmp_angle)
+                self.angle_dict_split[range_group] = np.array(tmp_angle_pad)
                 self.power_dict_split[range_group] = np.array(tmp_power_pad) * INDEX2POWER
             else:
                 self.power_dict_split[range_group] = np.array(
                     [x[uni_cnt_insert[range_group]:uni_cnt_insert[range_group + 1]]
                      for x_key, x in self.power_dict.items()]) * INDEX2POWER
-            self.angle_dict_split[range_group] = np.empty(np.hstack(
-                (np.array(self.power_dict_split[range_group].shape), 2)))
-            self.angle_dict_split[range_group][:] = np.nan
-            if len(range_bin_freq_lens) != 1:  # also pad angle data if need to pad power data
-                tmp_angle_pad = []
-                for x_key, x in self.angle_dict.items():  # pad nan to shorter channels
-                    tmp_data = np.array(x[uni_cnt_insert[range_group]:uni_cnt_insert[range_group + 1]])
-                    tmp_angle = np.pad(tmp_data.astype('float64'),
-                                       ((0, 0), (0, range_bin_freq_lens.max()-tmp_data.shape[1]), (0, 0)),
-                                       mode='constant', constant_values=(np.nan,))
-                    tmp_angle_pad.append(tmp_angle)
-                self.angle_dict_split[range_group] = np.array(tmp_angle_pad)
-            else:
                 for ch in np.argwhere(beam_type == 1):   # if split-beam
                     self.angle_dict_split[range_group][ch, :, :, :] = np.array(
                         self.angle_dict[ch[0]+1][uni_cnt_insert[range_group]:uni_cnt_insert[range_group + 1]])

--- a/echopype/convert/ek60.py
+++ b/echopype/convert/ek60.py
@@ -287,7 +287,7 @@ class ConvertEK60(ConvertBase):
                             sonar_convention_version='1.7',
                             summary='',
                             title='')
-            out_dict['date_created'] = dt.strptime(filedate + '-' + filetime,'%Y%m%d-%H%M%S').isoformat() + 'Z'
+            out_dict['date_created'] = dt.strptime(filedate + '-' + filetime, '%Y%m%d-%H%M%S').isoformat() + 'Z'
             return out_dict
 
         def _set_env_dict():

--- a/echopype/model/ek60.py
+++ b/echopype/model/ek60.py
@@ -106,7 +106,7 @@ class ModelEK60(ModelBase):
         #  to a separate .nc file in the same directory as the data filef.Sv = Sv
         self.Sv = Sv
         if save:
-            if save_postfix is not '_Sv':
+            if save_postfix != '_Sv':
                 self.Sv_path = os.path.join(os.path.dirname(self.file_path),
                                             os.path.splitext(os.path.basename(self.file_path))[0] +
                                             save_postfix + '.nc')

--- a/echopype/model/ek60.py
+++ b/echopype/model/ek60.py
@@ -82,7 +82,6 @@ class ModelEK60(ModelBase):
 
         # Get backscatter_r and range_bin
         backscatter_r = ds_beam['backscatter_r']
-        range_bin = ds_beam['range_bin']
 
         # Calc gain
         CSv = 10 * np.log10((ds_beam.transmit_power * (10 ** (ds_beam.gain_correction / 10)) ** 2 *

--- a/echopype/model/modelbase.py
+++ b/echopype/model/modelbase.py
@@ -491,7 +491,7 @@ class ModelBase(object):
                                 coords={'frequency': Sv_linear['frequency'].values,
                                         'ping_time': tmp_MVBS[0]['ping_time'].values,
                                         'range_bin': np.arange(MVBS_val.shape[2])},
-                                dims=['frequency', 'ping_time', 'range_bin'])
+                                dims=['frequency', 'ping_time', 'range_bin']).dropna(dim='range_bin', how='all')
 
         # Set MVBS attributes
         MVBS.name = 'MVBS'

--- a/echopype/model/modelbase.py
+++ b/echopype/model/modelbase.py
@@ -424,13 +424,13 @@ class ModelBase(object):
 
         # Noise estimates
         proc_data['power_cal'] = 10 ** ((proc_data.Sv - ABS - TVG) / 10)
-        if len(self.noise_est_range_bin_size) == 1:  # if number of range_bin per tile the same for all freq channels
+        if np.unique(self.noise_est_range_bin_size).shape[0] == 1:  # if number of range_bin per tile the same for all freq channels
             noise_est = 10 * np.log10(proc_data['power_cal'].coarsen(
                 ping_time=self.noise_est_ping_size,
                 range_bin=int(np.unique(self.noise_est_range_bin_size / self.sample_thickness)),
                 boundary='pad').mean().min(dim='range_bin'))
         else:
-            range_bin_coarsen_idx = (self.MVBS_range_bin_size / self.sample_thickness).astype(int)
+            range_bin_coarsen_idx = (self.noise_est_range_bin_size / self.sample_thickness).astype(int)
             tmp_noise = []
             for r_bin in range_bin_coarsen_idx:
                 freq = r_bin.frequency.values

--- a/echopype/model/modelbase.py
+++ b/echopype/model/modelbase.py
@@ -227,28 +227,19 @@ class ModelBase(object):
         #  or a list of numbers.
 
         # Adjust noise_est_range_bin_size because range_bin_size may be an inconvenient value
-        num_r_per_tile = (np.round(r_tile_sz / sample_thickness).astype(int)).values.max()  # num of range_bin per tile
-        r_tile_sz = (num_r_per_tile * sample_thickness).values
+        num_r_per_tile = np.round(r_tile_sz / sample_thickness).astype(int)  # num of range_bin per tile
+        r_tile_sz = num_r_per_tile * sample_thickness
 
-        # TODO: double check this, but edits from @cyrf0006 seems correct
+        # Total number of range_bin and ping tiles
         num_tile_range_bin = np.ceil(r_data_sz / num_r_per_tile).astype(int)
-        # Number of tiles along range_bin <--- old routine
-        # if np.mod(r_data_sz, num_r_per_tile) == 0:
-        #     num_tile_range_bin = np.ceil(r_data_sz / num_r_per_tile).astype(int) + 1
-        # else:
-        #     num_tile_range_bin = np.ceil(r_data_sz / num_r_per_tile).astype(int)
-
-        # Produce a new coordinate for groupby operation
         if np.mod(p_data_sz, p_tile_sz) == 0:
             num_tile_ping = np.ceil(p_data_sz / p_tile_sz).astype(int) + 1
         else:
             num_tile_ping = np.ceil(p_data_sz / p_tile_sz).astype(int)
-            pad = np.ones(p_data_sz - (num_tile_ping - 1) * p_tile_sz, dtype=int) \
-                  * (num_tile_ping - 1)
 
         # Tile bin edges along range
         # ... -1 to make sure each bin has the same size because of the right-inclusive and left-exclusive bins
-        r_tile_bin_edge = np.arange(num_tile_range_bin+1) * num_r_per_tile - 1
+        r_tile_bin_edge = [np.arange(x.values) * y.values - 1 for x, y in zip(num_tile_range_bin, num_r_per_tile)]
         p_tile_bin_edge = np.arange(num_tile_ping + 1) * p_tile_sz - 1
 
         return r_tile_sz, r_tile_bin_edge, p_tile_bin_edge
@@ -358,7 +349,7 @@ class ModelBase(object):
         # Save as object attributes as a netCDF file
         self.Sv_clean = Sv_clean
         if save:
-            if save_postfix is not '_Sv_clean':
+            if save_postfix != '_Sv_clean':
                 self.Sv_clean_path = os.path.join(os.path.dirname(self.file_path),
                                                   os.path.splitext(os.path.basename(self.file_path))[0] +
                                                   save_postfix + '.nc')
@@ -452,17 +443,7 @@ class ModelBase(object):
             whether to save the denoised Sv (``Sv_clean``) into a new .nc file
             default to ``False``
         """
-        # TODO: Overall -- change to use coarsen and resample (+groupby_bins) for
-        #  MVBS calculation. Also right now the code uses mean in the log domain, it
-        #  should be mean in the linear domain.
-
         # Check params
-        # TODO: Not sure what @cyrf0006 meant below, but need to resolve the issues surrounding
-        #  potentially having different sample_thickness for each frequency. This is the same
-        #  issue that needs to be resolved in ``get_tile_params`` and all calling methods.
-        #  --- Below are comments from @cyfr0006 ---
-        #  -FC here problem because self.MVBS_range_bin_size is size 4 while MVBS_range_bin_size is size 1
-        #  if (MVBS_range_bin_size is not None) and (self.MVBS_range_bin_size != MVBS_range_bin_size):
         if (MVBS_range_bin_size is not None) and (self.MVBS_range_bin_size != MVBS_range_bin_size):
             self.MVBS_range_bin_size = MVBS_range_bin_size
         if (MVBS_ping_size is not None) and (self.MVBS_ping_size != MVBS_ping_size):
@@ -485,35 +466,32 @@ class ModelBase(object):
                                  sample_thickness=self.sample_thickness)
         # Calculate MVBS
         Sv_linear = 10 ** (proc_data.Sv / 10)  # convert to linear domain before averaging
-        MVBS = 10 * np.log10(Sv_linear.coarsen(ping_time=self.MVBS_ping_size,
-                                               range_bin=int(np.unique(self.MVBS_range_bin_size/self.sample_thickness)),
-                                               boundary='pad').mean())
-        MVBS.coords['range_bin'] = ('range_bin', np.arange(MVBS['range_bin'].size))
-        #
-        # proc_data.coords['add_idx'] = ('ping_time', add_idx)
-        # if source == 'Sv':
-        #     MVBS = proc_data.Sv.groupby('add_idx').mean('ping_time').\
-        #         groupby_bins('range_bin', range_bin_tile_bin_edge).mean('range_bin')
-        # elif source == 'Sv_clean':
-        #     # TODO: the calculation below issues warnings when encountering all NaN slices.
-        #     #  This is an open issue in dask: https://github.com/dask/dask/issues/3245
-        #     #  Suppress this warning for now.
-        #     with warnings.catch_warnings():
-        #         warnings.simplefilter("ignore")
-        #         MVBS = proc_data.Sv_clean.groupby('add_idx').mean('ping_time').\
-        #             groupby_bins('range_bin', range_bin_tile_bin_edge).mean('range_bin')
-        # else:
-        #     raise ValueError('Unknown source, cannot calculate MVBS')
+        if len(self.MVBS_range_bin_size) == 1:  # if number of range_bin per tile the same for all freq channels
+            MVBS = 10 * np.log10(Sv_linear.coarsen(
+                ping_time=self.MVBS_ping_size,
+                range_bin=int(np.unique(self.MVBS_range_bin_size / self.sample_thickness)),
+                boundary='pad').mean())
+            MVBS.coords['range_bin'] = ('range_bin', np.arange(MVBS['range_bin'].size))
+        else:
+            range_bin_coarsen_idx = (self.MVBS_range_bin_size / self.sample_thickness).astype(int)
+            tmp_MVBS = []
+            for r_bin in range_bin_coarsen_idx:
+                freq = r_bin.frequency.values
+                tmp_da = 10 * np.log10(Sv_linear.sel(frequency=freq).coarsen(
+                        ping_time=self.MVBS_ping_size,
+                        range_bin=r_bin.values,
+                        boundary='pad').mean())
+                tmp_da.coords['range_bin'] = ('range_bin', np.arange(tmp_da['range_bin'].size))
+                tmp_da.name = 'MVBS'
+                tmp_MVBS.append(tmp_da)
 
-        # Set MVBS coordinates
-        # ping_time = proc_data.ping_time[list(map(lambda x: x[0],
-        #                                          list(proc_data.ping_time.groupby('add_idx').groups.values())))]
-        # MVBS.coords['ping_time'] = ('add_idx', ping_time)
-        # range_bin = list(map(lambda x: x[0], list(proc_data.range_bin.
-        #                                           groupby_bins('range_bin', range_bin_tile_bin_edge).groups.values())))
-        # MVBS.coords['range_bin'] = ('range_bin_bins', range_bin)
-        # MVBS = MVBS.swap_dims({'range_bin_bins': 'range_bin', 'add_idx': 'ping_time'}).\
-        #     drop_vars({'add_idx', 'range_bin_bins'})
+            # Construct a dataArray  TODO: this can probably be done smarter using xarray native functions
+            MVBS_val = np.array([zz.values for zz in xr.align(*tmp_MVBS, join='outer')])
+            MVBS = xr.DataArray(MVBS_val,
+                                coords={'frequency': Sv_linear['frequency'].values,
+                                        'ping_time': tmp_MVBS[0]['ping_time'].values,
+                                        'range_bin': np.arange(MVBS_val.shape[2])},
+                                dims=['frequency', 'ping_time', 'range_bin'])
 
         # Set MVBS attributes
         MVBS.name = 'MVBS'
@@ -528,11 +506,6 @@ class ModelBase(object):
         #  and also save an additional attribute that specifies the source
         # MVBS.attrs['noise_est_range_bin_size'] = self.noise_est_range_bin_size
         # MVBS.attrs['noise_est_ping_size'] = self.noise_est_ping_size
-
-        # # Drop add_idx added to Sv
-        # # TODO: somehow this still doesn't work and self.Sv or self.Sv_clean
-        # #  will have this additional dimension attached
-        # proc_data = proc_data.drop_vars('add_idx')
 
         # Save results in object and as a netCDF file
         self.MVBS = MVBS

--- a/echopype/model/modelbase.py
+++ b/echopype/model/modelbase.py
@@ -337,7 +337,7 @@ class ModelBase(object):
         TVG.name = 'TVG'
         pp = xr.merge([proc_data, ABS])
         pp = xr.merge([pp, TVG])
-        if np.unique(range_bin_tile_bin_edge, axis=0).shape[0] == 1:
+        if np.unique(self.noise_est_range_bin_size).shape[0] == 1:
             Sv_clean = pp.groupby_bins('ping_idx', ping_tile_bin_edge).\
                             map(remove_n, rr=range_bin_tile_bin_edge[0])
             Sv_clean = Sv_clean.drop_vars(['ping_idx', 'ping_idx_bins'])

--- a/echopype/model/modelbase.py
+++ b/echopype/model/modelbase.py
@@ -337,7 +337,8 @@ class ModelBase(object):
         TVG.name = 'TVG'
         pp = xr.merge([proc_data, ABS])
         pp = xr.merge([pp, TVG])
-        if np.unique(self.noise_est_range_bin_size).shape[0] == 1:
+        # check if number of range_bin per tile the same for all freq channels
+        if np.unique([np.array(x).size for x in range_bin_tile_bin_edge]).size == 1:
             Sv_clean = pp.groupby_bins('ping_idx', ping_tile_bin_edge).\
                             map(remove_n, rr=range_bin_tile_bin_edge[0])
             Sv_clean = Sv_clean.drop_vars(['ping_idx', 'ping_idx_bins'])
@@ -424,7 +425,8 @@ class ModelBase(object):
 
         # Noise estimates
         proc_data['power_cal'] = 10 ** ((proc_data.Sv - ABS - TVG) / 10)
-        if np.unique(self.noise_est_range_bin_size).shape[0] == 1:  # if number of range_bin per tile the same for all freq channels
+        # check if number of range_bin per tile the same for all freq channels
+        if np.unique([np.array(x).size for x in range_bin_tile_bin_edge]).size == 1:
             noise_est = 10 * np.log10(proc_data['power_cal'].coarsen(
                 ping_time=self.noise_est_ping_size,
                 range_bin=int(np.unique(self.noise_est_range_bin_size / self.sample_thickness)),
@@ -502,7 +504,8 @@ class ModelBase(object):
                                  sample_thickness=self.sample_thickness)
         # Calculate MVBS
         Sv_linear = 10 ** (proc_data.Sv / 10)  # convert to linear domain before averaging
-        if len(self.MVBS_range_bin_size) == 1:  # if number of range_bin per tile the same for all freq channels
+        # check if number of range_bin per tile the same for all freq channels
+        if np.unique([np.array(x).size for x in range_bin_tile_bin_edge]).size == 1:
             MVBS = 10 * np.log10(Sv_linear.coarsen(
                 ping_time=self.MVBS_ping_size,
                 range_bin=int(np.unique(self.MVBS_range_bin_size / self.sample_thickness)),

--- a/echopype/model/modelbase.py
+++ b/echopype/model/modelbase.py
@@ -239,7 +239,7 @@ class ModelBase(object):
 
         # Tile bin edges along range
         # ... -1 to make sure each bin has the same size because of the right-inclusive and left-exclusive bins
-        r_tile_bin_edge = [np.arange(x.values) * y.values - 1 for x, y in zip(num_tile_range_bin, num_r_per_tile)]
+        r_tile_bin_edge = [np.arange(x.values + 1) * y.values - 1 for x, y in zip(num_tile_range_bin, num_r_per_tile)]
         p_tile_bin_edge = np.arange(num_tile_ping + 1) * p_tile_sz - 1
 
         return r_tile_sz, r_tile_bin_edge, p_tile_bin_edge
@@ -323,8 +323,8 @@ class ModelBase(object):
         # Function for use with apply
         def remove_n(x, rr):
             p_c_lin = 10 ** ((x.Sv - x.ABS - x.TVG) / 10)
-            nn = 10 * np.log10(p_c_lin.mean(dim='ping_time')).groupby_bins('range_bin', rr).mean().min(
-                dim='range_bin_bins') + x.ABS + x.TVG
+            nn = 10 * np.log10(p_c_lin.mean(dim='ping_time').groupby_bins('range_bin', rr).mean().min(
+                dim='range_bin_bins')) + x.ABS + x.TVG
             # Return values where signal is [SNR] dB above noise and at least [Sv_threshold] dB
             if not Sv_threshold:
                 return x.Sv.where(x.Sv > (nn + SNR), other=np.nan)

--- a/echopype/tests/test_ek60_model.py
+++ b/echopype/tests/test_ek60_model.py
@@ -26,7 +26,7 @@ def test_noise_estimates_removal():
     e_data = EchoData(nc_path)
     e_data.calibrate(save=True)
     noise_est = e_data.noise_estimates()
-    # e_data.remove_noise()
+    e_data.remove_noise()
 
     with xr.open_dataset(ek60_test_path) as ds_test:
         ds_Sv = ds_test.Sv
@@ -36,65 +36,67 @@ def test_noise_estimates_removal():
     # Noise estimation via numpy brute force =======
     proc_data = xr.open_dataset(Sv_path)
 
-    # # Get tile indexing parameters
-    # e_data.noise_est_range_bin_size, range_bin_tile_bin_edge, ping_tile_bin_edge = \
-    #     e_data.get_tile_params(r_data_sz=proc_data.range_bin.size,
-    #                            p_data_sz=proc_data.ping_time.size,
-    #                            r_tile_sz=e_data.noise_est_range_bin_size,
-    #                            p_tile_sz=e_data.noise_est_ping_size,
-    #                            sample_thickness=e_data.sample_thickness)
-    #
-    # range_meter = e_data.range
-    # TVG = np.real(20 * np.log10(range_meter.where(range_meter >= 1, other=1)))
-    # ABS = 2 * e_data.seawater_absorption * range_meter
-    # power_cal_test = (10 ** ((proc_data.Sv - ABS - TVG) / 10)).values
-    #
-    # num_ping_bins = ping_tile_bin_edge.size -1 #np.unique(add_idx).size
-    # num_range_bins = range_bin_tile_bin_edge.size - 1
-    # noise_est_tmp = np.empty((proc_data.frequency.size, num_range_bins, num_ping_bins))  # all tiles
-    # noise_est_test = np.empty((proc_data.frequency.size, num_ping_bins))  # all columns
-    # p_sz = e_data.noise_est_ping_size
-    # p_idx = np.arange(p_sz, dtype=int)
-    # r_sz = (e_data.noise_est_range_bin_size.max() / e_data.sample_thickness[0].values).astype(int)
-    # r_idx = np.arange(r_sz, dtype=int)
-    #
-    # # Get noise estimates manually
-    # for f_seq in np.arange(proc_data.frequency.size):
-    #     for p_seq in np.arange(num_ping_bins):
-    #         for r_seq in np.arange(num_range_bins):
-    #             if p_idx[-1] + p_sz * p_seq < power_cal_test.shape[1]:
-    #                 pp_idx = p_idx + p_sz * p_seq
-    #             else:
-    #                 pp_idx = np.arange(p_sz * p_seq, power_cal_test.shape[1])
-    #             if r_idx[-1] + r_sz * r_seq < power_cal_test.shape[2]:
-    #                 rr_idx = r_idx + r_sz * r_seq
-    #             else:
-    #                 rr_idx = np.arange(r_sz * r_seq, power_cal_test.shape[2])
-    #             nn = power_cal_test[f_seq, :, :][np.ix_(pp_idx, rr_idx)]
-    #             noise_est_tmp[f_seq, r_seq, p_seq] = 10 * np.log10(nn.mean())
-    #         noise_est_test[f_seq, p_seq] = noise_est_tmp[f_seq, :, p_seq].min()
-    #
-    # # Check xarray and numpy noise estimates
-    # assert np.all(np.isclose(noise_est_test, noise_est.noise_est.values))
+    # Get tile indexing parameters
+    e_data.noise_est_range_bin_size, range_bin_tile_bin_edge, ping_tile_bin_edge = \
+        e_data.get_tile_params(r_data_sz=proc_data.range_bin.size,
+                               p_data_sz=proc_data.ping_time.size,
+                               r_tile_sz=e_data.noise_est_range_bin_size,
+                               p_tile_sz=e_data.noise_est_ping_size,
+                               sample_thickness=e_data.sample_thickness)
 
-    # # Remove noise manually
-    # Sv_clean_test = np.empty(proc_data.Sv.shape)
-    # for ff, freq in enumerate(proc_data.frequency.values):
-    #     for pp in np.arange(num_ping_bins):
-    #         if pp == num_ping_bins - 1:    # if the last ping bin
-    #             pp_idx = np.arange(p_sz * pp, power_cal_test.shape[1])
-    #         else:                          # all other ping bins
-    #             pp_idx = p_idx + p_sz * pp
-    #         ss_tmp = proc_data['Sv'].sel(frequency=freq).values[pp_idx, :]   # all data in this ping bin
-    #         nn_tmp = (noise_est['noise_est'].sel(frequency=freq).isel(ping_time=pp) +
-    #                   ABS.sel(frequency=freq) + TVG.sel(frequency=freq)).values
-    #         Sv_clean_tmp = ss_tmp.copy()
-    #         Sv_clean_tmp[Sv_clean_tmp <= nn_tmp] = np.nan
-    #         Sv_clean_test[ff, pp_idx, :] = Sv_clean_tmp
-    #
-    # # Check xarray and numpy noise removal
-    # assert ~np.any(e_data.Sv_clean['Sv'].values[~np.isnan(e_data.Sv_clean['Sv'].values)]
-    #                != Sv_clean_test[~np.isnan(Sv_clean_test)])
+    range_bin_tile_bin_edge = np.unique(range_bin_tile_bin_edge)
+
+    range_meter = e_data.range
+    TVG = np.real(20 * np.log10(range_meter.where(range_meter >= 1, other=1)))
+    ABS = 2 * e_data.seawater_absorption * range_meter
+    power_cal_test = (10 ** ((proc_data.Sv - ABS - TVG) / 10)).values
+
+    num_ping_bins = ping_tile_bin_edge.size - 1
+    num_range_bins = range_bin_tile_bin_edge.size - 1
+    noise_est_tmp = np.empty((proc_data.frequency.size, num_range_bins, num_ping_bins))  # all tiles
+    noise_est_test = np.empty((proc_data.frequency.size, num_ping_bins))  # all columns
+    p_sz = e_data.noise_est_ping_size
+    p_idx = np.arange(p_sz, dtype=int)
+    r_sz = (e_data.noise_est_range_bin_size.max() / e_data.sample_thickness[0].values).astype(int).values
+    r_idx = np.arange(r_sz, dtype=int)
+
+    # Get noise estimates manually
+    for f_seq in np.arange(proc_data.frequency.size):
+        for p_seq in np.arange(num_ping_bins):
+            for r_seq in np.arange(num_range_bins):
+                if p_idx[-1] + p_sz * p_seq < power_cal_test.shape[1]:
+                    pp_idx = p_idx + p_sz * p_seq
+                else:
+                    pp_idx = np.arange(p_sz * p_seq, power_cal_test.shape[1])
+                if r_idx[-1] + r_sz * r_seq < power_cal_test.shape[2]:
+                    rr_idx = r_idx + r_sz * r_seq
+                else:
+                    rr_idx = np.arange(r_sz * r_seq, power_cal_test.shape[2])
+                nn = power_cal_test[f_seq, :, :][np.ix_(pp_idx, rr_idx)]
+                noise_est_tmp[f_seq, r_seq, p_seq] = 10 * np.log10(nn.mean())
+            noise_est_test[f_seq, p_seq] = noise_est_tmp[f_seq, :, p_seq].min()
+
+    # Check xarray and numpy noise estimates
+    assert np.all(np.isclose(noise_est_test, noise_est.noise_est.values))
+
+    # Remove noise manually
+    Sv_clean_test = np.empty(proc_data.Sv.shape)
+    for ff, freq in enumerate(proc_data.frequency.values):
+        for pp in np.arange(num_ping_bins):
+            if pp == num_ping_bins - 1:    # if the last ping bin
+                pp_idx = np.arange(p_sz * pp, power_cal_test.shape[1])
+            else:                          # all other ping bins
+                pp_idx = p_idx + p_sz * pp
+            ss_tmp = proc_data['Sv'].sel(frequency=freq).values[pp_idx, :]   # all data in this ping bin
+            nn_tmp = (noise_est['noise_est'].sel(frequency=freq).isel(ping_time=pp) +
+                      ABS.sel(frequency=freq) + TVG.sel(frequency=freq)).values
+            Sv_clean_tmp = ss_tmp.copy()
+            Sv_clean_tmp[Sv_clean_tmp <= nn_tmp] = np.nan
+            Sv_clean_test[ff, pp_idx, :] = Sv_clean_tmp
+
+    # Check xarray and numpy noise removal
+    assert ~np.any(e_data.Sv_clean['Sv_clean'].values[~np.isnan(e_data.Sv_clean['Sv_clean'].values)]
+                   != Sv_clean_test[~np.isnan(Sv_clean_test)])
 
     proc_data.close()
     del tmp

--- a/echopype/tests/test_ek60_model.py
+++ b/echopype/tests/test_ek60_model.py
@@ -26,7 +26,7 @@ def test_noise_estimates_removal():
     e_data = EchoData(nc_path)
     e_data.calibrate(save=True)
     noise_est = e_data.noise_estimates()
-    e_data.remove_noise()
+    # e_data.remove_noise()
 
     with xr.open_dataset(ek60_test_path) as ds_test:
         ds_Sv = ds_test.Sv
@@ -36,65 +36,65 @@ def test_noise_estimates_removal():
     # Noise estimation via numpy brute force =======
     proc_data = xr.open_dataset(Sv_path)
 
-    # Get tile indexing parameters
-    e_data.noise_est_range_bin_size, range_bin_tile_bin_edge, ping_tile_bin_edge = \
-        e_data.get_tile_params(r_data_sz=proc_data.range_bin.size,
-                               p_data_sz=proc_data.ping_time.size,
-                               r_tile_sz=e_data.noise_est_range_bin_size,
-                               p_tile_sz=e_data.noise_est_ping_size,
-                               sample_thickness=e_data.sample_thickness)
+    # # Get tile indexing parameters
+    # e_data.noise_est_range_bin_size, range_bin_tile_bin_edge, ping_tile_bin_edge = \
+    #     e_data.get_tile_params(r_data_sz=proc_data.range_bin.size,
+    #                            p_data_sz=proc_data.ping_time.size,
+    #                            r_tile_sz=e_data.noise_est_range_bin_size,
+    #                            p_tile_sz=e_data.noise_est_ping_size,
+    #                            sample_thickness=e_data.sample_thickness)
+    #
+    # range_meter = e_data.range
+    # TVG = np.real(20 * np.log10(range_meter.where(range_meter >= 1, other=1)))
+    # ABS = 2 * e_data.seawater_absorption * range_meter
+    # power_cal_test = (10 ** ((proc_data.Sv - ABS - TVG) / 10)).values
+    #
+    # num_ping_bins = ping_tile_bin_edge.size -1 #np.unique(add_idx).size
+    # num_range_bins = range_bin_tile_bin_edge.size - 1
+    # noise_est_tmp = np.empty((proc_data.frequency.size, num_range_bins, num_ping_bins))  # all tiles
+    # noise_est_test = np.empty((proc_data.frequency.size, num_ping_bins))  # all columns
+    # p_sz = e_data.noise_est_ping_size
+    # p_idx = np.arange(p_sz, dtype=int)
+    # r_sz = (e_data.noise_est_range_bin_size.max() / e_data.sample_thickness[0].values).astype(int)
+    # r_idx = np.arange(r_sz, dtype=int)
+    #
+    # # Get noise estimates manually
+    # for f_seq in np.arange(proc_data.frequency.size):
+    #     for p_seq in np.arange(num_ping_bins):
+    #         for r_seq in np.arange(num_range_bins):
+    #             if p_idx[-1] + p_sz * p_seq < power_cal_test.shape[1]:
+    #                 pp_idx = p_idx + p_sz * p_seq
+    #             else:
+    #                 pp_idx = np.arange(p_sz * p_seq, power_cal_test.shape[1])
+    #             if r_idx[-1] + r_sz * r_seq < power_cal_test.shape[2]:
+    #                 rr_idx = r_idx + r_sz * r_seq
+    #             else:
+    #                 rr_idx = np.arange(r_sz * r_seq, power_cal_test.shape[2])
+    #             nn = power_cal_test[f_seq, :, :][np.ix_(pp_idx, rr_idx)]
+    #             noise_est_tmp[f_seq, r_seq, p_seq] = 10 * np.log10(nn.mean())
+    #         noise_est_test[f_seq, p_seq] = noise_est_tmp[f_seq, :, p_seq].min()
+    #
+    # # Check xarray and numpy noise estimates
+    # assert np.all(np.isclose(noise_est_test, noise_est.noise_est.values))
 
-    range_meter = e_data.range
-    TVG = np.real(20 * np.log10(range_meter.where(range_meter >= 1, other=1)))
-    ABS = 2 * e_data.seawater_absorption * range_meter
-    power_cal_test = (10 ** ((proc_data.Sv - ABS - TVG) / 10)).values
-
-    num_ping_bins = ping_tile_bin_edge.size -1 #np.unique(add_idx).size
-    num_range_bins = range_bin_tile_bin_edge.size - 1
-    noise_est_tmp = np.empty((proc_data.frequency.size, num_range_bins, num_ping_bins))  # all tiles
-    noise_est_test = np.empty((proc_data.frequency.size, num_ping_bins))  # all columns
-    p_sz = e_data.noise_est_ping_size
-    p_idx = np.arange(p_sz, dtype=int)
-    r_sz = (e_data.noise_est_range_bin_size.max() / e_data.sample_thickness[0].values).astype(int)
-    r_idx = np.arange(r_sz, dtype=int)
-
-    # Get noise estimates manually
-    for f_seq in np.arange(proc_data.frequency.size):
-        for p_seq in np.arange(num_ping_bins):
-            for r_seq in np.arange(num_range_bins):
-                if p_idx[-1] + p_sz * p_seq < power_cal_test.shape[1]:
-                    pp_idx = p_idx + p_sz * p_seq
-                else:
-                    pp_idx = np.arange(p_sz * p_seq, power_cal_test.shape[1])
-                if r_idx[-1] + r_sz * r_seq < power_cal_test.shape[2]:
-                    rr_idx = r_idx + r_sz * r_seq
-                else:
-                    rr_idx = np.arange(r_sz * r_seq, power_cal_test.shape[2])
-                nn = power_cal_test[f_seq, :, :][np.ix_(pp_idx, rr_idx)]
-                noise_est_tmp[f_seq, r_seq, p_seq] = 10 * np.log10(nn.mean())
-            noise_est_test[f_seq, p_seq] = noise_est_tmp[f_seq, :, p_seq].min()
-
-    # Check xarray and numpy noise estimates
-    assert np.all(np.isclose(noise_est_test, noise_est.noise_est.values))
-
-    # Remove noise manually
-    Sv_clean_test = np.empty(proc_data.Sv.shape)
-    for ff, freq in enumerate(proc_data.frequency.values):
-        for pp in np.arange(num_ping_bins):
-            if pp == num_ping_bins - 1:    # if the last ping bin
-                pp_idx = np.arange(p_sz * pp, power_cal_test.shape[1])
-            else:                          # all other ping bins
-                pp_idx = p_idx + p_sz * pp
-            ss_tmp = proc_data['Sv'].sel(frequency=freq).values[pp_idx, :]   # all data in this ping bin
-            nn_tmp = (noise_est['noise_est'].sel(frequency=freq).isel(ping_time=pp) +
-                      ABS.sel(frequency=freq) + TVG.sel(frequency=freq)).values
-            Sv_clean_tmp = ss_tmp.copy()
-            Sv_clean_tmp[Sv_clean_tmp <= nn_tmp] = np.nan
-            Sv_clean_test[ff, pp_idx, :] = Sv_clean_tmp
-
-    # Check xarray and numpy noise removal
-    assert ~np.any(e_data.Sv_clean['Sv'].values[~np.isnan(e_data.Sv_clean['Sv'].values)]
-                   != Sv_clean_test[~np.isnan(Sv_clean_test)])
+    # # Remove noise manually
+    # Sv_clean_test = np.empty(proc_data.Sv.shape)
+    # for ff, freq in enumerate(proc_data.frequency.values):
+    #     for pp in np.arange(num_ping_bins):
+    #         if pp == num_ping_bins - 1:    # if the last ping bin
+    #             pp_idx = np.arange(p_sz * pp, power_cal_test.shape[1])
+    #         else:                          # all other ping bins
+    #             pp_idx = p_idx + p_sz * pp
+    #         ss_tmp = proc_data['Sv'].sel(frequency=freq).values[pp_idx, :]   # all data in this ping bin
+    #         nn_tmp = (noise_est['noise_est'].sel(frequency=freq).isel(ping_time=pp) +
+    #                   ABS.sel(frequency=freq) + TVG.sel(frequency=freq)).values
+    #         Sv_clean_tmp = ss_tmp.copy()
+    #         Sv_clean_tmp[Sv_clean_tmp <= nn_tmp] = np.nan
+    #         Sv_clean_test[ff, pp_idx, :] = Sv_clean_tmp
+    #
+    # # Check xarray and numpy noise removal
+    # assert ~np.any(e_data.Sv_clean['Sv'].values[~np.isnan(e_data.Sv_clean['Sv'].values)]
+    #                != Sv_clean_test[~np.isnan(Sv_clean_test)])
 
     proc_data.close()
     del tmp

--- a/echopype/tests/test_ek60_model.py
+++ b/echopype/tests/test_ek60_model.py
@@ -95,7 +95,7 @@ def test_noise_estimates_removal():
             Sv_clean_test[ff, pp_idx, :] = Sv_clean_tmp
 
     # Check xarray and numpy noise removal
-    assert ~np.any(e_data.Sv_clean['Sv_clean'].values[~np.isnan(e_data.Sv_clean['Sv_clean'].values)]
+    assert ~np.any(e_data.Sv_clean['Sv'].values[~np.isnan(e_data.Sv_clean['Sv'].values)]
                    != Sv_clean_test[~np.isnan(Sv_clean_test)])
 
     proc_data.close()

--- a/environment.yml
+++ b/environment.yml
@@ -13,10 +13,11 @@ dependencies:
   - pandas
   - pip
   - pytz
-  - python=3.7
+  - python=3.8
   - requests
   - scipy
   - tox
   - xarray
+  - zarr
   - pip:
       - pynmea2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py38
 
 [testenv]
 deps =


### PR DESCRIPTION
- parse split-beam angle data correctly into alongship and athwardship angles
- pad NaN for channels with shorter length of range_bin
- fix bug for ek60 files with only 1 channel
- update get_MVBS(), remove_noise(), noise_estimates() to work with varying length of range_bin across channels
- update requirements to use py38 due to numcodecs problem as in #83 