### PR TITLE
Modify Convert to be able to read raw files from anywhere using fsspec mapping

### DIFF
--- a/echopype/convert/convert.py
+++ b/echopype/convert/convert.py
@@ -20,19 +20,27 @@ from ..utils import io
 MODELS = {
     "AZFP": {
         "ext": ".01A",
-        "xml": True
+        "xml": True,
+        "parser": ParseAZFP,
+        "set_groups": SetGroupsAZFP,
     },
     "EK60": {
         "ext": ".raw",
-        "xml": False
+        "xml": False,
+        "parser": ParseEK60,
+        "set_groups": SetGroupsEK60
     },
     "EK80": {
         "ext": ".raw",
-        "xml": False
+        "xml": False,
+        "parser": ParseEK80,
+        "set_groups": SetGroupsEK80
     },
     "EA640": {
         "ext": ".raw",
-        "xml": False
+        "xml": False,
+        "parser": ParseEK80,
+        "set_groups": SetGroupsEK80
     }
 }
 
@@ -237,21 +245,18 @@ class Convert:
     def _convert_indiv_file(self, file, output_path=None, engine=None):
         """Convert a single file.
         """
+
+        if self.sonar_model not in MODELS:
+            raise ValueError(f"Unsupported sonar model: {model}\nMust be one of: {list(MODELS)}")
+        
         # Use echosounder-specific object
-        if self.sonar_model == 'EK60':
-            c = ParseEK60
-            sg = SetGroupsEK60
-            params = self.data_type
-        elif self.sonar_model in ['EK80', 'EA640']:
-            c = ParseEK80
-            sg = SetGroupsEK80
-            params = self.data_type
-        elif self.sonar_model == 'AZFP':
-            c = ParseAZFP
-            sg = SetGroupsAZFP
+        c = MODELS[self.sonar_model]['parser']
+        sg = MODELS[self.sonar_model]['set_groups']
+        
+        if MODELS[self.sonar_model]['xml']:
             params = self.xml_path
         else:
-            raise ValueError("Unknown sonar model", self.sonar_model)
+            params = self.data_type
 
         # Handle saving to cloud or local filesystem
         # TODO: @ngkvain: You mean this took long before, what is the latest status?

--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -6,6 +6,7 @@ from datetime import timezone
 import math
 import numpy as np
 import os
+import fsspec
 from .parse_base import ParseBase
 
 FILENAME_DATETIME_AZFP = '\\w+.01A'
@@ -14,8 +15,8 @@ FILENAME_DATETIME_AZFP = '\\w+.01A'
 class ParseAZFP(ParseBase):
     """Class for converting data from ASL Environmental Sciences AZFP echosounder.
     """
-    def __init__(self, file, params):
-        super().__init__(file)
+    def __init__(self, file, params, storage_options={}):
+        super().__init__(file, storage_options)
         # Parent class attributes
         self.timestamp_pattern = FILENAME_DATETIME_AZFP  # regex pattern used to grab datetime embedded in filename
         self.xml_path = params
@@ -34,7 +35,9 @@ class ParseAZFP(ParseBase):
             return px.getElementsByTagName(tag_name)[element].childNodes[0].data
 
         # TODO: consider writing a ParamAZFPxml class for storing parameters
-        px = xml.dom.minidom.parse(self.xml_path)
+        xmlmap = fsspec.get_mapper(self.xml_path, **self.storage_options)
+
+        px = xml.dom.minidom.parse(xmlmap.fs.open(xmlmap.root))
         self.parameters['num_freq'] = int(get_value_by_tag_name('NumFreq'))
         self.parameters['serial_number'] = int(get_value_by_tag_name('SerialNumber'))
         self.parameters['burst_interval'] = float(get_value_by_tag_name('BurstInterval'))
@@ -117,8 +120,9 @@ class ParseAZFP(ParseBase):
 
         # Read xml file into dict
         self.load_AZFP_xml()
+        fmap = fsspec.get_mapper(self.source_file, **self.storage_options)
 
-        with open(self.source_file, 'rb') as file:
+        with fmap.fs.open(fmap.root, 'rb') as file:
             ping_num = 0
             eof = False
             while not eof:

