### PR TITLE
Fix provenance group netCDF4 error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,8 @@ Contributors
 `Kavin Nguyen <https://github.com/ngkavin>`_ (@ngkavin)
 are primary developers of this project.
 `Valentina Staneva <https://escience.washington.edu/people/valentina-staneva/>`_ (@valentina-s)
-provides consultation and also contributes to development. Other contributors are listed `here <echopype documentation>`_.
+provides consultation and also contributes to development.
+Other contributors are listed `here <echopype documentation>`_.
 
 We thank Dave Billenness of ASL Environmental Sciences for
 providing the AZFP Matlab Toolbox as reference for our

--- a/echopype/convert/ek60.py
+++ b/echopype/convert/ek60.py
@@ -462,7 +462,7 @@ class ConvertEK60(ConvertBase):
 
             # Check if nc file already exists and deletes it if overwrite is true
             if os.path.exists(out_file) and overwrite:
-                print("          overwriting: " + out_file)
+                print("          overwriting: " + out_file)  # TODO: this should be printed after 'converting...'
                 os.remove(out_file)
             # Check if nc file already exists
             # ... if yes, abort conversion and issue warning

--- a/echopype/model/azfp.py
+++ b/echopype/model/azfp.py
@@ -139,6 +139,8 @@ class ModelAZFP(ModelBase):
         save_path : str
             Full filename to save to, overwriting the RAWFILE_Sv.nc default
         """
+        # Print raw data nc file
+        print('%s  calibrating data in %s' % (dt.datetime.now().strftime('%H:%M:%S'), self.file_path))
 
         # Open data set for Environment and Beam groups
         ds_beam = xr.open_dataset(self.file_path, group="Beam")

--- a/echopype/model/ek60.py
+++ b/echopype/model/ek60.py
@@ -76,6 +76,9 @@ class ModelEK60(ModelBase):
         save_path : str
             Full filename to save to, overwriting the RAWFILENAME_Sv.nc default
         """
+        # Print raw data nc file
+        print('%s  calibrating data in %s' % (dt.datetime.now().strftime('%H:%M:%S'), self.file_path))
+
         # Open data set for Environment and Beam groups
         ds_beam = xr.open_dataset(self.file_path, group="Beam")
 

--- a/echopype/model/modelbase.py
+++ b/echopype/model/modelbase.py
@@ -220,6 +220,9 @@ class ModelBase(object):
                 file_out = _assemble_path()
 
         # Create folder if not already exists
+        if save_dir == '':
+            # TODO: should we use '.' instead of os.getcwd()?
+            save_dir = os.getcwd()  # explicit about path to current directory
         if not os.path.exists(save_dir):
             os.mkdir(save_dir)
 
@@ -557,7 +560,7 @@ class ModelBase(object):
 
         # Get Sv by validating path and calibrate if not already done
         if self.Sv is not None:
-            print('%s  Use Sv stored in memory to calculate MVBS.' % dt.datetime.now().strftime('%H:%M:%S'))
+            print('%s  use Sv stored in memory to calculate MVBS.' % dt.datetime.now().strftime('%H:%M:%S'))
             print_src = False
         else:
             print_src = True

--- a/notebooks/EK60_demo_OOI.ipynb
+++ b/notebooks/EK60_demo_OOI.ipynb
@@ -670,7 +670,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR fixes the issue with netCDF4 erroring out when a long list of input filenames are given. The fix was to save the filenames as a data variable, instead of as a str.

This PR also includes some minor updates in the printout messages.