### PR TITLE
Combine files and SetGroups updates

### DIFF
--- a/echopype/convert/convert.py
+++ b/echopype/convert/convert.py
@@ -441,20 +441,22 @@ class Convert:
         -------
         True or False depending on whether or not the combination was successful
         """
-        if len(self.source_file) < 2:
-            print("Combination did not occur as there is only 1 source file")
-            return False
-
         # self.output_path contains individual files to be combined if
         #  they have just been converted using this object
         indiv_files = self.output_file if indiv_files is None else indiv_files
+
+        if isinstance(indiv_files, str):
+            indiv_files = [indiv_files]
+        if len(indiv_files) < 2:
+            print("Combination did not occur as there is only one source file.")
+            return True
 
         # Construct the final combined save path
         if save_path is not None:
             # TODO: we need to check validity/permission of the user-specified save_path here
             combined_save_path = save_path
         else:
-            combined_save_path = self._get_combined_save_path(save_path, indiv_files)
+            combined_save_path = self._get_combined_save_path(indiv_files)
 
         # Get the correct xarray functions for opening datasets
         engine = io.get_file_format(combined_save_path)

--- a/echopype/convert/convert.py
+++ b/echopype/convert/convert.py
@@ -54,7 +54,6 @@ NMEA_SENTENCE_DEFAULT = ['GGA', 'GLL', 'RMC']
 
 # TODO: Used for backwards compatibility. Delete in future versions
 def ConvertEK80(_filename=""):
-    # TODO: use warnings.warn directly, not sure why we need an additional layer of abstraction
     warnings.warn("`ConvertEK80` is deprecated, use `Convert(file, model='EK80')` instead.",
                   DeprecationWarning, 2)
     return Convert(file=_filename, model='EK80')
@@ -307,7 +306,7 @@ class Convert:
         else:
             params = self.data_type
 
-        # Actually parsing and saving file(s)
+        # Actually parsing and saving file
         c = c(file, params=params, storage_options=self.storage_options)
         c.parse_raw()
         sg = sg(c, input_file=file, output_path=output_path, engine=engine, compress=self.compress,
@@ -325,17 +324,6 @@ class Convert:
                 shutil.rmtree(path)
             else:
                 os.remove(path)
-
-    # TODO: can take this out if we force output_path to always be a list
-    @staticmethod
-    def _path_list_to_str(path):
-        """Takes a list of filepaths and if there is only 1 path, return that path as a string.
-        Otherwise returns the list of filepaths
-        """
-        if len(path) == 1:
-            return path[0]
-        else:
-            return path
 
     def _perform_combination(self, input_paths, output_path, engine):
         """Opens a list of Netcdf/Zarr files as a single dataset and saves it to a single file.
@@ -751,7 +739,10 @@ class Convert:
                 else:
                     raise ValueError("Unknown data type", data_type)
                 xml_file.write(data)
-        self.output_file = self._path_list_to_str(self.output_file)
+
+        # If only one output file make it a string instead of a list
+        if len(self.output_file) == 1:
+            self.output_file = self.output_file[0]
 
     @staticmethod
     def check_files(file, model, xml_path=None, storage_options={}):
@@ -783,28 +774,25 @@ class Convert:
 
         return file, xml
 
-    # TODO: Used for backwards compatibility. Delete in future versions
+    # TODO: Remove below in future versions. They are for supporting old API calls.
     @property
     def nc_path(self):
         warnings.warn("`nc_path` is deprecated, Use `output_path` instead.", DeprecationWarning, 2)
         path = self._nc_path if self._nc_path is not None else self.output_file
         return path
 
-    # TODO: Used for backwards compatibility. Delete in future versions
     @property
     def zarr_path(self):
         warnings.warn("`zarr_path` is deprecated, Use `output_path` instead.", DeprecationWarning, 2)
         path = self._zarr_path if self._zarr_path is not None else self.output_file
         return path
 
-    # TODO: Used for backwards compatibility. Delete in future versions
     def raw2nc(self, save_path=None, combine_opt=False, overwrite=False, compress=True):
         warnings.warn("`raw2nc` is deprecated, use `to_netcdf` instead.", DeprecationWarning, 2)
         self.to_netcdf(save_path=save_path, compress=compress, combine=combine_opt,
                        overwrite=overwrite)
         self._nc_path = self.output_file
 