--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -57,7 +57,8 @@ class ParseEK(ParseBase):
     def parse_raw(self):
         """Parse raw data file from Simrad EK60, EK80, and EA640 echosounders.
         """
-        with RawSimradFile(self.source_file, 'r') as fid:
+        with RawSimradFile(self.source_file,
+                           'r', storage_options=self.storage_options) as fid:
             self.config_datagram = fid.read(1)
             self.config_datagram['timestamp'] = np.datetime64(
                 self.config_datagram['timestamp'].replace(tzinfo=None), '[ms]')

--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -27,7 +27,7 @@ class ParseBase:
 class ParseEK(ParseBase):
     """Class for converting data from Simrad echosounders.
     """
-    def __init__(self, file, storage_options, params):
+    def __init__(self, file, params, storage_options):
         super().__init__(file, storage_options)
 
         # Parent class attributes

--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -12,11 +12,12 @@ NMEA_GPS_SENTENCE = 'GGA'
 class ParseBase:
     """Parent class for all convert classes.
     """
-    def __init__(self, file):
+    def __init__(self, file, storage_options):
         self.source_file = file
         self.timestamp_pattern = None  # regex pattern used to grab datetime embedded in filename
         self.nmea_gps_sentence = None  # select GPS datagram in _set_platform_dict()
         self.ping_time = []            # list to store ping time
+        self.storage_options = storage_options
 
     def _print_status(self):
         """Prints message to console giving information about the raw file being parsed.
@@ -26,8 +27,8 @@ class ParseBase:
 class ParseEK(ParseBase):
     """Class for converting data from Simrad echosounders.
     """
-    def __init__(self, file, params):
-        super().__init__(file)
+    def __init__(self, file, storage_options, params):
+        super().__init__(file, storage_options)
 
         # Parent class attributes
         self.timestamp_pattern = FILENAME_DATETIME_EK60  # regex pattern used to grab datetime embedded in filename

--- a/echopype/convert/parse_ek60.py
+++ b/echopype/convert/parse_ek60.py
@@ -5,8 +5,8 @@ class ParseEK60(ParseEK):
     """Class for converting data from Simrad EK60 echosounders.
     """
 
-    def __init__(self, file, params):
-        super().__init__(file, params)
+    def __init__(self, file, params, storage_options={}):
+        super().__init__(file, storage_options, params)
 
     def _select_datagrams(self, params):
         # Translates user input into specific datagrams or ALL

--- a/echopype/convert/parse_ek60.py
+++ b/echopype/convert/parse_ek60.py
@@ -6,7 +6,7 @@ class ParseEK60(ParseEK):
     """
 
     def __init__(self, file, params, storage_options={}):
-        super().__init__(file, storage_options, params)
+        super().__init__(file, params, storage_options)
 
     def _select_datagrams(self, params):
         # Translates user input into specific datagrams or ALL

--- a/echopype/convert/parse_ek80.py
+++ b/echopype/convert/parse_ek80.py
@@ -5,7 +5,7 @@ class ParseEK80(ParseEK):
     """Class for converting data from Simrad EK80 echosounders.
     """
     def __init__(self, file, params, storage_options={}):
-        super().__init__(file, storage_options, params)
+        super().__init__(file, params, storage_options)
         self.environment = {}  # dictionary to store environment data
 
     def _select_datagrams(self, params):

--- a/echopype/convert/parse_ek80.py
+++ b/echopype/convert/parse_ek80.py
@@ -4,8 +4,8 @@ from .parse_base import ParseEK
 class ParseEK80(ParseEK):
     """Class for converting data from Simrad EK80 echosounders.
     """
-    def __init__(self, file, params):
-        super().__init__(file, params)
+    def __init__(self, file, params, storage_options={}):
+        super().__init__(file, storage_options, params)
         self.environment = {}  # dictionary to store environment data
 
     def _select_datagrams(self, params):

--- a/echopype/tests/test_convert.py
+++ b/echopype/tests/test_convert.py
@@ -77,3 +77,27 @@ def test_http_ek80_convert():
     assert ec.source_file[0] == ek80_path
 
     _file_export_checks(ec, model)
