### PR TITLE
Add support for NME1 datagram and remove sa_correction from broadband file

### DIFF
--- a/echopype/convert/ek80.py
+++ b/echopype/convert/ek80.py
@@ -471,15 +471,16 @@ class ConvertEK80(ConvertBase):
         # beam_dict['non_quantitative_processing'] = np.array([0, ] * freq.size, dtype='int32')
         # -- sample_time_offset is set to 2 for EK60 data, this value is NOT from sample_data['offset']
         # beam_dict['sample_time_offset'] = np.array([2, ] * freq.size, dtype='int32')
-        pulse_length = 'pulse_duration_fm' if bb else 'pulse_duration'
-        # Gets indices from pulse length table using the transmit_duration_nominal values selected
-        idx = [np.argwhere(np.isclose(tx_sig['transmit_duration_nominal'][i],
-                                      self.config_datagram['configuration'][ch][pulse_length])).squeeze()
-               for i, ch in enumerate(ch_ids)]
-        # Use the indices to select sa_correction values from the sa correction table
-        beam_dict['sa_correction'] = \
-            np.array([x['sa_correction'][y]
-                     for x, y in zip(self.config_datagram['configuration'].values(), np.array(idx))])
+        if not bb:
+            pulse_length = 'pulse_duration'
+            # Gets indices from pulse length table using the transmit_duration_nominal values selected
+            idx = [np.argwhere(np.isclose(tx_sig['transmit_duration_nominal'][i],
+                                          self.config_datagram['configuration'][ch][pulse_length])).squeeze()
+                   for i, ch in enumerate(ch_ids)]
+            # Use the indices to select sa_correction values from the sa correction table
+            beam_dict['sa_correction'] = \
+                np.array([x['sa_correction'][y]
+                         for x, y in zip(self.config_datagram['configuration'].values(), np.array(idx))])
 
         return beam_dict
 

--- a/echopype/convert/utils/ek_raw_parsers.py
+++ b/echopype/convert/utils/ek_raw_parsers.py
@@ -267,7 +267,7 @@ class SimradBottomParser(_SimradDatagramParser):
 
 class SimradAnnotationParser(_SimradDatagramParser):
     '''
-    ER60 NMEA datagram contains the following keys:
+    ER60 Annotation datagram contains the following keys:
 
 
         type:         string == 'TAG0'
@@ -378,10 +378,15 @@ class SimradNMEAParser(_SimradDatagramParser):
 
     def __init__(self):
         headers = {0: [('type', '4s'),
-                             ('low_date', 'L'),
-                             ('high_date', 'L')
-                            ]
-                        }
+                       ('low_date', 'L'),
+                       ('high_date', 'L')
+                       ],
+                   1: [('type', '4s'),
+                       ('low_date', 'L'),
+                       ('high_date', 'L'),
+                       ('port', '32s')
+                       ]
+                   }
 
         _SimradDatagramParser.__init__(self, "NME", headers)
 
@@ -407,7 +412,11 @@ class SimradNMEAParser(_SimradDatagramParser):
         data['timestamp'] = nt_to_unix((data['low_date'], data['high_date']))
         data['bytes_read'] = bytes_read
 
-        if version == 0:
+        # Remove trailing \x00 from the PORT field for NME1, rest of the datagram identical to NME0
+        if version == 1:
+            data['port'] = data['port'].strip('\x00')
+
+        if version == 0 or version == 1:
             if (sys.version_info.major > 2):
                 data['nmea_string'] = str(raw_string[self.header_size(version):].strip(b'\x00'), 'ascii', errors='replace')
             else:


### PR DESCRIPTION
This PR contains the following changes:
- Add support for NME1 datagram in the EK parser. This allows converting .raw files from EA640. This closes #192 .
- Remove `sa_correction` from broadband EK80 files since it is not used in broadband processing. This closes #196 .