-    # TODO: Used for backwards compatibility. Delete in future versions
     def raw2zarr(self, save_path=None, combine_opt=False, overwrite=False, compress=True):
         warnings.warn("`raw2zarr` is deprecated, use `to_zarr` instead.", DeprecationWarning, 2)
         self.to_zarr(save_path=save_path, compress=compress, combine=combine_opt,

--- a/echopype/convert/convert.py
+++ b/echopype/convert/convert.py
@@ -16,7 +16,7 @@ from .set_groups_azfp import SetGroupsAZFP
 from .set_groups_ek60 import SetGroupsEK60
 from .set_groups_ek80 import SetGroupsEK80
 from ..utils import io
-from .convert_combine import get_combined_save_path, remove_indiv_files, perform_combination
+from ..convert import convert_combine as combine_fcn
 
 
 warnings.simplefilter('always', DeprecationWarning)
@@ -348,11 +348,11 @@ class Convert:
             # TODO: we need to check validity/permission of the user-specified save_path here
             combined_save_path = save_path
         else:
-            combined_save_path = get_combined_save_path(indiv_files)
+            combined_save_path = combine_fcn.get_combined_save_path(indiv_files)
 
         # Get the correct xarray functions for opening datasets
         engine = io.get_file_format(combined_save_path)
-        perform_combination(self.sonar_model, indiv_files, combined_save_path, engine)
+        combine_fcn.perform_combination(self.sonar_model, indiv_files, combined_save_path, engine)
 
         # Update output_path to be the combined path name
         self.output_file = combined_save_path
@@ -360,7 +360,7 @@ class Convert:
         # Delete individual files after combining
         if remove_indiv:
             for f in indiv_files:
-                remove_indiv_files(f)
+                combine_fcn.remove_indiv_files(f)
 
     def update_platform(self, files=None, extra_platform_data=None):
         """

--- a/echopype/convert/convert.py
+++ b/echopype/convert/convert.py
@@ -409,7 +409,7 @@ class Convert:
         print("All input files combined into " + output_path)
 
     @staticmethod
-    def _get_combined_save_path(save_path, source_paths):
+    def _get_combined_save_path(source_paths):
         def get_combined_fname(path):
             fname, ext = os.path.splitext(path)
             return fname + '__combined' + ext
@@ -422,6 +422,10 @@ class Convert:
 
     def combine_files(self, indiv_files=None, save_path=None, remove_orig=True):
         """Combine output files when self.combine=True.
+
+        `combine_files` can be called to combine files that have just be converted
+        by the current instance of Convert (those listed in self.output_path)
+        or files that were previously converted (specified in `indiv_files`).
 
         Parameters
         ----------
@@ -441,7 +445,7 @@ class Convert:
             print("Combination did not occur as there is only 1 source file")
             return False
 
-        # self.output path contains individual files to be combined if
+        # self.output_path contains individual files to be combined if
         #  they have just been converted using this object
         indiv_files = self.output_file if indiv_files is None else indiv_files
 

--- a/echopype/convert/convert.py
+++ b/echopype/convert/convert.py
@@ -667,8 +667,9 @@ class Convert:
         if extra_platform_data is not None:
             self.update_platform(files=self.output_file, extra_platform_data=extra_platform_data)
 
-        # Tidy up output_path
-        self.output_file = self._path_list_to_str(self.output_file)
+        # If only one output file make it a string instead of a list
+        if len(self.output_file) == 1:
+            self.output_file = self.output_file[0]
 
     def to_netcdf(self, **kwargs):
         return self._to_file('netcdf4', **kwargs)

--- a/echopype/convert/convert.py
+++ b/echopype/convert/convert.py
@@ -2,13 +2,10 @@
 UI class for converting raw data from different echosounders to netcdf or zarr.
 """
 import os
-import shutil
 import warnings
 import xarray as xr
 import numpy as np
 import zarr
-from fsspec.mapping import FSMap
-from fsspec.implementations.local import LocalFileSystem
 from collections.abc import MutableMapping
 from datetime import datetime as dt
 import fsspec
@@ -19,11 +16,10 @@ from .set_groups_azfp import SetGroupsAZFP
 from .set_groups_ek60 import SetGroupsEK60
 from .set_groups_ek80 import SetGroupsEK80
 from ..utils import io
-from .._version import get_versions
+from .convert_combine import get_combined_save_path, remove_indiv_files, perform_combination
+
 
 warnings.simplefilter('always', DeprecationWarning)
-
-ECHOPYPE_VERSION = get_versions()['version']
 
 MODELS = {
     "AZFP": {
@@ -53,11 +49,6 @@ MODELS = {
 }
 
 NMEA_SENTENCE_DEFAULT = ['GGA', 'GLL', 'RMC']
-
-DEFAULT_CHUNK_SIZE = {
-    'range_bin': 25000,
-    'ping_time': 2500
-}
 
 
 # TODO: Used for backwards compatibility. Delete in future versions
@@ -321,128 +312,7 @@ class Convert:
                 overwrite=self.overwrite, params=self._conversion_params, sonar_model=self.sonar_model)
         sg.save()
 
-    @staticmethod
-    def _remove_indiv_files(path):
-        """Used to delete .nc or .zarr files"""
-        if isinstance(path, FSMap):
-            path.fs.delete(path.root, recursive=True)
-        else:
-            fname, ext = os.path.splitext(path)
-            if ext == '.zarr':
-                shutil.rmtree(path)
-            else:
-                os.remove(path)
-
-    @staticmethod
-    def _assemble_combine_provenance(input_paths):
-        prov_dict = {'conversion_software_name': 'echopype',
-                     'conversion_software_version': ECHOPYPE_VERSION,
-                     'conversion_time': dt.utcnow().isoformat(timespec='seconds') + 'Z',  # use UTC time
-                     'src_filenames': input_paths}
-        ds = xr.Dataset()
-        return ds.assign_attrs(prov_dict)
-
-    def _perform_combination(self, input_paths, output_path, engine):
-        """Opens a list of Netcdf/Zarr files as a single dataset and saves it to a single file.
-        """
-        def coerce_type(ds, group):
-            if group == 'Beam':
-                if self.sonar_model == 'EK80':
-                    ds['transceiver_software_version'] = ds['transceiver_software_version'].astype('<U10')
-                    ds['channel_id'] = ds['channel_id'].astype('<U50')
-                elif self.sonar_model == 'EK60':
-                    ds['gpt_software_version'] = ds['gpt_software_version'].astype('<U10')
-                    ds['channel_id'] = ds['channel_id'].astype('<U50')
-
-        print('combining files...')
-        # Open multiple files as one dataset of each group and save them into a single file
-
-        # TODO: add in the documentation that the Top-level and Sonar groups are
-        #  combined by taking values (attributes) from the first file
-        # Combine Top-level group, use values from the first file
-        with xr.open_dataset(input_paths[0], engine=engine) as ds_top:
-            io.save_file(ds_top, path=output_path, mode='w', engine=engine)
-
-        # Combine Sonar group, use values from the first file
-        with xr.open_dataset(input_paths[0], group='Sonar', engine=engine) as ds_sonar:
-            io.save_file(ds_sonar, path=output_path, mode='a', engine=engine, group='Sonar')
-
-        # Combine Provenance group,
-        ds_prov = self._assemble_combine_provenance(input_paths)
-        io.save_file(ds_prov, path=output_path, mode='a', engine=engine, group='Provenance')
-
-        # TODO: Put the following in docs:
-        #  Right now we follow xr.combine_by_coords default to only combine files
-        #  with nicely monotonically varying ping_time/location_time/mru_time.
-        #  However we know there are lots of problems with pings going backward in time for EK60/EK80 files,
-        #  and we will need to clean up data before calling merge.
-        # Combine Beam
-        with xr.open_mfdataset(input_paths, group='Beam',
-                               concat_dim='ping_time', data_vars='minimal', engine=engine) as ds_beam:
-            coerce_type(ds_beam, 'Beam')
-            io.save_file(ds_beam.chunk({'range_bin': DEFAULT_CHUNK_SIZE['range_bin'],
-                                        'ping_time': DEFAULT_CHUNK_SIZE['ping_time']}),  # these chunk sizes are ad-hoc
-                         path=output_path, mode='a', engine=engine, group='Beam')
-
-        # Combine Environment group
-        with xr.open_mfdataset(input_paths, group='Environment',
-                               concat_dim='ping_time', data_vars='minimal', engine=engine) as ds_env:
-            io.save_file(ds_env.chunk({'ping_time': DEFAULT_CHUNK_SIZE['ping_time']}),
-                         path=output_path, mode='a', engine=engine, group='Environment')
-
-        # Combine Platform group
-        # The platform group for AZFP does not have coordinates, so it must be handled differently from EK60
-        # TODO: check AZFP platform: shouldn't the AZFP platform coordinates just be empty?
-        if self.sonar_model == 'AZFP':
-            with xr.open_mfdataset(input_paths, group='Platform', combine='nested',
-                                   compat='identical', engine=engine) as ds_plat:
-                io.save_file(ds_plat, path=output_path, mode='a', engine=engine, group='Platform')
-        elif self.sonar_model in ['EK80', 'EA640']:
-            with xr.open_mfdataset(input_paths, group='Platform',
-                                   concat_dim=['location_time', 'mru_time'],
-                                   data_vars='minimal', engine=engine) as ds_plat:
-                    io.save_file(ds_plat.chunk({'location_time': DEFAULT_CHUNK_SIZE['ping_time'],
-                                                'mru_time': DEFAULT_CHUNK_SIZE['ping_time']}),
-                                 path=output_path, mode='a', engine=engine, group='Platform')
-        elif self.sonar_model in ['EK60']:
-            with xr.open_mfdataset(input_paths, group='Platform',
-                                   concat_dim=['location_time', 'ping_time'],
-                                   data_vars='minimal', engine=engine) as ds_plat:
-                io.save_file(ds_plat.chunk({'location_time': DEFAULT_CHUNK_SIZE['ping_time'],
-                                            'ping_time': DEFAULT_CHUNK_SIZE['ping_time']}),
-                             path=output_path, mode='a', engine=engine, group='Platform')
-
-        # Combine Platform/NMEA group
-        if self.sonar_model in ['EK60', 'EK80', 'EA640']:
-            with xr.open_mfdataset(input_paths, group='Platform/NMEA',
-                                   concat_dim='location_time', data_vars='minimal', engine=engine) as ds_nmea:
-                io.save_file(ds_nmea.chunk({'location_time': DEFAULT_CHUNK_SIZE['ping_time']}).astype('str'),
-                             path=output_path, mode='a', engine=engine, group='Platform/NMEA')
-
-        # Combine Vendor-specific group
-        # TODO: double check this works with AZFP data as data variables change with ping_time
-        with xr.open_mfdataset(input_paths, group='Vendor',
-                               combine='nested',  # nested since this is more like merge and no dim to concat
-                               compat='no_conflicts', data_vars='minimal', engine=engine) as ds_vend:
-            io.save_file(ds_vend, path=output_path, mode='a', engine=engine, group='Vendor')
-
-        # TODO: print out which group combination errors out and raise appropriate error
-
-        print("All input files combined into " + output_path)
-
-    @staticmethod
-    def _get_combined_save_path(source_paths):
-        def get_combined_fname(path):
-            fname, ext = os.path.splitext(path)
-            return fname + '__combined' + ext
-
-        sample_file = source_paths[0]
-        save_path = get_combined_fname(sample_file.root) if isinstance(sample_file, FSMap) else get_combined_fname(sample_file)
-        if isinstance(sample_file, FSMap) and not isinstance(sample_file.fs, LocalFileSystem):
-            return sample_file.fs.get_mapper(save_path)
-        return save_path
-
-    def combine_files(self, indiv_files=None, save_path=None, remove_indiv_files=True):
+    def combine_files(self, indiv_files=None, save_path=None, remove_indiv=True):
         """Combine output files when self.combine=True.
 
         `combine_files` can be called to combine files that have just be converted
@@ -455,7 +325,7 @@ class Convert:
             List of NetCDF or Zarr files to combine
         save_path : str
             Either a directory or a file. If none, use the name of the first ``src_file``
-        remove_indiv_files : bool
+        remove_indiv : bool
             Whether or not to remove the files in ``indiv_files``
             Defaults to ``True``
 
@@ -478,19 +348,19 @@ class Convert:
             # TODO: we need to check validity/permission of the user-specified save_path here
             combined_save_path = save_path
         else:
-            combined_save_path = self._get_combined_save_path(indiv_files)
+            combined_save_path = get_combined_save_path(indiv_files)
 
         # Get the correct xarray functions for opening datasets
         engine = io.get_file_format(combined_save_path)
-        self._perform_combination(indiv_files, combined_save_path, engine)
+        perform_combination(self.sonar_model, indiv_files, combined_save_path, engine)
 
         # Update output_path to be the combined path name
         self.output_file = combined_save_path
 
         # Delete individual files after combining
-        if remove_indiv_files:
+        if remove_indiv:
             for f in indiv_files:
-                self._remove_indiv_files(f)
+                remove_indiv_files(f)
 
     def update_platform(self, files=None, extra_platform_data=None):
         """
@@ -685,7 +555,7 @@ class Convert:
 
         # Combine files if needed
         if self.combine:
-            self.combine_files(save_path=save_path, remove_indiv_files=True)
+            self.combine_files(save_path=save_path, remove_indiv=True)
 
         # Attached platform data
         if extra_platform_data is not None:

--- a/echopype/convert/convert_combine.py
+++ b/echopype/convert/convert_combine.py
@@ -66,8 +66,7 @@ def perform_combination(sonar_model, input_paths, output_path, engine):
                 ds['gpt_software_version'] = ds['gpt_software_version'].astype('<U10')
                 ds['channel_id'] = ds['channel_id'].astype('<U50')
 
-    print('combining files...')
-    # Open multiple files as one dataset of each group and save them into a single file
+    print(f"{dt.now().strftime('%H:%M:%S')}  combining files...")
 
     # TODO: add in the documentation that the Top-level and Sonar groups are
     #  combined by taking values (attributes) from the first file
@@ -140,4 +139,4 @@ def perform_combination(sonar_model, input_paths, output_path, engine):
 
     # TODO: print out which group combination errors out and raise appropriate error
 
-    print("All input files combined into " + output_path)
+    print(f"{dt.now().strftime('%H:%M:%S')}  all files combined into {output_path}")

--- a/echopype/convert/convert_combine.py
+++ b/echopype/convert/convert_combine.py
@@ -1,3 +1,7 @@
+"""
+This file contains functions used by Convert.combine_files().
+"""
+
 import os
 import shutil
 from datetime import datetime as dt
@@ -6,7 +10,6 @@ from fsspec.implementations.local import LocalFileSystem
 import xarray as xr
 from .._version import get_versions
 from ..utils import io
-
 
 ECHOPYPE_VERSION = get_versions()['version']
 
@@ -53,6 +56,7 @@ def assemble_combined_provenance(input_paths):
 def perform_combination(sonar_model, input_paths, output_path, engine):
     """Opens a list of Netcdf/Zarr files as a single dataset and saves it to a single file.
     """
+
     def coerce_type(ds, group):
         if group == 'Beam':
             if sonar_model == 'EK80':
@@ -137,4 +141,3 @@ def perform_combination(sonar_model, input_paths, output_path, engine):
     # TODO: print out which group combination errors out and raise appropriate error
 
     print("All input files combined into " + output_path)
-

--- a/echopype/convert/convert_combine.py
+++ b/echopype/convert/convert_combine.py
@@ -1,0 +1,140 @@
+import os
+import shutil
+from datetime import datetime as dt
+from fsspec.mapping import FSMap
+from fsspec.implementations.local import LocalFileSystem
+import xarray as xr
+from .._version import get_versions
+from ..utils import io
+
+
+ECHOPYPE_VERSION = get_versions()['version']
+
+DEFAULT_CHUNK_SIZE = {
+    'range_bin': 25000,
+    'ping_time': 2500
+}
+
+
+def get_combined_save_path(source_paths):
+    def get_combined_fname(path):
+        fname, ext = os.path.splitext(path)
+        return fname + '__combined' + ext
+
+    sample_file = source_paths[0]
+    save_path = get_combined_fname(sample_file.root) if isinstance(sample_file, FSMap) else get_combined_fname \
+        (sample_file)
+    if isinstance(sample_file, FSMap) and not isinstance(sample_file.fs, LocalFileSystem):
+        return sample_file.fs.get_mapper(save_path)
+    return save_path
+
+
+def remove_indiv_files(path):
+    """Used to delete .nc or .zarr files"""
+    if isinstance(path, FSMap):
+        path.fs.delete(path.root, recursive=True)
+    else:
+        fname, ext = os.path.splitext(path)
+        if ext == '.zarr':
+            shutil.rmtree(path)
+        else:
+            os.remove(path)
+
+
+def assemble_combined_provenance(input_paths):
+    prov_dict = {'conversion_software_name': 'echopype',
+                 'conversion_software_version': ECHOPYPE_VERSION,
+                 'conversion_time': dt.utcnow().isoformat(timespec='seconds') + 'Z',  # use UTC time
+                 'src_filenames': input_paths}
+    ds = xr.Dataset()
+    return ds.assign_attrs(prov_dict)
+
+
+def perform_combination(sonar_model, input_paths, output_path, engine):
+    """Opens a list of Netcdf/Zarr files as a single dataset and saves it to a single file.
+    """
+    def coerce_type(ds, group):
+        if group == 'Beam':
+            if sonar_model == 'EK80':
+                ds['transceiver_software_version'] = ds['transceiver_software_version'].astype('<U10')
+                ds['channel_id'] = ds['channel_id'].astype('<U50')
+            elif sonar_model == 'EK60':
+                ds['gpt_software_version'] = ds['gpt_software_version'].astype('<U10')
+                ds['channel_id'] = ds['channel_id'].astype('<U50')
+
+    print('combining files...')
+    # Open multiple files as one dataset of each group and save them into a single file
+
+    # TODO: add in the documentation that the Top-level and Sonar groups are
+    #  combined by taking values (attributes) from the first file
+    # Combine Top-level group, use values from the first file
+    with xr.open_dataset(input_paths[0], engine=engine) as ds_top:
+        io.save_file(ds_top, path=output_path, mode='w', engine=engine)
+
+    # Combine Sonar group, use values from the first file
+    with xr.open_dataset(input_paths[0], group='Sonar', engine=engine) as ds_sonar:
+        io.save_file(ds_sonar, path=output_path, mode='a', engine=engine, group='Sonar')
+
+    # Combine Provenance group,
+    ds_prov = assemble_combined_provenance(input_paths)
+    io.save_file(ds_prov, path=output_path, mode='a', engine=engine, group='Provenance')
+
+    # TODO: Put the following in docs:
+    #  Right now we follow xr.combine_by_coords default to only combine files
+    #  with nicely monotonically varying ping_time/location_time/mru_time.
+    #  However we know there are lots of problems with pings going backward in time for EK60/EK80 files,
+    #  and we will need to clean up data before calling merge.
+    # Combine Beam
+    with xr.open_mfdataset(input_paths, group='Beam',
+                           concat_dim='ping_time', data_vars='minimal', engine=engine) as ds_beam:
+        coerce_type(ds_beam, 'Beam')
+        io.save_file(ds_beam.chunk({'range_bin': DEFAULT_CHUNK_SIZE['range_bin'],
+                                    'ping_time': DEFAULT_CHUNK_SIZE['ping_time']}),  # these chunk sizes are ad-hoc
+                     path=output_path, mode='a', engine=engine, group='Beam')
+
+    # Combine Environment group
+    with xr.open_mfdataset(input_paths, group='Environment',
+                           concat_dim='ping_time', data_vars='minimal', engine=engine) as ds_env:
+        io.save_file(ds_env.chunk({'ping_time': DEFAULT_CHUNK_SIZE['ping_time']}),
+                     path=output_path, mode='a', engine=engine, group='Environment')
+
+    # Combine Platform group
+    # The platform group for AZFP does not have coordinates, so it must be handled differently from EK60
+    # TODO: check AZFP platform: shouldn't the AZFP platform coordinates just be empty?
+    if sonar_model == 'AZFP':
+        with xr.open_mfdataset(input_paths, group='Platform', combine='nested',
+                               compat='identical', engine=engine) as ds_plat:
+            io.save_file(ds_plat, path=output_path, mode='a', engine=engine, group='Platform')
+    elif sonar_model in ['EK80', 'EA640']:
+        with xr.open_mfdataset(input_paths, group='Platform',
+                               concat_dim=['location_time', 'mru_time'],
+                               data_vars='minimal', engine=engine) as ds_plat:
+            io.save_file(ds_plat.chunk({'location_time': DEFAULT_CHUNK_SIZE['ping_time'],
+                                        'mru_time': DEFAULT_CHUNK_SIZE['ping_time']}),
+                         path=output_path, mode='a', engine=engine, group='Platform')
+    elif sonar_model in ['EK60']:
+        with xr.open_mfdataset(input_paths, group='Platform',
+                               concat_dim=['location_time', 'ping_time'],
+                               data_vars='minimal', engine=engine) as ds_plat:
+            io.save_file(ds_plat.chunk({'location_time': DEFAULT_CHUNK_SIZE['ping_time'],
+                                        'ping_time': DEFAULT_CHUNK_SIZE['ping_time']}),
+                         path=output_path, mode='a', engine=engine, group='Platform')
+
+    # Combine Platform/NMEA group
+    if sonar_model in ['EK60', 'EK80', 'EA640']:
+        with xr.open_mfdataset(input_paths, group='Platform/NMEA',
+                               concat_dim='location_time', data_vars='minimal', engine=engine) as ds_nmea:
+            io.save_file(ds_nmea.chunk({'location_time': DEFAULT_CHUNK_SIZE['ping_time']}).astype('str'),
+                         path=output_path, mode='a', engine=engine, group='Platform/NMEA')
+
+    # Combine Vendor-specific group
+    # TODO: double check this works with AZFP data as data variables change with ping_time
+    with xr.open_mfdataset(input_paths, group='Vendor',
+                           combine='nested',  # nested since this is more like merge and no dim to concat
+                           compat='no_conflicts', data_vars='minimal', engine=engine) as ds_vend:
+        io.save_file(ds_vend, path=output_path, mode='a', engine=engine, group='Vendor')
+
+    # TODO: print out which group combination errors out and raise appropriate error
+
+    print("All input files combined into " + output_path)
+

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -1,13 +1,11 @@
 """
 Class to save unpacked echosounder data to appropriate groups in netcdf or zarr.
 """
-import os
 import xarray as xr
 import numpy as np
-import zarr
-import netCDF4
 from .set_groups_base import SetGroupsBase
 from ..utils import io
+from .set_groups_base import DEFAULT_CHUNK_SIZE
 
 
 class SetGroupsAZFP(SetGroupsBase):
@@ -16,23 +14,20 @@ class SetGroupsAZFP(SetGroupsBase):
     def save(self):
         """Actually save groups to file by calling the set methods.
         """
-        sonar_values = ('ASL Environmental Sciences', 'Acoustic Zooplankton Fish Profiler',
-                        int(self.parser_obj.unpacked_data['serial_number']),
-                        'Based on AZFP Matlab Toolbox', '1.4', 'echosounder')
-        self.set_toplevel("AZFP")
-        self.set_env()
+        # TODO: check if there is any earlier time than the first ping_time for AZFP
+        self.set_toplevel(self.sonar_model, date_created=self.parser_obj.ping_time[0])
         self.set_provenance()
+        self.set_env()
         self.set_platform()
-        self.set_sonar(sonar_values)
+        self.set_sonar()
         self.set_beam()
         self.set_vendor()
 
-    def set_env(self, ):
+    def set_env(self):
         """Set the Environment group.
         """
-        # TODO Look at why this cannot be encoded without the modifications
+        # TODO Look at why this cannot be encoded without the modifications -- @ngkavin: what modification?
         ping_time = (self.parser_obj.ping_time - np.datetime64('1970-01-01T00:00:00')) / np.timedelta64(1, 's')
-        # ping_time = self.convert_obj.ping_time
         ds = xr.Dataset({'temperature': (['ping_time'], self.parser_obj.unpacked_data['temperature'])},
                         coords={'ping_time': (['ping_time'], ping_time,
                                 {'axis': 'T',
@@ -43,7 +38,25 @@ class SetGroupsAZFP(SetGroupsBase):
                         attrs={'long_name': "Water temperature",
                                'units': "C"})
         # Save to file
-        io.save_file(ds, path=self.output_path, mode='a', group='Environment', engine=self.engine)
+        io.save_file(ds.chunk({'ping_time': DEFAULT_CHUNK_SIZE['ping_time']}),
+                     path=self.output_path, mode='a', group='Environment', engine=self.engine)
+
+    def set_sonar(self):
+        """Set the Sonar group.
+        """
+        # Assemble sonar group dictionary
+        sonar_dict = {
+            'sonar_manufacturer': 'ASL Environmental Sciences',
+            'sonar_model': 'Acoustic Zooplankton Fish Profiler',
+            'sonar_serial_number': int(self.parser_obj.unpacked_data['serial_number']),
+            'sonar_software_name': 'Based on AZFP Matlab Toolbox',
+            'sonar_software_version': '1.4',
+            'sonar_type': 'echosounder'
+        }
+        # Save
+        ds = xr.Dataset()
+        ds = ds.assign_attrs(sonar_dict)
+        io.save_file(ds, path=self.output_path, group='Sonar', mode='a', engine=self.engine)
 
     def set_platform(self):
         """Set the Platform group.
@@ -51,15 +64,10 @@ class SetGroupsAZFP(SetGroupsBase):
         platform_dict = {'platform_name': self.ui_param['platform_name'],
                          'platform_type': self.ui_param['platform_type'],
                          'platform_code_ICES': self.ui_param['platform_code_ICES']}
-        if self.engine == 'netcdf4':
-            with netCDF4.Dataset(self.output_path, 'a', format='NETCDF4') as ncfile:
-                plat = ncfile.createGroup('Platform')
-                [plat.setncattr(k, v) for k, v in platform_dict.items()]
-        elif self.engine == 'zarr':
-            zarrfile = zarr.open(self.output_path, mode='a')
-            plat = zarrfile.create_group('Platform')
-            for k, v in platform_dict.items():
-                plat.attrs[k] = v
+        # Save
+        ds = xr.Dataset()
+        ds = ds.assign_attrs(platform_dict)
+        io.save_file(ds, path=self.output_path, group='Platform', mode='a', engine=self.engine)
 
     def set_beam(self):
         """Set the Beam group.
@@ -157,7 +165,8 @@ class SetGroupsAZFP(SetGroupsBase):
                                'tilt_Y_d': parameters['Y_d']})
 
         # Save to file
-        io.save_file(ds.chunk({'range_bin': 25000, 'ping_time': 100}),
+        io.save_file(ds.chunk({'range_bin': DEFAULT_CHUNK_SIZE['range_bin'],
+                               'ping_time': DEFAULT_CHUNK_SIZE['ping_time']}),
                      path=self.output_path, mode='a', engine=self.engine,
                      group='Beam', compression_settings=self.compression_settings)
 
@@ -168,23 +177,26 @@ class SetGroupsAZFP(SetGroupsBase):
         freq = np.array(unpacked_data['frequency']) * 1000    # Frequency in Hz
         ping_time = (self.parser_obj.ping_time - np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's')
 
-        ds = xr.Dataset({
-            'digitization_rate': (['frequency'], unpacked_data['dig_rate']),
-            'lockout_index': (['frequency'], unpacked_data['lockout_index']),
-            'number_of_bins_per_channel': (['frequency'], unpacked_data['num_bins']),
-            'number_of_samples_per_average_bin': (['frequency'], unpacked_data['range_samples_per_bin']),
-            'board_number': (['frequency'], unpacked_data['board_num']),
-            'data_type': (['frequency'], unpacked_data['data_type']),
-            'ping_status': (['ping_time'], unpacked_data['ping_status']),
-            'number_of_acquired_pings': (['ping_time'], unpacked_data['num_acq_pings']),
-            'first_ping': (['ping_time'], unpacked_data['first_ping']),
-            'last_ping': (['ping_time'], unpacked_data['last_ping']),
-            'data_error': (['ping_time'], unpacked_data['data_error']),
-            'sensor_flag': (['ping_time'], unpacked_data['sensor_flag']),
-            'ancillary': (['ping_time', 'ancillary_len'], unpacked_data['ancillary']),
-            'ad_channels': (['ping_time', 'ad_len'], unpacked_data['ad']),
-            'battery_main': (['ping_time'], unpacked_data['battery_main']),
-            'battery_tx': (['ping_time'], unpacked_data['battery_tx'])},
+        ds = xr.Dataset(
+            {
+                'digitization_rate': (['frequency'], unpacked_data['dig_rate']),
+                'lockout_index': (['frequency'], unpacked_data['lockout_index']),
+                'number_of_bins_per_channel': (['frequency'], unpacked_data['num_bins']),
+                'number_of_samples_per_average_bin': (['frequency'], unpacked_data['range_samples_per_bin']),
+                'board_number': (['frequency'], unpacked_data['board_num']),
+                'data_type': (['frequency'], unpacked_data['data_type']),
+                'ping_status': (['ping_time'], unpacked_data['ping_status']),
+                'number_of_acquired_pings': (['ping_time'], unpacked_data['num_acq_pings']),
+                'first_ping': (['ping_time'], unpacked_data['first_ping']),
+                'last_ping': (['ping_time'], unpacked_data['last_ping']),
+                'data_error': (['ping_time'], unpacked_data['data_error']),
+                'sensor_flag': (['ping_time'], unpacked_data['sensor_flag']),
+                'ancillary': (['ping_time', 'ancillary_len'], unpacked_data['ancillary']),
+                'ad_channels': (['ping_time', 'ad_len'], unpacked_data['ad']),
+                'battery_main': (['ping_time'], unpacked_data['battery_main']),
+                'battery_tx': (['ping_time'], unpacked_data['battery_tx']),
+                'profile_number': (['ping_time'], unpacked_data['profile_number']),
+            },
             coords={
                 'frequency': (['frequency'], freq,
                               {'units': 'Hz',
@@ -199,7 +211,6 @@ class SetGroupsAZFP(SetGroupsBase):
                 'ad_len': (['ad_len'], list(range(len(unpacked_data['ad'][0]))))},
             attrs={
                 'profile_flag': unpacked_data['profile_flag'],
-                'profile_number': unpacked_data['profile_number'],
                 'burst_interval': unpacked_data['burst_int'],
                 'ping_per_profile': unpacked_data['ping_per_profile'],
                 'average_pings_flag': unpacked_data['avg_pings'],
@@ -210,5 +221,6 @@ class SetGroupsAZFP(SetGroupsBase):
         )
 
         # Save to file
-        io.save_file(ds, path=self.output_path, mode='a', engine=self.engine,
+        io.save_file(ds.chunk({'ping_time': DEFAULT_CHUNK_SIZE['ping_time']}),
+                     path=self.output_path, mode='a', engine=self.engine,
                      group='Vendor', compression_settings=self.compression_settings)

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -3,7 +3,6 @@ from datetime import datetime as dt
 import xarray as xr
 import numpy as np
 import zarr
-import netCDF4
 from .._version import get_versions
 from ..utils import io
 ECHOPYPE_VERSION = get_versions()['version']
@@ -14,13 +13,17 @@ COMPRESSION_SETTINGS = {
     'zarr': {'compressor': zarr.Blosc(cname='zstd', clevel=3, shuffle=2)}
 }
 
+DEFAULT_CHUNK_SIZE = {
+    'range_bin': 25000,
+    'ping_time': 2500
+}
+
 
 class SetGroupsBase:
     """Base class for saving groups to netcdf or zarr from echosounder data files.
     """
     def __init__(self, parser_obj, input_file, output_path, sonar_model=None,
                  engine='zarr', compress=True, overwrite=True, params=None):
-        # TODO: Change convert_obj to parse_obj
         self.parser_obj = parser_obj   # parser object ParseEK60/ParseAZFP/etc...
         self.sonar_model = sonar_model   # Used for when a sonar that is not AZFP/EK60/EK80 can still be saved
         self.input_file = input_file
@@ -38,25 +41,13 @@ class SetGroupsBase:
     def save(self):
         """Actually save groups to file by calling the set methods.
         """
+        pass
 
     # TODO: change the set_XXX methods to return a dataset to be saved in the overarching save method
     def set_toplevel(self, sonar_model, date_created=None):
         """Set the top-level group.
         """
         # Collect variables
-        # TODO: Change SetGroupsEK60/EK80/AZFP to pass date_created specifically,
-        #  instead of grabbing from parser object depending on sonar object
-        if date_created is None:
-            # TODO: change below to use time of config datagram
-            # Check if AZFP or EK
-            if isinstance(self.parser_obj.ping_time, list):
-                date_created = self.parser_obj.ping_time[0]
-            else:
-                pt = []
-                for v in self.parser_obj.ping_time.values():
-                    pt.append(v[0])
-                date_created = np.sort(pt)[0]
-
         tl_dict = {'conventions': 'CF-1.7, SONAR-netCDF4-1.0, ACDD-1.3',
                    'keywords': sonar_model,
                    'sonar_convention_authority': 'ICES',
@@ -66,20 +57,10 @@ class SetGroupsBase:
                    'title': '',
                    'date_created': np.datetime_as_string(date_created, 's') + 'Z',
                    'survey_name': self.ui_param['survey_name']}
-        # Add any extra user defined values
-        for k, v in list(self.ui_param.items())[5:]:
-            tl_dict[k] = v
-
         # Save
-        if self.engine == 'netcdf4':
-            with netCDF4.Dataset(self.output_path, "w", format="NETCDF4") as ncfile:
-                [ncfile.setncattr(k, v) for k, v in tl_dict.items()]
-        elif self.engine == 'zarr':
-            zarrfile = zarr.open(self.output_path, mode="w")
-            for k, v in tl_dict.items():
-                zarrfile.attrs[k] = v
-        else:
-            raise ValueError("Unsupported file format")
+        ds = xr.Dataset()
+        ds = ds.assign_attrs(tl_dict)
+        io.save_file(ds, path=self.output_path, mode='w', engine=self.engine)
 
     def set_provenance(self):
         """Set the Provenance group.
@@ -90,38 +71,19 @@ class SetGroupsBase:
                      'conversion_time': dt.utcnow().isoformat(timespec='seconds') + 'Z',    # use UTC time
                      'src_filenames': self.input_file}
         # Save
