### PR TITLE
Model warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ OOI-D20170821-T081522.raw
 2015843-D20151023-T190636.raw
 D20170912-T234910.raw
 echopype/test_data/ek80/*.raw
+*default.profraw

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -6,5 +6,5 @@ This page provides an auto-generated summary of echopype’s API.
 .. automodapi:: echopype.convert
    :no-inheritance-diagram:
 
-.. automodapi:: echopype.model
+.. automodapi:: echopype.process
    :no-inheritance-diagram:

--- a/docs/source/plotting.rst
+++ b/docs/source/plotting.rst
@@ -3,7 +3,7 @@ Plotting with echopype
 
 Introduction
 -------------
-echopype proves an easy to use framework for plotting echograms using ``EchoData`` objects. Minimal code is required to see Sv, TS, or MVBS data plotted with select frequencies, but as echopype's plotting functionality are simply a thin wrapper around `xarray <http://xarray.pydata.org/en/stable/index.html>`_
+echopype proves an easy to use framework for plotting echograms using ``Process`` objects. Minimal code is required to see Sv, TS, or MVBS data plotted with select frequencies, but as echopype's plotting functionality are simply a thin wrapper around `xarray <http://xarray.pydata.org/en/stable/index.html>`_
 plotting functions, which wrap `matplotlib <https://matplotlib.org/>`_  functions, plots can be customized using matplotlib's extensive features.
 
 Plotting an Echogram
@@ -14,7 +14,7 @@ AZFP Example
 This example will use the test datasets in the `echopype <https://github.com/OSOceanAcoustics/echopype>`_
 GitHub repository.
 
-First, create an ``EchoData`` object for the AZFP data
+First, create a ``Process`` object for the AZFP data
 
 .. code-block:: console
 
@@ -27,8 +27,8 @@ First, create an ``EchoData`` object for the AZFP data
     tmp_convert = ep.convert.Convert(azfp_01a_path, azfp_xml_path)
     tmp_convert.raw2nc()
 
-    # Make EchoData object
-    tmp_echo = ep.model.EchoData(tmp_convert.nc_path)
+    # Make Process object
+    tmp_echo = ep.process.Process(tmp_convert.nc_path)
 
 Now, calibrate the raw data to acquire xarray Datasets to plot
 
@@ -41,7 +41,7 @@ Now, calibrate the raw data to acquire xarray Datasets to plot
 Plotting a Single Channel
 ++++++++++++++++++++++++++++
 
-For plotting a single frequency, plot the data using ``.plot()`` on the ``EchoData`` object and specify the frequency to be plotted (in Hz). This example data set contains data collected in bursts. So times where the instrument did not take measurements are blank.
+For plotting a single frequency, plot the data using ``.plot()`` on the ``Process`` object and specify the frequency to be plotted (in Hz). This example data set contains data collected in bursts. So times where the instrument did not take measurements are blank.
 
 .. code-block:: console
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -91,7 +91,7 @@ the following in an interactive Python session:
 
 .. code-block:: python
 
-    from echopype.convert import Convert
+    from echopype import Convert
     dc = Convert('FILENAME.raw')
     dc.raw2nc()
 
@@ -108,7 +108,7 @@ This can be done by:
 
 .. code-block:: python
 
-    from echopype.convert import Convert
+    from echopype import Convert
     dc = Convert('FILENAME.01A', 'XMLFILENAME.xml')
     dc.raw2nc()
 
@@ -246,11 +246,11 @@ Data processing
 ---------------
 
 .. warning::
-   The 'model' module has been renamed to 'process' and
-   ``EchoData`` has been renamed to ``Process``.
-   As such, ``EchoData``, ``ModelAZFP``, ``ModelEK60`` are deprecated and
-   will be no longer work in the future.
-   Instead, use ``Process``, ``ProcessAZFP``, ``ProcessEK60``, or ``ProcessEK80``.
+   The ``model`` subpackage has been renamed to ``process``,
+   and the data processing interface ``EchoData`` under ``model``
+   has been renamed to ``Process``.
+   Attempts to import and use ``EchoData`` will continue to function
+   at the moment but will be deprecated in the future.
 
 
 Functionality
@@ -271,7 +271,7 @@ The steps of performing these analysis for each echosounder are summarized below
 
 .. code-block:: python
 
-   from echopype.process import Process
+   from echopype import Process
    nc_path = './converted_files/convertedfile.nc'  # path to a converted nc file
    ed = Process(nc_path)   # create a processing object
    ed.calibrate()           # Sv
@@ -315,7 +315,7 @@ path. For example:
 
    .. code-block:: python
 
-      from echopype.process import Process
+      from echopype import Process
       nc_path = './converted_files/convertedfile.nc'  # path to a converted nc file
       ed = Process(nc_path)   # create a processing object
       ed.get_MVBS()  # echopype will call .calibrate() automatically
@@ -325,7 +325,7 @@ path. For example:
 
    .. code-block:: python
 
-      from echopype.process import Process
+      from echopype import Process
       nc_path = './converted_files/convertedfile.nc'  # path to a converted nc file
       ed = Process(nc_path)   # create a data processing object
       ed.get_MVBS(source_path='another_directory', source_postfix='_Sv_clean')

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -245,6 +245,13 @@ Echopype accommodates these cases in the following two ways:
 Data processing
 ---------------
 
+.. warning::
+   The 'model' module has been renamed to 'process' and
+   ``EchoData`` has been renamed to ``Process``.
+   As such, ``EchoData``, ``ModelAZFP``, ``ModelEK60`` are deprecated and
+   will be no longer work in the future.
+   Instead, use ``Process``, ``ProcessAZFP``, ``ProcessEK60``, or ``ProcessEK80``.
+
 
 Functionality
 ~~~~~~~~~~~~~

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -264,9 +264,9 @@ The steps of performing these analysis for each echosounder are summarized below
 
 .. code-block:: python
 
-   from echopype.model import EchoData
+   from echopype.process import Process
    nc_path = './converted_files/convertedfile.nc'  # path to a converted nc file
-   ed = EchoData(nc_path)   # create an echo data processing object
+   ed = Process(nc_path)   # create a processing object
    ed.calibrate()           # Sv
    ed.remove_noise()        # denoise
    ed.get_MVBS()            # calculate MVBS
@@ -308,9 +308,9 @@ path. For example:
 
    .. code-block:: python
 
-      from echopype.model import EchoData
+      from echopype.process import Process
       nc_path = './converted_files/convertedfile.nc'  # path to a converted nc file
-      ed = EchoData(nc_path)   # create an echo data processing object
+      ed = Process(nc_path)   # create a processing object
       ed.get_MVBS()  # echopype will call .calibrate() automatically
 
 2. Try to do MVBS calculation with _Sv_clean.nc file previously created in
@@ -318,9 +318,9 @@ path. For example:
 
    .. code-block:: python
 
-      from echopype.model import EchoData
+      from echopype.process import Process
       nc_path = './converted_files/convertedfile.nc'  # path to a converted nc file
-      ed = EchoData(nc_path)   # create an echo data processing object
+      ed = Process(nc_path)   # create a data processing object
       ed.get_MVBS(source_path='another_directory', source_postfix='_Sv_clean')
 
 
@@ -444,7 +444,7 @@ check after setting these parameters!
    In the Matlab code, users set temperature/salinity parameters in
    AZFP_parameters.m and run that script first before doing unpacking.
    Here we require users to unpack raw data first into netCDF, and then
-   set temperature/salinity in the model module if they want to perform
+   set temperature/salinity in the process module if they want to perform
    calibration. This is cleaner and less error prone, because the param
    setting step is separated from the raw data unpacking, so user-defined
    params are not in the unpacked files.

--- a/echopype/__init__.py
+++ b/echopype/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 from . import convert
 from . import process
+from . import model     # Delete in later patch
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/echopype/__init__.py
+++ b/echopype/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
-from . import convert
-from . import process
+from .convert import Convert
+from .process import Process
 from . import model     # Delete in later patch
 
 from ._version import get_versions

--- a/echopype/model/__init__.py
+++ b/echopype/model/__init__.py
@@ -1,0 +1,6 @@
+"""
+Temporary file. Will be deleted in a future update with the removal model
+"""
+from .echodata import EchoData
+from .ek60 import ModelEK60
+from .azfp import ModelAZFP

--- a/echopype/model/azfp.py
+++ b/echopype/model/azfp.py
@@ -1,0 +1,11 @@
+""" Temporary file used for transitioning from using 'model' to 'process' due to rename
+    ModelAZFP changed to ProcessAZFP
+"""
+from echopype.process import ProcessAZFP
+from warnings import warn
+
+
+def ModelAZFP(nc_path):
+    warn("ModelAZFP has been renamed to ProcessAZFP and will no longer be supported in the future.",
+         DeprecationWarning, 2)
+    return ProcessAZFP(nc_path)

--- a/echopype/model/echodata.py
+++ b/echopype/model/echodata.py
@@ -1,0 +1,11 @@
+""" Temporary file used for transitioning from using 'model' to 'process' due to rename
+    EchoData changed to Process
+"""
+from echopype.process import Process
+from warnings import warn
+
+
+def EchoData(nc_path):
+    warn("Echodata has been renamed to Process and will no longer be supported in the future.",
+         DeprecationWarning, 2)
+    return Process(nc_path)

--- a/echopype/model/ek60.py
+++ b/echopype/model/ek60.py
@@ -1,0 +1,11 @@
+""" Temporary file used for transitioning from using 'model' to 'process' due to rename
+    ModelEK60 changed to ProcessEK60
+"""
+from echopype.process import ProcessEK60
+from warnings import warn
+
+
+def ModelEK60(nc_path):
+    warn("ModelEK60 has been renamed to ProcessEK60 and will no longer be supported in the future.",
+         DeprecationWarning, 2)
+    return ProcessEK60(nc_path)


### PR DESCRIPTION
Re-enables the use of Model and EchoData by wrapping Process. Raises a DeprecationWarning if `ModelAZFP`, `ModelEK60`, or `EchoData`are used.
Changes `Echodata` to `Process` in the documentation. A warning was also added under the Data processing section of the usage page.

closes #158 
