### PR TITLE
Update testing environment to use both python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: xenial   # required for Python >= 3.7
 language: python
 python:
   - "3.7"
+  - "3.8"
 
 before_install:
   - git lfs pull

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -25,17 +25,15 @@ Echopype can be installed from PyPI:
       $ conda install -c conda-forge echopype
 
 
-   When creating an conda environment to work with echopype,
-   use the supplied ``environment.yml`` or do
+When creating an conda environment to work with echopype,
+use the supplied ``environment.yml`` or do
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ conda create -c conda-forge -n echopype python=3.8 --file requirements.txt
+   $ conda create -c conda-forge -n echopype python=3.8 --file requirements.txt
 
+Echopype works for python>=3.7.
 
-.. note::  Echopype uses python 3.8 due to an
-   `issue <https://github.com/OSOceanAcoustics/echopype/issues/83>`_
-   with numcodecs wheels.
 
 
 Test files

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38
+envlist = py38, py37
 
 [testenv]
 deps =


### PR DESCRIPTION
The numcodec wheel problem was resolved in new release and testing with python 3.7 works now both on travis and locally. This PR resolves #83 . Docs are updated.