-        if self.engine == 'netcdf4':
-            with netCDF4.Dataset(self.output_path, "a", format="NETCDF4") as ncfile:
-                prov = ncfile.createGroup("Provenance")
-                [prov.setncattr(k, v) for k, v in prov_dict.items()]
-        elif self.engine == 'zarr':
-            zarr_file = zarr.open(self.output_path, mode="a")
-            prov = zarr_file.create_group('Provenance')
-            for k, v in prov_dict.items():
-                prov.attrs[k] = v
-        else:
-            raise ValueError("Unsupported file format")
+        ds = xr.Dataset()
+        ds = ds.assign_attrs(prov_dict)
+        io.save_file(ds, path=self.output_path, group='Provenance', mode='a', engine=self.engine)
 
-    def set_sonar(self, sonar_vals):
+    def set_env(self):
+        """Set the Environment group.
+        """
+        pass
+
+    def set_sonar(self):
         """Set the Sonar group.
         """
-        # Collect variables
-        sonar_dict = dict(zip(('sonar_manufacturer', 'sonar_model', 'sonar_serial_number',
-                               'sonar_software_name', 'sonar_software_version', 'sonar_type'), sonar_vals))
-
-        # Save variables
-        if self.engine == 'netcdf4':
-            with netCDF4.Dataset(self.output_path, "a", format="NETCDF4") as ncfile:
-                snr = ncfile.createGroup("Sonar")
-                # set group attributes
-                [snr.setncattr(k, v) for k, v in sonar_dict.items()]
-
-        elif self.engine == 'zarr':
-            zarrfile = zarr.open(self.output_path, mode='a')
-            snr = zarrfile.create_group('Sonar')
-
-            for k, v in sonar_dict.items():
-                snr.attrs[k] = v
+        pass
 
     def set_nmea(self):
         """Set the Platform/NMEA group.

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -44,6 +44,8 @@ class SetGroupsBase:
         """Set the top-level group.
         """
         # Collect variables
+        # TODO: Change SetGroupsEK60/EK80/AZFP to pass date_created specifically,
+        #  instead of grabbing from parser object depending on sonar object
         if date_created is None:
             # TODO: change below to use time of config datagram
             # Check if AZFP or EK

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -3,6 +3,7 @@ import numpy as np
 from collections import defaultdict
 from .set_groups_base import SetGroupsBase
 from ..utils import io
+from .set_groups_base import DEFAULT_CHUNK_SIZE
 
 
 class SetGroupsEK60(SetGroupsBase):
@@ -11,22 +12,18 @@ class SetGroupsEK60(SetGroupsBase):
     def save(self):
         """Actually save groups to file by calling the set methods.
         """
-        # filename must have timestamp that matches self.timestamp_pattern
-        sonar_values = ('Simrad', self.parser_obj.config_datagram['sounder_name'],
-                        '', '', self.parser_obj.config_datagram['version'], 'echosounder')
-
         # Save only up to the platform group if the user selects "GPS"
         if 'NME' in self.parser_obj.data_type:
             self.set_toplevel('EK60', date_created=self.parser_obj.nmea['timestamp'][0])
             self.set_provenance()
-            self.set_sonar(sonar_values)
+            self.set_sonar()
             self.set_platform(NMEA_only=True)
             return
 
         # TODO: Specifically pass in date_created here
-        self.set_toplevel('EK60')
-        self.set_provenance()           # provenance group
-        self.set_sonar(sonar_values)    # sonar group
+        self.set_toplevel(self.sonar_model, date_created=self.parser_obj.config_datagram['timestamp'])
+        self.set_provenance()       # provenance group
+        self.set_sonar()            # sonar group
         self.set_env()              # environment group
         self.set_platform()         # platform group
         self.set_beam()             # beam group
@@ -78,8 +75,25 @@ class SetGroupsEK60(SetGroupsBase):
                                              ds.ping_time.attrs)})
 
         # Save to file
-        io.save_file(ds.chunk({'ping_time': 100}),
+        io.save_file(ds.chunk({'ping_time': DEFAULT_CHUNK_SIZE['ping_time']}),
                      path=self.output_path, mode='a', engine=self.engine, group='Environment')
+
+    def set_sonar(self):
+        """Set the Sonar group.
+        """
+        # Assemble sonar group dictionary
+        sonar_dict = {
+            'sonar_manufacturer': 'Simrad',
+            'sonar_model': self.parser_obj.config_datagram['sounder_name'],
+            'sonar_serial_number': '',
+            'sonar_software_name': '',
+            'sonar_software_version': self.parser_obj.config_datagram['version'],
+            'sonar_type': 'echosounder'
+        }
+        # Save
+        ds = xr.Dataset()
+        ds = ds.assign_attrs(sonar_dict)
+        io.save_file(ds, path=self.output_path, group='Sonar', mode='a', engine=self.engine)
 
     def set_platform(self, NMEA_only=False):
         """Set the Platform group.
