### PR TITLE
Save EK80 configuration xml

### DIFF
--- a/echopype/convert/ek80.py
+++ b/echopype/convert/ek80.py
@@ -144,8 +144,6 @@ class ConvertEK80(ConvertBase):
         ----------
         raw : str
             raw filename
-        export_xml : bool
-            whether or not to export the configuration as an xml file
         """
         print('%s  converting file: %s' % (dt.now().strftime('%H:%M:%S'), os.path.basename(raw)))
         with RawSimradFile(raw, 'r') as fid:
@@ -641,16 +639,18 @@ class ConvertEK80(ConvertBase):
             self._combine_files()
 
     def export_xml(self):
+        """ Exports the configuration data as an xml file in the same directory as the data files.
+        """
         def write_str(file):
             xml_str = self.config_datagram['xml']
             xml_path = file[:-3] + 'xml'
             with open(xml_path, 'w') as xml_file:
                 xml_file.write(xml_str)
-        """ Exports the configuration data as an xml file in the same directory as the data files"""
+
         if self.config_datagram is not None:
             write_str(self.filename[-1])
         else:
-            for file in self.filename:
+            for filename in self.filename:
                 self.reset_vars('EK80')
-                self.load_ek80_raw(file)
-                write_str(file)
+                self.load_ek80_raw(filename)
+                write_str(filename)

--- a/echopype/convert/ek80.py
+++ b/echopype/convert/ek80.py
@@ -621,14 +621,7 @@ class ConvertEK80(ConvertBase):
         # Delete temporary folder:
         shutil.rmtree(self._temp_dir)
 
-    # Overloads base methods due to the option to export the configuration xml
-    def raw2nc(self, save_path=None, combine_opt=False, overwrite=False, compress=True, export_xml=False):
-        self.save(".nc", save_path, combine_opt, overwrite, compress, export_xml)
-
-    def raw2zarr(self, save_path=None, combine_opt=False, overwrite=False, compress=True, export_xml=False):
-        self.save(".zarr", save_path, combine_opt, overwrite, compress, export_xml)
-
-    def save(self, file_format, save_path=None, combine_opt=False, overwrite=False, compress=True, export_xml=False):
+    def save(self, file_format, save_path=None, combine_opt=False, overwrite=False, compress=True):
         """Save data from EK60 `.raw` to netCDF format.
         """
         save_settings = dict(combine_opt=combine_opt, overwrite=overwrite, compress=compress)
@@ -640,7 +633,7 @@ class ConvertEK80(ConvertBase):
                 self.reset_vars('EK80')
             # Load data if it has not already been loaded.
             if self.config_datagram is None:
-                self.load_ek80_raw(file, export_xml)
+                self.load_ek80_raw(file)
             # multiple raw files are saved differently between the .nc and .zarr formats
             if file_format == '.nc':
                 self._export_nc(save_settings, file_idx)
@@ -650,3 +643,9 @@ class ConvertEK80(ConvertBase):
                 self._export_zarr(save_settings, file_idx)
         if combine_opt and file_format == '.nc':
             self._combine_files()
+
+    def export_xml(self):
+        """ Exports the configuration data as an xml file in the same directory as the data files"""
+        for file in self.filename:
+            self.reset_vars('EK80')
+            self.load_ek80_raw(file, export_xml=True)

--- a/echopype/convert/utils/ek_raw_io.py
+++ b/echopype/convert/utils/ek_raw_io.py
@@ -81,7 +81,7 @@ class RawSimradFile(BufferedReader):
                       }
 
 
-    def __init__(self, name, mode='rb', closefd=True, return_raw=False, buffer_size=1024*1024, xml_path=None):
+    def __init__(self, name, mode='rb', closefd=True, return_raw=False, buffer_size=1024*1024):
 
         #  9-28-18 RHT: Changed RawSimradFile to implement BufferedReader instead of
         #  io.FileIO to increase performance.
@@ -94,7 +94,6 @@ class RawSimradFile(BufferedReader):
         self._current_dgram_offset = 0
         self._total_dgram_count = None
         self._return_raw = return_raw
-        self._xml_path = xml_path
 
 
     def _seek_bytes(self, bytes_, whence=0):
@@ -326,10 +325,7 @@ class RawSimradFile(BufferedReader):
 
         dgram_type = raw_datagram_string[:3].decode()
         try:
-            if dgram_type == 'XML':
-                parser = parsers.SimradXMLParser(self._xml_path)
-            else:
-                parser = self.DGRAM_TYPE_KEY[dgram_type]
+            parser = self.DGRAM_TYPE_KEY[dgram_type]
         except KeyError:
             #raise KeyError('Unknown datagram type %s, valid types: %s' % (str(dgram_type), str(self.DGRAM_TYPE_KEY.keys())))
             return raw_datagram_string

--- a/echopype/convert/utils/ek_raw_io.py
+++ b/echopype/convert/utils/ek_raw_io.py
@@ -81,7 +81,7 @@ class RawSimradFile(BufferedReader):
                       }
 
 
-    def __init__(self, name, mode='rb', closefd=True, return_raw=False, buffer_size=1024*1024):
+    def __init__(self, name, mode='rb', closefd=True, return_raw=False, buffer_size=1024*1024, xml_path=None):
 
         #  9-28-18 RHT: Changed RawSimradFile to implement BufferedReader instead of
         #  io.FileIO to increase performance.
@@ -94,6 +94,7 @@ class RawSimradFile(BufferedReader):
         self._current_dgram_offset = 0
         self._total_dgram_count = None
         self._return_raw = return_raw
+        self._xml_path = xml_path
 
 
     def _seek_bytes(self, bytes_, whence=0):
@@ -325,7 +326,10 @@ class RawSimradFile(BufferedReader):
 
         dgram_type = raw_datagram_string[:3].decode()
         try:
-            parser = self.DGRAM_TYPE_KEY[dgram_type]
+            if dgram_type == 'XML':
+                parser = parsers.SimradXMLParser(self._xml_path)
+            else:
+                parser = self.DGRAM_TYPE_KEY[dgram_type]
         except KeyError:
             #raise KeyError('Unknown datagram type %s, valid types: %s' % (str(dgram_type), str(self.DGRAM_TYPE_KEY.keys())))
             return raw_datagram_string

--- a/echopype/convert/utils/ek_raw_parsers.py
+++ b/echopype/convert/utils/ek_raw_parsers.py
@@ -751,10 +751,7 @@ class SimradXMLParser(_SimradDatagramParser):
                 xml_string = str(raw_string[self.header_size(version):].strip(b'\x00'), 'ascii', errors='replace')
             else:
                 xml_string = unicode(raw_string[self.header_size(version):].strip('\x00'), 'ascii', errors='replace')
-            # write xml string to file
-            if self._xml_path is not None:
-                with open(self._xml_path, 'w') as xml_file:
-                    xml_file.write(xml_string)
+
             #  get the ElementTree element
             root = ET.fromstring(xml_string)
 
@@ -766,6 +763,10 @@ class SimradXMLParser(_SimradDatagramParser):
 
             #  parse it
             if (data['subtype'] == 'configuration'):
+                # write xml string to file
+                if self._xml_path is not None:
+                    with open(self._xml_path, 'w') as xml_file:
+                        xml_file.write(xml_string)
 
                 #  parse the Transceiver section
                 for t in root.iter('Transceiver'):

--- a/echopype/convert/utils/ek_raw_parsers.py
+++ b/echopype/convert/utils/ek_raw_parsers.py
@@ -651,13 +651,13 @@ class SimradXMLParser(_SimradDatagramParser):
                                 }
 
 
-    def __init__(self):
+    def __init__(self, xml_path=None):
         headers = {0: [('type', '4s'),
                         ('low_date', 'L'),
                         ('high_date', 'L')
                             ]
                         }
-
+        self._xml_path = xml_path
         _SimradDatagramParser.__init__(self, "XML", headers)
 
 
@@ -751,7 +751,10 @@ class SimradXMLParser(_SimradDatagramParser):
                 xml_string = str(raw_string[self.header_size(version):].strip(b'\x00'), 'ascii', errors='replace')
             else:
                 xml_string = unicode(raw_string[self.header_size(version):].strip('\x00'), 'ascii', errors='replace')
-
+            # write xml string to file
+            if self._xml_path is not None:
+                with open(self._xml_path, 'w') as xml_file:
+                    xml_file.write(xml_string)
             #  get the ElementTree element
             root = ET.fromstring(xml_string)
 
@@ -834,7 +837,7 @@ class SimradXMLParser(_SimradDatagramParser):
                     dict_to_dict(transducer_xml, data['environment'],
                             self.envxdcr_parsing_options)
 
-
+        data['xml'] = xml_string
         return data
 
 

--- a/echopype/convert/utils/ek_raw_parsers.py
+++ b/echopype/convert/utils/ek_raw_parsers.py
@@ -651,13 +651,12 @@ class SimradXMLParser(_SimradDatagramParser):
                                 }
 
 
-    def __init__(self, xml_path=None):
+    def __init__(self):
         headers = {0: [('type', '4s'),
                         ('low_date', 'L'),
                         ('high_date', 'L')
                             ]
                         }
-        self._xml_path = xml_path
         _SimradDatagramParser.__init__(self, "XML", headers)
 
 
@@ -763,10 +762,6 @@ class SimradXMLParser(_SimradDatagramParser):
 
             #  parse it
             if (data['subtype'] == 'configuration'):
-                # write xml string to file
-                if self._xml_path is not None:
-                    with open(self._xml_path, 'w') as xml_file:
-                        xml_file.write(xml_string)
 
                 #  parse the Transceiver section
                 for t in root.iter('Transceiver'):

--- a/echopype/convert/utils/set_groups_ek80.py
+++ b/echopype/convert/utils/set_groups_ek80.py
@@ -395,7 +395,10 @@ class SetGroupsEK80(SetGroupsBase):
                 # Save xml string
                 vdr.setncattr('xml', vendor_dict['xml'])
             elif self.format == '.zarr':
-                ds = xr.Dataset(vendor_dict['filter_coefficients'])
-                for k, v in vendor_dict['decimation_factors'].items():
-                    ds.attrs[k] = v
-                ds.to_zarr(store=self.file_path, mode='a', group='Vendor')
+                # Only save vendor group if not appending to an existing .zarr file
+                if not self.append_zarr:
+                    ds = xr.Dataset(vendor_dict['filter_coefficients'])
+                    ds.attrs['xml'] = vendor_dict['xml']
+                    for k, v in vendor_dict['decimation_factors'].items():
+                        ds.attrs[k] = v
+                    ds.to_zarr(store=self.file_path, mode='a', group='Vendor')

--- a/echopype/convert/utils/set_groups_ek80.py
+++ b/echopype/convert/utils/set_groups_ek80.py
@@ -392,6 +392,8 @@ class SetGroupsEK80(SetGroupsBase):
                     var[:] = data
                 for k, v in vendor_dict['decimation_factors'].items():
                     vdr.setncattr(k, v)
+                # Save xml string
+                vdr.setncattr('xml', vendor_dict['xml'])
             elif self.format == '.zarr':
                 ds = xr.Dataset(vendor_dict['filter_coefficients'])
                 for k, v in vendor_dict['decimation_factors'].items():


### PR DESCRIPTION
Saves the configuration xml to the vendor group.
Also provides the option for exporting the configuration to an xml file by calling `export_xml()` on a `Convert `object

Closes #171 