### PR TITLE
Fix README image display on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-    <img src="https://github.com/OSOceanAcoustics/echopype/blob/master/docs/source/_static/echopype_logo_banner.png" width="400">
+<img src="https://raw.githubusercontent.com/OSOceanAcoustics/echopype/master/docs/source/_static/echopype_logo_banner.png" width="400">
 </div>
 
 # Echopype

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ are primary developers of this package.
 [Valentina Staneva](https://escience.washington.edu/people/valentina-staneva/) (@valentina-s)
 and [Emilio Mayorga](https://www.apl.washington.edu/people/profile.php?last_name=Mayorga&first_name=Emilio) (@emiliom)
 provide consultation and also contribute to the development.
-Other contributors are listed in `echopype documentation`_.
+Other contributors are listed in [echopype documentation](https://echopype.readthedocs.io).
 
 We thank Dave Billenness of ASL Environmental Sciences for
 providing the AZFP Matlab Toolbox as reference for our


### PR DESCRIPTION
- Update a leftover rst link syntax
- Use the raw URL to point to the image itself for display in PyPI as discussed [here](https://github.com/pypa/warehouse/issues/5246).