@@ -110,7 +124,7 @@ class SetGroupsEK60(SetGroupsBase):
                                        'long_name': 'Timestamps for NMEA position datagrams',
                                        'standard_name': 'time',
                                        'units': 'seconds since 1900-01-01'})})
-        ds = ds.chunk({'location_time': 100})
+        ds = ds.chunk({'location_time': DEFAULT_CHUNK_SIZE['ping_time']})
 
         if not NMEA_only:
             # Convert np.datetime64 numbers to seconds since 1900-01-01
@@ -178,10 +192,10 @@ class SetGroupsEK60(SetGroupsBase):
 
             # Convert np.datetime64 numbers to seconds since 1900-01-01
             # due to xarray.to_netcdf() error on encoding np.datetime64 objects directly
-            ds = ds.assign_coords({'ping_time': (['ping_time'],
-                                                 (ds['ping_time'] -
-                                                  np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's'),
-                                                 ds.ping_time.attrs)}).chunk({'ping_time': 100})
+            ds = ds.assign_coords({
+                'ping_time': (['ping_time'],
+                              (ds['ping_time'] - np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's'),
+                              ds.ping_time.attrs)}).chunk({'ping_time': DEFAULT_CHUNK_SIZE['ping_time']})
 
         # Save to file
         io.save_file(ds, path=self.output_path, mode='a', engine=self.engine,
@@ -296,19 +310,7 @@ class SetGroupsEK60(SetGroupsBase):
                 'gain_correction': (['frequency'], beam_params['gain'],
                                     {'long_name': 'Gain correction',
                                      'units': 'dB'}),
-                # TODO: currently it seems to be encoded as
                 'gpt_software_version': (['frequency'], beam_params['gpt_software_version'])
-                # TODO: need to parse and store 'offset' from configuration datagram
-                # 'sample_time_offset': (['frequency'], np.array([2, ] * freq.size, dtype='int32'),
-                #                        {'long_name': 'Time offset that is subtracted from the timestamp '
-                #                                      'of each sample',
-                #                         'units': 's'}),
-                # 'non_quantitative_processing': (['frequency'], np.array([0, ] * freq.size, dtype='int32'),
-                #                                 {'flag_meanings': 'no_non_quantitative_processing',
-                #                                  'flag_values': '0',
-                #                                  'long_name': 'Presence or not of non-quantitative '
-                #                                               'processing applied to the backscattering '
-                #                                               'data (sonar specific)'}),
             },
             coords={
                 'frequency': (['frequency'], freq,
@@ -396,7 +398,8 @@ class SetGroupsEK60(SetGroupsBase):
                                              ds.ping_time.attrs)})
 
         # Save to file