+
+
+def test_s3_ek60_convert():
+    model = 'EK60'
+    # http
+    ek60_path = 's3://ncei-wcsd-archive/data/raw/Bell_M._Shimada/SH1707/EK60/Summer2017-D20170615-T190214.raw'
+
+    ec = Convert(ek60_path, model=model, storage_options={'anon': True})
+
+    assert ec.source_file[0] == ek60_path
+
+    _file_export_checks(ec, model)
+
+
+def test_s3_ek80_convert():
+    model = 'EK80'
+    # http
+    ek80_path = 's3://ncei-wcsd-archive/data/raw/Bell_M._Shimada/SH1707/EK80/D20170826-T205615.raw'
+
+    ec = Convert(ek80_path, model=model, storage_options={'anon': True})
+
+    assert ec.source_file[0] == ek80_path
+
+    _file_export_checks(ec, model)

--- a/echopype/tests/test_convert.py
+++ b/echopype/tests/test_convert.py
@@ -1,0 +1,52 @@
+import os
+import shutil
+import numpy as np
+import xarray as xr
+import pandas as pd
+from ..convert import Convert
+
+def test_http_azfp_convert():
+    # http
+    azfp_path = 'https://rawdata.oceanobservatories.org/files/CE01ISSM/R00007/instrmts/dcl37/ZPLSC_sn55075/ce01issm_zplsc_55075_recovered_2017-10-27/DATA/201703/17032923.01A'
+    xml_path = 'https://rawdata.oceanobservatories.org/files/CE01ISSM/R00007/instrmts/dcl37/ZPLSC_sn55075/ce01issm_zplsc_55075_recovered_2017-10-27/DATA/201703/17032922.XML'
+
+    out_file = "./test.nc"
+    ec = Convert(azfp_path, model='AZFP', xml_path=xml_path)
+
+    assert ec.source_file[0] == azfp_path
+    assert ec.xml_path == xml_path
+
+    ec.to_netcdf(out_file, overwrite=True)
+    groups = ['Environment', 'Platform', 'Provenance', 'Sonar']
+
+    for g in groups:
+        ds = xr.open_dataset(out_file, engine='netcdf4', group=g)
+
+        assert isinstance(ds, xr.Dataset) is True
+
+    os.unlink(out_file)
+
+def test_http_ek60_convert():
+    # http
+    ek60_path = 'https://rawdata.oceanobservatories.org/files/CE04OSPS/PC01B/ZPLSCB102_10.33.10.143/2017/08/21/OOI-D20170821-T031816.raw'
+
+    out_file = "./test.nc"
+    ec = Convert(ek60_path, model='EK60')
+    ec.to_netcdf(out_file, overwrite=True)
+
+    assert ec.source_file[0] == ek60_path
+
+    os.unlink(out_file)
+
+# TODO: Need ek80 http example
+# def test_http_ek80_convert():
+#     # http
+#     ek80_path = 'https://rawdata.oceanobservatories.org/files/CE01ISSM/R00007/instrmts/dcl37/ZPLSC_sn55075/ce01issm_zplsc_55075_recovered_2017-10-27/DATA/201703/17032923.01A'
+
+#     out_file = "./test.nc"
+#     ec = Convert(ek80_path, model='EK80')
+#     ec.to_netcdf(out_file, overwrite=True)
+
+#     assert ec.source_file[0] == ek80_path
+
+#     os.unlink(out_file)

--- a/echopype/tests/test_convert.py
+++ b/echopype/tests/test_convert.py
@@ -5,48 +5,75 @@ import xarray as xr
 import pandas as pd
 from ..convert import Convert
 
+
+def _converted_group_checker(model, engine, out_file):
+    groups = ['Environment', 'Platform', 'Provenance', 'Sonar']
+    if model in ['EK60', 'EK80']:
+        groups = groups + ['Beam', 'Vendor']
+
+    for g in groups:
+        ds = xr.open_dataset(out_file, engine=engine, group=g)
+
+        assert isinstance(ds, xr.Dataset) is True
+
+
+def _file_export_checks(ec, model):
+    file_map = {
+        '.nc': {
+            'engine': 'netcdf4',
+            'export_func': ec.to_netcdf,
+            'cleaner': os.unlink,
+        },
+        '.zarr': {
+            'engine': 'zarr',
+            'export_func': ec.to_zarr,
+            'cleaner': shutil.rmtree,
+        },
+    }
+    for k, v in file_map.items():
+        out_file = f"./test_{model.lower()}{k}"
+        func = v['export_func']
+        clean = v['cleaner']
+        func(out_file, overwrite=True)
+        _converted_group_checker(
+            model=model, engine=v['engine'], out_file=out_file
+        )
+        clean(out_file)
+
+
 def test_http_azfp_convert():
