### PR TITLE
Bugfix/two in one transducer compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ OOI-D20170821-T081522.raw
 2015843-D20151023-T190636.raw
 D20170912-T234910.raw
 echopype/test_data/ek80/*.raw
+venv/

--- a/echopype/convert/ek80.py
+++ b/echopype/convert/ek80.py
@@ -318,7 +318,8 @@ class ConvertEK80(ConvertBase):
 
         # Find largest dimensions of array in order to pad and stack smaller arrays
         max_samples = 0
-        max_splits = max([n_c for n_c in self.n_complex_dict.values()])
+        # TODO How to determine if a CW data set is split beam or single beam, and how many splits?
+        max_splits = max([n_c for n_c in self.n_complex_dict.values()]) if bb else 4
         for tx in ch_ids:
             if bb:
                 reshaped = np.array(self.complex_dict[tx]).reshape((ping_num, -1, self.n_complex_dict[tx]))

--- a/echopype/convert/utils/set_groups_ek80.py
+++ b/echopype/convert/utils/set_groups_ek80.py
@@ -314,7 +314,7 @@ class SetGroupsEK80(SetGroupsBase):
                                            'long_name': 'Timestamp of each ping',
                                            'standard_name': 'time',
                                            'units': 'seconds since 1900-01-01'}),
-                            'quadrant': (['quadrant'], np.arange(4)),
+                            'quadrant': (['quadrant'], np.arange(beam_dict["backscatter_r"].shape[1])),
                             'range_bin': (['range_bin'], beam_dict['range_bin'])
                             })
                 ds = xr.merge([ds, bb])

--- a/echopype/model/ek80.py
+++ b/echopype/model/ek80.py
@@ -177,7 +177,10 @@ class ModelEK80(ModelBase):
             for ch in range(ds_beam.frequency.size):
                 # tmp_x = np.fft.fft(backscatter[i].dropna('range_bin'))
                 # tmp_y = np.fft.fft(np.flipud(np.conj(ytx[i])))
-                tmp_b = backscatter[ch].dropna('range_bin')
+                # remove quadrants that are nans across all samples
+                tmp_b = backscatter[ch].dropna('range_bin', how='all')
+                # remove samples that are nans across all quadrants
+                tmp_b = tmp_b.dropna('quadrant', how='all')
                 # tmp_b = tmp_b[:, 0, :]        # 1 ping
                 tmp_y = np.flipud(np.conj(self.ytx[ch]))
 
@@ -197,7 +200,7 @@ class ModelEK80(ModelBase):
                 tau_constants.append(np.sum(ptxa) / (np.max(ptxa)))
             self._tau_effective = np.array(tau_constants) * sample_interval
             # Pad nans so that each channel has the same range_bin length
-            largest_range_bin = max(bc.shape for bc in backscatter_compressed)[2]
+            largest_range_bin = max([bc.shape[2] for bc in backscatter_compressed])
             for i, ds in enumerate(backscatter_compressed):
                 pad_width = largest_range_bin - ds.shape[2]
                 backscatter_compressed[i] = xr.apply_ufunc(lambda x: np.pad(x, ((0,0), (0,0), (0,pad_width)),

--- a/echopype/model/ek80.py
+++ b/echopype/model/ek80.py
@@ -284,7 +284,7 @@ class ModelEK80(ModelBase):
             if mode == 'Sv':
                 Sv.name = 'Sv'
                 Sv = Sv.to_dataset()
-                Sv['range'] = (('frequency', 'range_bin'), ranges)
+                Sv['ranges'] = (('frequency', 'range_bin'), ranges)
                 self.Sv = Sv
                 if save:
                     self.Sv_path = self.validate_path(save_path, save_postfix)

--- a/echopype/test_data/ek80/Green2.Survey2.FM.short.slow.-D20191004-T211557.raw
+++ b/echopype/test_data/ek80/Green2.Survey2.FM.short.slow.-D20191004-T211557.raw
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b37e448f3dd8bf28db7e94a4b0f7678d49d370d17ddaed9238375cbd9dc119ad
+size 104894232

--- a/echopype/tests/test_2in1_ek80_convert.py
+++ b/echopype/tests/test_2in1_ek80_convert.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+from echopype.convert import Convert
+
+
+def test_2in1_ek80_conversion():
+    file = Path("./echopype/test_data/ek80/Green2.Survey2.FM.short.slow.-D20191004-T211557.raw").resolve()
+    nc_path = file.parent.joinpath(file.stem+".nc")
+    tmp = Convert(str(file), model="EK80")
+    tmp.raw2nc()
+    del tmp
+    nc_path.unlink()


### PR DESCRIPTION
This is a proposed fix for #145 . There is no known alternative for matching a transducer to a channel apart from serial number (which is the same for 2-in-1 transducers). To determine if there is a 2-in-1 transducer attached to a transceiver, I compare the number of detected transducers to the number of transducers attached to the transceiver. If they are unequal than there is likely to be a combination transducer present.

My work-around hack is to look at the name of the channel_short_id attribute and extract the frequency from it with regex, then compare that frequency with the frequency attribute of the transducer element. If they are matching then update the configuration datagram with the transducer information.

