### PR TITLE
Fix missing MRU/NMEA data for EK80

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -114,6 +114,13 @@ For data files from the EK80 broadband echosounder, use
 
     dc = Convert('FILENAME.raw', model='EK80')
 
+.. note::
+
+   The water level should be specified using `dc.water_level = 'some value'`
+   if the value is known. Otherwise, the default water level
+   will be `None` if it is not already recorded by the instrument.
+
+
 to indicate the echosounder type, since the filename extension
 ``.raw`` does not contain echosounder type information.
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -114,15 +114,15 @@ For data files from the EK80 broadband echosounder, use
 
     dc = Convert('FILENAME.raw', model='EK80')
 
-.. note::
-
-   The water level should be specified using `dc.water_level = 'some value'`
-   if the value is known. Otherwise, the default water level
-   will be `None` if it is not already recorded by the instrument.
-
-
 to indicate the echosounder type, since the filename extension
 ``.raw`` does not contain echosounder type information.
+
+.. note::
+
+   The water level should be specified using ``dc.water_level = 'some value'``
+   if the value is known. Otherwise, the water level will be saved as
+   ``None`` if it is not already recorded by the instrument.
+
 
 For data files from the AZFP echosounder, the conversion requires an
 extra ``.XML`` file along with the ``.01A`` data file. The ``.XML`` file

--- a/echopype/convert/ek80.py
+++ b/echopype/convert/ek80.py
@@ -53,6 +53,15 @@ class ConvertEK80(ConvertBase):
         self.ch_ids = []                      # List of all channel ids
         self.recorded_ch_ids = []
         self.timestamp_pattern = re.compile(regex)