+    model = 'AZFP'
     # http
     azfp_path = 'https://rawdata.oceanobservatories.org/files/CE01ISSM/R00007/instrmts/dcl37/ZPLSC_sn55075/ce01issm_zplsc_55075_recovered_2017-10-27/DATA/201703/17032923.01A'
     xml_path = 'https://rawdata.oceanobservatories.org/files/CE01ISSM/R00007/instrmts/dcl37/ZPLSC_sn55075/ce01issm_zplsc_55075_recovered_2017-10-27/DATA/201703/17032922.XML'
 
-    out_file = "./test.nc"
-    ec = Convert(azfp_path, model='AZFP', xml_path=xml_path)
+    ec = Convert(azfp_path, model=model, xml_path=xml_path)
 
     assert ec.source_file[0] == azfp_path
     assert ec.xml_path == xml_path
 
-    ec.to_netcdf(out_file, overwrite=True)
-    groups = ['Environment', 'Platform', 'Provenance', 'Sonar']
+    _file_export_checks(ec, model)
 
-    for g in groups:
-        ds = xr.open_dataset(out_file, engine='netcdf4', group=g)
-
-        assert isinstance(ds, xr.Dataset) is True
-
-    os.unlink(out_file)
 
 def test_http_ek60_convert():
+    model = 'EK60'
     # http
-    ek60_path = 'https://rawdata.oceanobservatories.org/files/CE04OSPS/PC01B/ZPLSCB102_10.33.10.143/2017/08/21/OOI-D20170821-T031816.raw'
+    ek60_path = 'https://ncei-wcsd-archive.s3-us-west-2.amazonaws.com/data/raw/Bell_M._Shimada/SH1707/EK60/Summer2017-D20170615-T190214.raw'
 
-    out_file = "./test.nc"
-    ec = Convert(ek60_path, model='EK60')
-    ec.to_netcdf(out_file, overwrite=True)
+    ec = Convert(ek60_path, model=model)
 
     assert ec.source_file[0] == ek60_path
 
-    os.unlink(out_file)
+    _file_export_checks(ec, model)
 
-# TODO: Need ek80 http example
-# def test_http_ek80_convert():
-#     # http
-#     ek80_path = 'https://rawdata.oceanobservatories.org/files/CE01ISSM/R00007/instrmts/dcl37/ZPLSC_sn55075/ce01issm_zplsc_55075_recovered_2017-10-27/DATA/201703/17032923.01A'
 
-#     out_file = "./test.nc"
-#     ec = Convert(ek80_path, model='EK80')
-#     ec.to_netcdf(out_file, overwrite=True)
+def test_http_ek80_convert():
+    model = 'EK80'
+    # http
+    ek80_path = 'https://ncei-wcsd-archive.s3-us-west-2.amazonaws.com/data/raw/Bell_M._Shimada/SH1707/EK80/D20170826-T205615.raw'
 
-#     assert ec.source_file[0] == ek80_path
+    ec = Convert(ek80_path, model=model)
 
-#     os.unlink(out_file)
+    assert ec.source_file[0] == ek80_path
+
+    _file_export_checks(ec, model)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ pytz
 scipy
 xarray==0.16.2
 zarr
+fsspec>=0.8
+requests
+aiohttp


### PR DESCRIPTION
## Overview

This PR adds the ability for echopype `Convert` object to read and parse raw files located in any filesystem listed [here](https://github.com/intake/filesystem_spec/blob/a5bb95155b450ec2443872a45a4a58ce90748297/fsspec/registry.py#L88-L182). 
Local file system stays the same however for sonal models that require `RawSimradFile` class, meaning it uses python `FileIO` rather than fsspec local file system mapping.

Additionally, `storage_options` attribute is added to the class to allow user to pass in keyword arguments for any of fsspec file system.

## Issue Related
Partial solution to #195 