### PR TITLE
Update OOI notebook and info about EK80 branch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,10 @@ Echopype currently supports file conversion and computation of data produced by:
 - Simrad EK60 echosounder (``.raw`` files)
 - ASL Environmental Sciences AZFP echosounders (``.01A`` files)
 
-In the `ek80 <https://github.com/OSOceanAcoustics/echopype/tree/ek80>`_ development branch
-we are actively developing file conversion and processing routines
-such as pulse compression and calibration for the broadband Simrad EK80 ``.raw`` files.
+Support for ``.raw`` files from the broadband Simrad EK80 echosounder is currently
+in the development branch
+`combine-refactor <https://github.com/OSOceanAcoustics/echopype/tree/convert-refactor>`_
+and we will merge it to the master branch once it's ready for alpha testing.
 
 The file conversion functionality converts data from manufacturer-specific
 binary formats into a standardized netCDF files, based on which all subsequent

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -46,9 +46,10 @@ Echopype currently supports conversion from
 
 into netCDF (stable) or zarr (beta) files.
 
-In the `ek80 <https://github.com/OSOceanAcoustics/echopype/tree/ek80>`_ development branch
-we are actively developing file conversion and processing routines
-such as pulse compression and calibration for the broadband Simrad EK80 ``.raw`` files.
+Support for ``.raw`` files from the broadband Simrad EK80 echosounder is currently
+in the development branch
+`combine-refactor <https://github.com/OSOceanAcoustics/echopype/tree/convert-refactor>`_
+and we will merge it to the master branch once it's ready for alpha testing.
 
 We are considering implementing calibration routines for
 *raw beam* data from common-found Acoustic Doppler Current Profilers (ADCPs).

--- a/notebooks/EK60_demo_OOI.ipynb
+++ b/notebooks/EK60_demo_OOI.ipynb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:03ecb77863e7ddb54f7f0cb8631b0619d31532b4dfcd72cb6ee88e4f1c547f51
-size 17452
+oid sha256:422bde504e325242990043a18d250484d584f9e1e620ac020d60b0d21e951477
+size 314891


### PR DESCRIPTION
This PR:
- updates the EK60_demo_OOI notebook to use the new OOI raw archive folder structure.
- updates info about support for EK80 `.raw` files as we move toward merging/refactoring everything in the dev branch `combine-refactor`