+        self._water_level = None
+
+    @property
+    def water_level(self):
+        return self._water_level
+
+    @water_level.setter
+    def water_level(self, water_level):
+        self._water_level = water_level
 
     def _read_datagrams(self, fid):
         """
@@ -281,8 +290,9 @@ class ConvertEK80(ConvertBase):
         out_dict['pitch'] = np.array(self.mru_data.get('pitch', [np.nan]))
         out_dict['roll'] = np.array(self.mru_data.get('roll', [np.nan]))
         out_dict['heave'] = np.array(self.mru_data.get('heave', [np.nan]))
-        # TODO: we need a method for user to set water_level before conversion
-        if 'water_level_draft' in self.environment:
+        if self.water_level is not None:
+            out_dict['water_level'] = self.water_level
+        elif 'water_level_draft' in self.environment:
             out_dict['water_level'] = self.environment['water_level_draft']
         else:
             out_dict['water_level'] = None

--- a/echopype/convert/ek80.py
+++ b/echopype/convert/ek80.py
@@ -277,10 +277,10 @@ class ConvertEK80(ConvertBase):
         out_dict['platform_code_ICES'] = self.platform_code_ICES
 
         # Read pitch/roll/heave from ping data
-        out_dict['mru_time'] = self.mru_data['timestamp']  # [seconds since 1900-01-01] for xarray.to_netcdf conversion
-        out_dict['pitch'] = np.array(self.mru_data['pitch'])
-        out_dict['roll'] = np.array(self.mru_data['roll'])
-        out_dict['heave'] = np.array(self.mru_data['heave'])
+        out_dict['mru_time'] = np.array(self.mru_data.get('timestamp', [np.nan]))  # [seconds since 1900-01-01] for xarray.to_netcdf conversion
+        out_dict['pitch'] = np.array(self.mru_data.get('pitch', [np.nan]))
+        out_dict['roll'] = np.array(self.mru_data.get('roll', [np.nan]))
+        out_dict['heave'] = np.array(self.mru_data.get('heave', [np.nan]))
         # TODO: we need a method for user to set water_level before conversion
         if 'water_level_draft' in self.environment:
             out_dict['water_level'] = self.environment['water_level_draft']
@@ -293,9 +293,10 @@ class ConvertEK80(ConvertBase):
         idx_loc = np.argwhere(np.isin(self.nmea_data.messages, ['GGA', 'GLL', 'RMC'])).squeeze()
         nmea_msg = []
         [nmea_msg.append(pynmea2.parse(self.nmea_data.raw_datagrams[x])) for x in idx_loc]
-        out_dict['lat'] = np.array([x.latitude for x in nmea_msg])
-        out_dict['lon'] = np.array([x.longitude for x in nmea_msg])
-        out_dict['location_time'] = self.nmea_data.nmea_times[idx_loc]
+        out_dict['lat'] = np.array([x.latitude for x in nmea_msg]) if idx_loc else [np.nan]
+        out_dict['lon'] = np.array([x.longitude for x in nmea_msg]) if idx_loc else [np.nan]
+        out_dict['location_time'] = self.nmea_data.nmea_times[idx_loc] if idx_loc else [np.nan]
+
         return out_dict
 
     def _set_nmea_dict(self):

--- a/echopype/convert/ek80.py
+++ b/echopype/convert/ek80.py
@@ -303,9 +303,9 @@ class ConvertEK80(ConvertBase):
         idx_loc = np.argwhere(np.isin(self.nmea_data.messages, ['GGA', 'GLL', 'RMC'])).squeeze()
         nmea_msg = []
         [nmea_msg.append(pynmea2.parse(self.nmea_data.raw_datagrams[x])) for x in idx_loc]
-        out_dict['lat'] = np.array([x.latitude for x in nmea_msg]) if idx_loc else [np.nan]
-        out_dict['lon'] = np.array([x.longitude for x in nmea_msg]) if idx_loc else [np.nan]
-        out_dict['location_time'] = self.nmea_data.nmea_times[idx_loc] if idx_loc else [np.nan]
+        out_dict['lat'] = np.array([x.latitude for x in nmea_msg]) if nmea_msg else [np.nan]
+        out_dict['lon'] = np.array([x.longitude for x in nmea_msg]) if nmea_msg else [np.nan]
+        out_dict['location_time'] = self.nmea_data.nmea_times[idx_loc] if nmea_msg else [np.nan]
 
         return out_dict
 

--- a/echopype/convert/utils/set_groups_ek80.py
+++ b/echopype/convert/utils/set_groups_ek80.py
@@ -56,9 +56,9 @@ class SetGroupsEK80(SetGroupsBase):
             # Convert np.datetime64 numbers to seconds since 1900-01-01
             # due to xarray.to_netcdf() error on encoding np.datetime64 objects directly
             mru_time = (platform_dict['mru_time'] - np.datetime64('1900-01-01T00:00:00')) \
-                / np.timedelta64(1, 's') if not np.isnan(platform_dict['mru_time']) else [np.nan]
+                / np.timedelta64(1, 's') if not np.all(np.isnan(platform_dict['mru_time'])) else [np.nan]
             location_time = (platform_dict['location_time'] - np.datetime64('1900-01-01T00:00:00')) \
-                / np.timedelta64(1, 's') if not np.isnan(platform_dict['location_time']) else [np.nan]
+                / np.timedelta64(1, 's') if not np.all(np.isnan(platform_dict['location_time'])) else [np.nan]
 
             ds = xr.Dataset(
                 {'pitch': (['mru_time'], platform_dict['pitch'],

--- a/echopype/convert/utils/set_groups_ek80.py
+++ b/echopype/convert/utils/set_groups_ek80.py
@@ -56,9 +56,9 @@ class SetGroupsEK80(SetGroupsBase):
             # Convert np.datetime64 numbers to seconds since 1900-01-01
             # due to xarray.to_netcdf() error on encoding np.datetime64 objects directly
             mru_time = (platform_dict['mru_time'] - np.datetime64('1900-01-01T00:00:00')) \
-                / np.timedelta64(1, 's')
+                / np.timedelta64(1, 's') if not np.isnan(platform_dict['mru_time']) else [np.nan]
             location_time = (platform_dict['location_time'] - np.datetime64('1900-01-01T00:00:00')) \
-                / np.timedelta64(1, 's')
+                / np.timedelta64(1, 's') if not np.isnan(platform_dict['location_time']) else [np.nan]
 
             ds = xr.Dataset(
                 {'pitch': (['mru_time'], platform_dict['pitch'],


### PR DESCRIPTION
If MRU time data is missing, pitch, roll, and heave are saved as NaN.
If location time is missing, lat and lon are saved as NaN.

Adds a setter/getter for the EK80 water level.


Closes #185