### PR TITLE
temporarily take out conda install option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,8 @@ with increasing data volume - by providing open-source tools as entry points for
 scientists to make discovery using these new data.
 
 
-Installation
-------------
+Functionality
+-------------
 
 Echopype currently supports file conversion and computation of data produced by:
 
@@ -41,26 +41,33 @@ computations are performed.
 The data processing routines include calibration (instrument-specific), noise
 removal, and mean volume backscattering strength (MVBS) calculation.
 
+
+Installation
+------------
+
 Echopype can be installed from PyPI:
 
 .. code-block:: console
 
    $ pip install echopype
 
+What about conda?
+We are currently working to resolve some build issues with echopype on conda-forge,
+so please use pip to install the latest version (0.3.1).
 
-or through conda:
+.. or through conda:
 
-.. code-block:: console
+    .. code-block:: console
 
-   $ conda install -c conda-forge echopype
+       $ conda install -c conda-forge echopype
 
 
-When creating an conda environment to work with echopype,
-use the supplied ``environment.yml`` or do
+    When creating an conda environment to work with echopype,
+    use the supplied ``environment.yml`` or do
 
-.. code-block:: console
+    .. code-block:: console
 
-   $ conda create -c conda-forge -n echopype python=3.8 --file requirements.txt
+       $ conda create -c conda-forge -n echopype python=3.8 --file requirements.txt
 
 
 Usage

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -12,22 +12,28 @@ Echopype can be installed from PyPI:
    $ pip install echopype
 
 
-or through conda:
-
-.. code-block:: console
-
-   $ conda install -c conda-forge echopype
-
-
-When creating an conda environment to work with echopype,
-use the supplied ``environment.yml`` or do
-
-.. code-block:: console
-
-   $ conda create -c conda-forge -n echopype python=3.8 --file requirements.txt
+.. note::
+   What about conda?
+   We are currently working to resolve some build issues with echopype on conda-forge,
+   so please use pip to install the latest version (0.3.1).
 
 
-.. note::  Echopype currently uses python 3.8 due to an
+.. or through conda:
+
+   .. code-block:: console
+
+      $ conda install -c conda-forge echopype
+
+
+   When creating an conda environment to work with echopype,
+   use the supplied ``environment.yml`` or do
+
+   .. code-block:: console
+
+      $ conda create -c conda-forge -n echopype python=3.8 --file requirements.txt
+
+
+.. note::  Echopype uses python 3.8 due to an
    `issue <https://github.com/OSOceanAcoustics/echopype/issues/83>`_
    with numcodecs wheels.
 


### PR DESCRIPTION
Temporarily take out the option to install through conda in documentation and README, due to build issue of the latest release (0.3.1) #127 .