### PR TITLE
Add file that describes test data

### DIFF
--- a/echopype/test_data/README.md
+++ b/echopype/test_data/README.md
@@ -1,0 +1,28 @@
+## Files Used in Tests
+Most of these files are stored on Git LFS but the ones that aren't (due to file size) can be found on the echopype shared drive.
+
+
+### EK80
+
+- D20190822-T161221.raw: Contains channels that only record real power data
+
+- D20170912-T234910.raw: Contains channels that only record complex power data
+
+- Summer2018 (3 files): Contains channels with complex power data as well as channels with real power data. They can be combined.
+
+- 2019118 group2survey-D20191214-T081342.raw: Contains 6 channels but only 2 of those channels collect ping data.
+
+- 0001a-D20200321-T032026.raw: Data was taken from an EA640 and not an EK80, however, parsing an EA640 file should work under the EK80 routine.
+
+
+### EK60
+
+- DY1801_EK60-D20180211-T164025.raw: Standard test with constant ranges across ping times
+
+- 2015843-D20151023-T190636.raw: Not used in tests but contains ranges are not constant across ping times
+
+- SH1701_consecutive_files_w_range_change: Not used in tests. [Folder](https://drive.google.com/drive/u/1/folders/1PaDtL-xnG5EK3N3P1kGlXa5ub16Yic0f) on shared drive that contains seqential files with ranges that are not constant across ping times.
+
+### AZFP
+
+- 17082117.01A: standard test. Used with 17041823.XML.


### PR DESCRIPTION
This pull request contains a README added to the test_data folder that describes the test files used for EK80, EK60, and AZFP.