-        io.save_file(ds.chunk({'range_bin': 25000, 'ping_time': 100}),
+        io.save_file(ds.chunk({'range_bin': DEFAULT_CHUNK_SIZE['range_bin'],
+                               'ping_time': DEFAULT_CHUNK_SIZE['ping_time']}),
                      path=self.output_path, mode='a', engine=self.engine,
                      group='Beam', compression_settings=self.compression_settings)
 

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -23,6 +23,7 @@ class SetGroupsEK60(SetGroupsBase):
             self.set_platform(NMEA_only=True)
             return
 
+        # TODO: Specifically pass in date_created here
         self.set_toplevel('EK60')
         self.set_provenance()           # provenance group
         self.set_sonar(sonar_values)    # sonar group

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -1,10 +1,9 @@
-import os
-import shutil
 from collections import defaultdict
 import xarray as xr
 import numpy as np
 from ..utils import io
 from .set_groups_base import SetGroupsBase
+from .set_groups_base import DEFAULT_CHUNK_SIZE
 
 
 class SetGroupsEK80(SetGroupsBase):
@@ -13,12 +12,6 @@ class SetGroupsEK80(SetGroupsBase):
     def save(self):
         """Actually save groups to file by calling the set methods.
         """
-
-        # def set_beam_type_specific_groups(ch_ids, bb, path):
-        #     self.set_beam(ch_ids, bb=bb, path=path)
-        #     self.set_sonar(ch_ids, path=path)
-        #     self.set_vendor(ch_ids, bb=bb, path=path)
-
         # Save environment only
         if 'ENV' in self.parser_obj.data_type:
             self.set_toplevel(self.sonar_model, date_created=self.parser_obj.environment['timestamp'])
@@ -33,27 +26,14 @@ class SetGroupsEK80(SetGroupsBase):
             return
 
         # Save all groups
-        self.set_toplevel(self.sonar_model)
+        self.set_toplevel(self.sonar_model, date_created=self.parser_obj.config_datagram['timestamp'])
         self.set_provenance()    # provenance group
         self.set_env()           # environment group
         self.set_platform()      # platform group
         self.set_nmea()          # platform/NMEA group
-
         self.set_beam()
         self.set_sonar()
         self.set_vendor()
-
-        # # If there is both bb and cw data
-        # if self.parser_obj.ch_ids['complex'] and self.parser_obj.ch_ids['power']:
-        #     new_path = self._copy_file(self.output_path)
-        #     set_beam_type_specific_groups(self.parser_obj.ch_ids['complex'], bb=True, path=self.output_path)
-        #     set_beam_type_specific_groups(self.parser_obj.ch_ids['power'], bb=False, path=new_path)
-        # # If there is only bb data
-        # elif self.parser_obj.ch_ids['complex']:
-        #     set_beam_type_specific_groups(self.parser_obj.ch_ids['complex'], bb=True, path=self.output_path)
-        # # If there is only cw data
-        # else:
-        #     set_beam_type_specific_groups(self.parser_obj.ch_ids['power'], bb=False, path=self.output_path)
 
     def set_env(self, env_only=False):
         """Set the Environment group.
@@ -87,6 +67,34 @@ class SetGroupsEK80(SetGroupsBase):
         # Save to file
         io.save_file(ds, path=self.output_path, mode='a', engine=self.engine,
                      group='Environment', compression_settings=self.compression_settings)
+
+    def set_sonar(self):
+        # Collect unique variables
+        params = ['transducer_frequency',
+                  'serial_number',
+                  'transducer_name',
+                  'application_name',
+                  'application_version']
+        var = defaultdict(list)
+        for ch_id, data in self.parser_obj.config_datagram['configuration'].items():
+            for param in params:
+                var[param].append(data[param])
+
+        # Create dataset
+        ds = xr.Dataset(
+            {
+                'serial_number': (['frequency'], var['serial_number']),
+                'sonar_model': (['frequency'], var['transducer_name']),
+                'sonar_software_name': (['frequency'], var['application_name']),  # identical for all channels
+                'sonar_software_version': (['frequency'], var['application_version']),  # identical for all channels
+            },
+            coords={'frequency': var['transducer_frequency']},
+            attrs={'sonar_manufacturer': 'Simrad',
+                   'sonar_type': 'echosounder'})
+
+        # Save to file
+        io.save_file(ds, path=self.output_path, mode='a', engine=self.engine,
+                     group='Sonar', compression_settings=self.compression_settings)
 
     def set_platform(self):
         """Set the Platform group.
@@ -164,7 +172,8 @@ class SetGroupsEK80(SetGroupsBase):
                                         hasattr(self.parser_obj.environment, 'drop_keel_offset') else np.nan)})
 
         # save to file
