### PR TITLE
Check if angle data exists before indexing

### DIFF
--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -341,7 +341,8 @@ class SetGroupsEK60(SetGroupsBase):
                                        'units': 'seconds since 1900-01-01'}),
                         'range_bin': (['range_bin'], np.arange(data_shape[1]))})
 
-            # Set angle data if split beam
+            # Set angle data if in split beam mode (beam_type == 1)
+            # because single beam mode (beam_type == 0) does not record angle data
             if self.convert_obj.config_datagram['transceivers'][ch]['beam_type'] == 1:
                 ds_tmp = ds_tmp.assign(
                     {

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -20,7 +20,7 @@ class SetGroupsEK60(SetGroupsBase):
         if 'ENV' in self.convert_obj.data_type:
             self.set_env()           # environment group
             return
-        elif 'GPS' in self.convert_obj.data_type:
+        elif 'NME' in self.convert_obj.data_type:
             self.set_platform()
             return
 
@@ -314,12 +314,6 @@ class SetGroupsEK60(SetGroupsBase):
                 {'backscatter_r': (['ping_time', 'range_bin'], self.convert_obj.ping_data_dict['power'][ch],
                                    {'long_name': 'Backscatter power',
                                     'units': 'dB'}),
-                 'angle_athwartship': (['ping_time', 'range_bin'],
-                                       self.convert_obj.ping_data_dict['angle'][ch][:, :, 0],
-                                       {'long_name': 'electrical athwartship angle'}),
-                 'angle_alongship': (['ping_time', 'range_bin'],
-                                     self.convert_obj.ping_data_dict['angle'][ch][:, :, 1],
-                                     {'long_name': 'electrical alongship angle'}),
                  'sample_interval': (['ping_time'],
                                      self.convert_obj.ping_data_dict['sample_interval'][ch],
                                      {'long_name': 'Interval between recorded raw data samples',
@@ -346,6 +340,18 @@ class SetGroupsEK60(SetGroupsBase):
                                        'standard_name': 'time',
                                        'units': 'seconds since 1900-01-01'}),
                         'range_bin': (['range_bin'], np.arange(data_shape[1]))})
+
+            # Set angle data if split beam
+            if self.convert_obj.config_datagram['transceivers'][ch]['beam_type'] == 1:
+                ds_tmp = ds_tmp.assign(
+                    {
+                        'angle_athwartship': (['ping_time', 'range_bin'],
+                                              self.convert_obj.ping_data_dict['angle'][ch][:, :, 0],
+                                              {'long_name': 'electrical athwartship angle'}),
+                        'angle_alongship': (['ping_time', 'range_bin'],
+                                            self.convert_obj.ping_data_dict['angle'][ch][:, :, 1],
+                                            {'long_name': 'electrical alongship angle'}),
+                    })
 
             # Attach frequency dimension/coordinate
             ds_tmp = ds_tmp.expand_dims(

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -415,7 +415,8 @@ class SetGroupsEK80(SetGroupsBase):
                     }
                 )
 
-                # Set angle data if split beam
+                # Set angle data if in split beam mode (beam_type == 1)
+                # because single beam mode (beam_type == 0) does not record angle data
                 if self.convert_obj.config_datagram['configuration'][ch]['transducer_beam_type'] == 1:
                     ds_tmp = ds_tmp.assign(
                         {

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -25,7 +25,7 @@ class SetGroupsEK80(SetGroupsBase):
         if 'ENV' in self.convert_obj.data_type:
             self.set_env()           # environment group
             return
-        elif 'GPS' in self.convert_obj.data_type:
+        elif 'NME' in self.convert_obj.data_type:
             self.set_platform()
             return
 
@@ -155,7 +155,7 @@ class SetGroupsEK80(SetGroupsBase):
         """
         # Assemble Dataset for channel-specific Beam group variables
         params = [
-            'beam_type',
+            'transducer_beam_type',
             'beam_width_alongship',
             'beam_width_athwartship',
             'transducer_alpha_x',
@@ -188,7 +188,7 @@ class SetGroupsEK80(SetGroupsBase):
         ds = xr.Dataset(
             {
                 'channel_id': (['frequency'], ch_ids),
-                'beam_type': (['frequency'], beam_params['beam_type']),
+                'beam_type': (['frequency'], beam_params['transducer_beam_type']),
                 'beamwidth_receive_alongship': (['frequency'], beam_params['beam_width_alongship'],
                                                 {'long_name': 'Half power one-way receive beam width along '
                                                               'alongship axis of beam',
@@ -386,12 +386,6 @@ class SetGroupsEK80(SetGroupsBase):
                                           self.convert_obj.ping_data_dict['power'][ch],
                                           {'long_name': 'Backscattering power',
                                            'units': 'dB'}),
-                        'angle_athwartship': (['ping_time', 'range_bin'],
-                                              self.convert_obj.ping_data_dict['angle'][ch][:, :, 0],
-                                              {'long_name': 'electrical athwartship angle'}),
-                        'angle_alongship': (['ping_time', 'range_bin'],
-                                            self.convert_obj.ping_data_dict['angle'][ch][:, :, 1],
-                                            {'long_name': 'electrical alongship angle'}),
                         'sample_interval': (['ping_time'],
                                             self.convert_obj.ping_data_dict['sample_interval'][ch],
                                             {'long_name': 'Interval between recorded raw data samples',
@@ -420,6 +414,19 @@ class SetGroupsEK80(SetGroupsBase):
                         'range_bin': (['range_bin'], np.arange(data_shape[1])),
                     }
                 )
+
+                # Set angle data if split beam
+                if self.convert_obj.config_datagram['configuration'][ch]['transducer_beam_type'] == 1:
+                    ds_tmp = ds_tmp.assign(
+                        {
+                            'angle_athwartship': (['ping_time', 'range_bin'],
+                                                  self.convert_obj.ping_data_dict['angle'][ch][:, :, 0],
+                                                  {'long_name': 'electrical athwartship angle'}),
+                            'angle_alongship': (['ping_time', 'range_bin'],
+                                                self.convert_obj.ping_data_dict['angle'][ch][:, :, 1],
+                                                {'long_name': 'electrical alongship angle'}),
+                        })
+
                 # Attach frequency dimension/coordinate
                 ds_tmp = ds_tmp.expand_dims(
                     {'frequency': [self.convert_obj.config_datagram['configuration'][ch]['transducer_frequency']]})


### PR DESCRIPTION
EK60 SetGroups errored out when trying to save angle data of channels that do not have angle data. 

This fix checks the beam type and only saves the angle data if the beam_type == 1 (split beam mode) because if beam_type == 0 (single beam mode) there is no angle data.

Channels without angle data are saved as NaN (ping_time x range_bin)