-        io.save_file(ds.chunk({'location_time': 100, 'mru_time': 100}),
+        io.save_file(ds.chunk({'location_time': DEFAULT_CHUNK_SIZE['ping_time'],
+                               'mru_time': DEFAULT_CHUNK_SIZE['ping_time']}),
                      path=self.output_path, mode='a', engine=self.engine,
                      group='Platform', compression_settings=self.compression_settings)
 
@@ -415,7 +424,8 @@ class SetGroupsEK80(SetGroupsBase):
                                                - np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's'),
                                ds_combine.ping_time.attrs)})
             # Save to file
-            io.save_file(ds_combine.chunk({'range_bin': 25000, 'ping_time': 100}),
+            io.save_file(ds_combine.chunk({'range_bin': DEFAULT_CHUNK_SIZE['range_bin'],
+                                           'ping_time': DEFAULT_CHUNK_SIZE['ping_time']}),
                          path=self.output_path, mode='a', engine=self.engine,
                          group=group_name, compression_settings=self.compression_settings)
 
@@ -567,63 +577,3 @@ class SetGroupsEK80(SetGroupsBase):
         # Save to file
         io.save_file(ds, path=self.output_path, mode='a', engine=self.engine,
                      group='Vendor', compression_settings=self.compression_settings)
-
-    def set_sonar(self):
-        config = self.parser_obj.config_datagram['configuration']
-        # channels['frequency'] = np.array([self.config_datagram['configuration'][x]['transducer_frequency']
-        #                                   for x in self.ch_ids], dtype='float32')
-
-        # Collect unique variables
-        params = ['transducer_frequency',
-                  'serial_number',
-                  'transducer_name',
-                  'application_name',
-                  'application_version']
-        var = defaultdict(list)
-        for ch_id, data in config.items():
-            for param in params:
-                var[param].append(data[param])
-
-        # Create dataset
-        ds = xr.Dataset(
-            {
-                'serial_number': (['frequency'], var['serial_number']),
-                'sonar_model': (['frequency'], var['transducer_name']),
-                'sonar_software_name': (['frequency'], var['application_name']),  # identical for all channels
-                'sonar_software_version': (['frequency'], var['application_version']),  # identical for all channels
-            },
-            coords={'frequency': var['transducer_frequency']},
-            attrs={'sonar_manufacturer': 'Simrad',
-                   'sonar_type': 'echosounder'})
-
-        # Save to file
-        io.save_file(ds, path=self.output_path, mode='a', engine=self.engine,
-                     group='Sonar', compression_settings=self.compression_settings)
-
-    # TODO: the overwriting message should not be here,
-    #  the assembling filename part also should not be here
-    #  symptom:
-    #  >>> from echopype import Convert
-    #  >>> raw_path_bb_cw = './echopype/test_data/ek80/Summer2018--D20180905-T033113.raw'  # Large file (CW and BB)
-    #  >>> tmp = Convert(file=raw_path_bb_cw, model='EK80')
-    #  >>> tmp.to_netcdf(save_path='/Users/wu-jung/Downloads', overwrite=True)
-    #            overwriting: /Users/wu-jung/Downloads/Summer2018--D20180905-T033113.nc
-    #  17:14:00 converting file Summer2018--D20180905-T033113.raw, time of first ping: 2018-Sep-05 03:31:13
-    #            overwriting: /Users/wu-jung/Downloads/Summer2018--D20180905-T033113_cw.nc
-    def _copy_file(self, file):
-        # Copy the current file into a new file with _cw appended to filename
-        # TODO: here the _cw (_power) filename should be passed down from the convert object
-        #  instead of being made on the fly. This is a bug.
-        fname, ext = os.path.splitext(file)
-        new_path = fname + '_cw' + ext
-        if os.path.exists(new_path):
-            print("          overwriting: " + new_path)
-            if ext == '.zarr':
-                shutil.rmtree(new_path)
-            elif ext == '.nc':
-                os.remove(new_path)
-        if ext == '.zarr':
-            shutil.copytree(file, new_path)
-        elif ext == '.nc':
-            shutil.copyfile(file, new_path)
-        return new_path

--- a/echopype/tests/test_convert_ek60.py
+++ b/echopype/tests/test_convert_ek60.py
@@ -90,7 +90,7 @@ def test_combine():
     # Test combining after converting
     tmp = Convert(file=raw_paths[4:8], model='EK60')
     tmp.to_netcdf(save_path=export_folder, overwrite=True)
-    tmp.combine_files(tmp.output_file, remove_indiv_files=False)
+    tmp.combine_files(tmp.output_file, remove_indiv=False)
 
     shutil.rmtree(export_folder)
 

--- a/echopype/tests/test_convert_ek60.py
+++ b/echopype/tests/test_convert_ek60.py
@@ -90,7 +90,7 @@ def test_combine():
     # Test combining after converting
     tmp = Convert(file=raw_paths[4:8], model='EK60')
     tmp.to_netcdf(save_path=export_folder, overwrite=True)
-    tmp.combine_files(tmp.output_file, remove_orig=False)
+    tmp.combine_files(tmp.output_file, remove_indiv_files=False)
 
     shutil.rmtree(export_folder)
 


### PR DESCRIPTION
This PR contains updates related to `Convert.combine_files`. 

### Main changes
- combine-related functions are now in `convert_combine.py` to declutter `convert.py`
- bug fixed related to Platform group dimensions for EK60 and EK80
- remove `combine=nested` from all groups that need to be combined along the `ping_time`/`location_time`/`mru_time` dimensions. This makes file combination only possible when these coordinates are nicely monotonically varying within each individual file prior to combination. This is often not the case for EK60/EK80 files (?? somehow time often goes backward) and we will need to add a handler to clean up these anomalies before combining the files.
- change the default chunk size (ad-hoc but the original ping_time chunk of 100 seems too small):
  ```
  DEFAULT_CHUNK_SIZE = {
      'range_bin': 25000,
      'ping_time': 2500
  }
  ```
### Main changes since first PR
- bug fixed related to Vendor group dimensions for AZFP
- make `set_toplevel` and `set_sonar` consistent across all sonar models

### TODO for future versions
- add a handler to clean up anomalous time entries (e.g. `ping_time` going backward) before file combination
- another possible why to deal with this is to use `combine='nested'` in open_mfdataset but make sure that the list of individual files passed in are listed sequentially, since `combine_nested` does not check this.
- experiment with chunking sizes
- consider separating `location_time` and `mru_time` chunk size from that of `ping_time` since the associated data variables are typically 1D (instead of 2-4D like in the Beam group). However keeping it consistent with `ping_time` may help with data slicing.
