### PR TITLE
Convert upgrade to be able to read/write to object store

### DIFF
--- a/.ci_helpers/Dockerfile
+++ b/.ci_helpers/Dockerfile
@@ -1,0 +1,2 @@
+FROM minio/minio
+CMD ["minio", "server", "/data"]

--- a/.ci_helpers/py3.7.yaml
+++ b/.ci_helpers/py3.7.yaml
@@ -1,0 +1,18 @@
+name: echopype
+channels:
+  - conda-forge
+dependencies:
+  - python=3.7
+  - dask
+  - matplotlib
+  - netCDF4==1.5.5
+  - numpy
+  - pynmea2
+  - pytz
+  - scipy
+  - xarray==0.16.2
+  - zarr
+  - fsspec>=0.8
+  - requests
+  - aiohttp
+  - s3fs==0.5.2

--- a/.ci_helpers/py3.8.yaml
+++ b/.ci_helpers/py3.8.yaml
@@ -1,0 +1,18 @@
+name: echopype
+channels:
+  - conda-forge
+dependencies:
+  - python=3.8
+  - dask
+  - matplotlib
+  - netCDF4==1.5.5
+  - numpy
+  - pynmea2
+  - pytz
+  - scipy
+  - xarray==0.16.2
+  - zarr
+  - fsspec>=0.8
+  - requests
+  - aiohttp
+  - s3fs==0.5.2

--- a/.ci_helpers/py3.9.yaml
+++ b/.ci_helpers/py3.9.yaml
@@ -1,0 +1,18 @@
+name: echopype
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9
+  - dask
+  - matplotlib
+  - netCDF4==1.5.5
+  - numpy
+  - pynmea2
+  - pytz
+  - scipy
+  - xarray==0.16.2
+  - zarr
+  - fsspec>=0.8
+  - requests
+  - aiohttp
+  - s3fs==0.5.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,15 @@ env:
 jobs:
   test:
     name: ${{ matrix.python-version }}-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         python-version: [3.7, 3.8]
+        experimental: [false]
+        include:
+        - python-version: 3.9
+          experimental: true
     services:
       minio:
         image: cormorack/minioci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,74 @@
+name: Test CI
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+      - class-redesign
+
+env:
+  CONDA_ENV: echopype
+
+jobs:
+  test:
+    name: ${{ matrix.python-version }}-build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8]
+    services:
+      minio:
+        image: cormorack/minioci
+        ports:
+          - 9000:9000
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - name: Get cache key of git-lfs files
+        id: git-lfs
+        run: echo "::set-output name=sha256::$(git lfs ls-files | openssl dgst -sha256)"
+      - name: Cache lfs
+        uses: actions/cache@v2
+        with:
+          path: .git/lfs
+          key: ${{ steps.git-lfs.outputs.sha256 }}
+      - name: Cache conda
+        uses: actions/cache@v2
+        env:
+          # Increase this value to reset cache if .ci_helpers/py${{ matrix.python-version }}.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('.ci_helpers/py${{ matrix.python-version }}.yml') }}
+      - name: setup miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: ${{ env.CONDA_ENV }}
+          environment-file: .ci_helpers/py${{ matrix.python-version }}.yml
+          python-version: ${{ matrix.python-version }}
+          auto-activate-base: false
+          use-only-tar-bz2: true
+      - name: print conda env
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+      - name: install dev tools
+        shell: bash -l {0}
+        run: |
+          conda install -c conda-forge -n ${{ env.CONDA_ENV }} --yes --file requirements-dev.txt
+      - name: install echopype
+        shell: bash -l {0}
+        run: |
+          python -m pip install -e .
+      - name: Running Convert Tests
+        shell: bash -l {0}
+        run: |
+          python -m pytest --log-cli-level=WARNING --verbose echopype/tests/test_convert.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,11 +42,11 @@ jobs:
       - name: Cache conda
         uses: actions/cache@v2
         env:
-          # Increase this value to reset cache if .ci_helpers/py${{ matrix.python-version }}.yml has not changed
+          # Increase this value to reset cache if .ci_helpers/py${{ matrix.python-version }}.yaml has not changed
           CACHE_NUMBER: 0
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('.ci_helpers/py${{ matrix.python-version }}.yml') }}
+          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('.ci_helpers/py${{ matrix.python-version }}.yaml') }}
       - name: setup miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
   test:
     name: ${{ matrix.python-version }}-build
     runs-on: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: ${{ env.CONDA_ENV }}
-          environment-file: .ci_helpers/py${{ matrix.python-version }}.yml
+          environment-file: .ci_helpers/py${{ matrix.python-version }}.yaml
           python-version: ${{ matrix.python-version }}
           auto-activate-base: false
           use-only-tar-bz2: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,18 @@
+name: Lint code
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+      - class-redesign
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0
+      # allow to error for now
+      continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ toolbox
 *.xml
 ek60/
 azfp/
+temp_echopype_output/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: check-docstring-first
+    - id: check-json
+    - id: check-yaml
+    - id: pretty-format-json
+      args: ["--autofix", "--indent=2", "--no-sort-keys"]
+
+-   repo: https://github.com/ambv/black
+    rev: 19.10b0
+    hooks:
+    - id: black
+      args: ["--line-length", "100"]
+
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+    - id: flake8
+
+-   repo: https://github.com/asottile/seed-isort-config
+    rev: v2.2.0
+    hooks:
+    - id: seed-isort-config
+
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.2.0
+    hooks:
+    - id: isort
+
+-   repo: https://github.com/myint/rstcheck
+    rev: master
+    hooks:
+    -   id: rstcheck

--- a/echopype/convert/convert.py
+++ b/echopype/convert/convert.py
@@ -255,6 +255,7 @@ class Convert:
         file_format : str {'.nc', '.zarr'}
         """
         if save_path is None:
+            warnings.warn("save_path is not provided")
             fsmap = fsspec.get_mapper(self.source_file[0], **self.storage_options)
             fs = fsmap.fs
 
@@ -273,6 +274,7 @@ class Convert:
                 # Check permission, raise exception if no permission
                 io.check_file_permissions(out_dir)
 
+            warnings.warn(f"Resulting converted file(s) will be available at {str(out_dir)}")
             out_path = [str(out_dir.joinpath(Path(os.path.splitext(Path(f).name)[0] + file_format)))
                         for f in self.source_file]
 

--- a/echopype/convert/convert.py
+++ b/echopype/convert/convert.py
@@ -489,7 +489,7 @@ class Convert:
                 ds_platform.to_zarr(f, mode="a", group="Platform")
 
     def _to_file(self, convert_type, save_path=None, data_type='ALL', compress=True, combine=False,
-                 overwrite=False, parallel=False, extra_platform_data=None):
+                 overwrite=False, parallel=False, extra_platform_data=None, storage_options={}, **kwargs):
         """Convert a file or a list of files to netCDF or zarr.
 
         Parameters
@@ -514,6 +514,8 @@ class Convert:
             whether or not to use parallel processing. (Not yet implemented)
         extra_platform_data : Dataset
             The dataset containing the platform information to be added to the output
+        storage_options : dict
+            Additional keywords to pass to the filesystem class.
         """
         self.data_type = data_type
         self.compress = compress
@@ -575,9 +577,59 @@ class Convert:
             self.output_file = self.output_file[0]
 
     def to_netcdf(self, **kwargs):
+        """Convert a file or a list of files to netCDF.
+
+        Parameters
+        ----------
+        save_path : str
+            path that converted .nc file will be saved
+        data_type : str {'ALL', 'GPS', 'CONFIG', 'ENV'}
+            select specific datagrams to save (EK60 and EK80 only)
+            Defaults to ``ALL``
+        compress : bool
+            whether or not to perform compression on data variables
+            Defaults to ``True``
+        combine : bool
+            whether or not to combine all converted individual files into one file
+            Defaults to ``False``
+        overwrite : bool
+            whether or not to overwrite existing files
+            Defaults to ``False``
+        parallel : bool
+            whether or not to use parallel processing. (Not yet implemented)
+        extra_platform_data : Dataset
+            The dataset containing the platform information to be added to the output
+        storage_options : dict
+            Additional keywords to pass to the filesystem class.
+        """
         return self._to_file('netcdf4', **kwargs)
 
     def to_zarr(self, **kwargs):
+        """Convert a file or a list of files to zarr.
+
+        Parameters
+        ----------
+        save_path : str
+            path that converted .nc file will be saved
+        data_type : str {'ALL', 'GPS', 'CONFIG', 'ENV'}
+            select specific datagrams to save (EK60 and EK80 only)
+            Defaults to ``ALL``
+        compress : bool
+            whether or not to perform compression on data variables
+            Defaults to ``True``
+        combine : bool
+            whether or not to combine all converted individual files into one file
+            Defaults to ``False``
+        overwrite : bool
+            whether or not to overwrite existing files
+            Defaults to ``False``
+        parallel : bool
+            whether or not to use parallel processing. (Not yet implemented)
+        extra_platform_data : Dataset
+            The dataset containing the platform information to be added to the output
+        storage_options : dict
+            Additional keywords to pass to the filesystem class.
+        """
         return self._to_file('zarr', **kwargs)
 
     def to_xml(self, save_path=None, data_type='CONFIG'):

--- a/echopype/convert/convert.py
+++ b/echopype/convert/convert.py
@@ -272,8 +272,9 @@ class Convert:
 
                 # Check permission, raise exception if no permission
                 io.check_file_permissions(out_dir)
-                out_path = [str(out_dir.joinpath(Path(os.path.splitext(Path(f).name)[0] + file_format)))
-                            for f in self.source_file]
+
+            out_path = [str(out_dir.joinpath(Path(os.path.splitext(Path(f).name)[0] + file_format)))
+                        for f in self.source_file]
 
         else:
             fsmap = fsspec.get_mapper(save_path, **self._output_storage_options)

--- a/echopype/tests/test_convert.py
+++ b/echopype/tests/test_convert.py
@@ -2,175 +2,269 @@ import os
 import glob
 import fsspec
 import shutil
-import numpy as np
 import xarray as xr
-import pandas as pd
+import pytest
 from ..convert import Convert
 
 
-def test_validate_path_single_source():
-    single_path = './echopype/test_data/ek60/DY1801_EK60-D20180211-T164025.raw'
-    fsmap = fsspec.get_mapper(single_path)
+@pytest.mark.parametrize("model", ["EK60"])
+@pytest.mark.parametrize("file_format", [".zarr"])
+@pytest.mark.parametrize(
+    "input_path",
+    ["./echopype/test_data/ek60/DY1801_EK60-D20180211-T164025.raw"],
+)
+@pytest.mark.parametrize(
+    "output_save_path",
+    [
+        None,
+        "./echopype/test_data/dump/",
+        "./echopype/test_data/dump/tmp.zarr",
+        "./echopype/test_data/dump/tmp.nc",
+    ],
+)
+def test_validate_path_single_source(
+    model, file_format, input_path, output_save_path
+):
+    fsmap = fsspec.get_mapper(input_path)
     single_dir = os.path.dirname(fsmap.root)
     single_fname = os.path.splitext(os.path.basename(fsmap.root))[0]
-    tmp_single = Convert(single_path, model='EK60')
+    tmp_single = Convert(input_path, model=model)
 
-    # if no output path is given
-    tmp_single._validate_path(file_format='.zarr')
-    assert tmp_single.output_file == [os.path.join(single_dir, single_fname+'.zarr')]
+    tmp_single._validate_path(
+        file_format=file_format, save_path=output_save_path
+    )
 
-    # if an output folder is given, below works with and without the slash at the end
-    test_save_path = './echopype/test_data/dump/'
-    tmp_single._validate_path(file_format='.zarr', save_path=test_save_path)
-    fsmap_tmp = fsspec.get_mapper(test_save_path)
-    assert tmp_single.output_file == [os.path.join(fsmap_tmp.root, single_fname+'.zarr')]
-    os.rmdir(os.path.dirname(tmp_single.output_file[0]))
+    if output_save_path is not None:
+        fsmap_tmp = fsspec.get_mapper(output_save_path)
+        if output_save_path.endswith('/'):
+            # if an output folder is given, below works with and without the slash at the end
+            assert tmp_single.output_file == [
+                os.path.join(fsmap_tmp.root, single_fname + '.zarr')
+            ]
+        elif output_save_path.endswith('.zarr'):
+            # if an output filename is given
+            assert tmp_single.output_file == [fsmap_tmp.root]
+        else:
+            # force output file extension to the called type (here .zarr)
+            assert tmp_single.output_file == [
+                os.path.splitext(fsmap_tmp.root)[0] + '.zarr'
+            ]
+        os.rmdir(os.path.dirname(tmp_single.output_file[0]))
+    else:
+        # if no output path is given
+        assert tmp_single.output_file == [
+            os.path.join(single_dir, single_fname + '.zarr')
+        ]
 
-    # if an output filename is given
-    test_save_path = './echopype/test_data/dump/tmp.zarr'
-    tmp_single._validate_path(file_format='.zarr', save_path=test_save_path)
-    fsmap_tmp = fsspec.get_mapper(test_save_path)
-    assert tmp_single.output_file == [fsmap_tmp.root]
-    os.rmdir(os.path.dirname(tmp_single.output_file[0]))
 
-    # force output file extension to the called type (here .zarr)
-    test_save_path = './echopype/test_data/dump/tmp.nc'
-    tmp_single._validate_path(file_format='.zarr', save_path=test_save_path)
-    fsmap_tmp = fsspec.get_mapper(test_save_path)
-    assert tmp_single.output_file == [os.path.splitext(fsmap_tmp.root)[0] + '.zarr']
-    os.rmdir(os.path.dirname(tmp_single.output_file[0]))
-
-
-def test_validate_path_multiple_source():
-    mult_path = glob.glob('./echopype/test_data/ek60/*.raw')
+@pytest.mark.parametrize("model", ["EK60"])
+@pytest.mark.parametrize("file_format", [".zarr"])
+@pytest.mark.parametrize(
+    "input_path",
+    ["./echopype/test_data/ek60/*.raw"],
+)
+@pytest.mark.parametrize(
+    "output_save_path",
+    [
+        None,
+        "./echopype/test_data/dump/",
+        "./echopype/test_data/dump/tmp.zarr",
+        "./echopype/test_data/dump/tmp.nc",
+    ],
+)
+def test_validate_path_multiple_source(
+    model, file_format, input_path, output_save_path
+):
+    mult_path = glob.glob(input_path)
     fsmap = fsspec.get_mapper(mult_path[0])
     mult_dir = os.path.dirname(fsmap.root)
     tmp_mult = Convert(mult_path, model='EK60')
 
-    # if no output path is given
-    tmp_mult._validate_path(file_format='.zarr')
-    assert tmp_mult.output_file == [os.path.join(mult_dir, os.path.splitext(os.path.basename(f))[0]+'.zarr')
-                                    for f in mult_path]
+    tmp_mult._validate_path(
+        file_format=file_format, save_path=output_save_path
+    )
 
-    # if an output folder is given, below works with and without the slash at the end
-    test_save_path = './echopype/test_data/dump/'
-    tmp_mult._validate_path(file_format='.zarr', save_path=test_save_path)
-    fsmap_tmp = fsspec.get_mapper(test_save_path)
-    assert tmp_mult.output_file == [os.path.join(fsmap_tmp.root, os.path.splitext(os.path.basename(f))[0]+'.zarr')
-                                    for f in mult_path]
-    os.rmdir(os.path.dirname(tmp_mult.output_file[0]))
+    if output_save_path is not None:
+        fsmap_tmp = fsspec.get_mapper(output_save_path)
+        if output_save_path.endswith('/'):
+            # if an output folder is given, below works with and without the slash at the end
+            assert tmp_mult.output_file == [
+                os.path.join(
+                    fsmap_tmp.root,
+                    os.path.splitext(os.path.basename(f))[0] + '.zarr',
+                )
+                for f in mult_path
+            ]
+        elif output_save_path.endswith('.zarr'):
+            # if an output filename is given: only use the directory
+            assert tmp_mult.output_file == [os.path.abspath(output_save_path)]
+        elif output_save_path.endswith('.nc'):
+            # force output file extension to the called type (here .zarr)
+            assert tmp_mult.output_file == [
+                os.path.abspath(output_save_path.replace('.nc', '.zarr'))
+            ]
+        os.rmdir(os.path.dirname(tmp_mult.output_file[0]))
+    else:
+        # if no output path is given
+        assert tmp_mult.output_file == [
+            os.path.join(
+                mult_dir, os.path.splitext(os.path.basename(f))[0] + '.zarr'
+            )
+            for f in mult_path
+        ]
 
-    # if an output filename is given: only use the directory
-    test_save_path = './echopype/test_data/dump/tmp.zarr'
-    tmp_mult._validate_path(file_format='.zarr', save_path=test_save_path)
-    fsmap_tmp = fsspec.get_mapper(test_save_path)
-    assert tmp_mult.output_file == [os.path.join(os.path.dirname(fsmap_tmp.root),
-                                                 os.path.splitext(os.path.basename(f))[0]+'.zarr')
-                                    for f in mult_path]
-    os.rmdir(os.path.dirname(tmp_mult.output_file[0]))
 
-    # force output file extension to the called type (here .zarr)
-    test_save_path = './echopype/test_data/dump/tmp.nc'
-    tmp_mult._validate_path(file_format='.zarr', save_path=test_save_path)
-    fsmap_tmp = fsspec.get_mapper(test_save_path)
-    assert tmp_mult.output_file == [os.path.join(os.path.dirname(fsmap_tmp.root),
-                                                 os.path.splitext(os.path.basename(f))[0] + '.zarr')
-                                    for f in mult_path]
-    os.rmdir(os.path.dirname(tmp_mult.output_file[0]))
-
-
-def _converted_group_checker(model, engine, out_file):
-    groups = ['Environment', 'Platform', 'Provenance', 'Sonar']
-    if model in ['EK60', 'EK80']:
-        groups = groups + ['Beam', 'Vendor']
-
+def _check_file_group(data_file, engine, groups):
     for g in groups:
-        ds = xr.open_dataset(out_file, engine=engine, group=g)
+        ds = xr.open_dataset(data_file, engine=engine, group=g)
 
         assert isinstance(ds, xr.Dataset) is True
 
 
-def _file_export_checks(ec, model):
-    file_map = {
-        '.nc': {
-            'engine': 'netcdf4',
-            'export_func': ec.to_netcdf,
-            'cleaner': os.unlink,
-        },
-        '.zarr': {
-            'engine': 'zarr',
-            'export_func': ec.to_zarr,
-            'cleaner': shutil.rmtree,
-        },
-    }
-    for k, v in file_map.items():
-        out_file = f"./test_{model.lower()}{k}"
-        func = v['export_func']
-        clean = v['cleaner']
-        func(out_file, overwrite=True)
-        _converted_group_checker(
-            model=model, engine=v['engine'], out_file=out_file
-        )
-        clean(out_file)
+def _converted_group_checker(model, engine, out_file, multiple_files):
+    groups = ['Environment', 'Platform', 'Provenance', 'Sonar']
+    if model in ['EK60', 'EK80']:
+        groups = groups + ['Beam', 'Vendor']
+
+    if multiple_files:
+        dirname = os.path.abspath(out_file)
+        out_files = [os.path.join(dirname, f) for f in os.listdir(dirname)]
+        for data_file in out_files:
+            _check_file_group(data_file, engine, groups)
+    else:
+        _check_file_group(out_file, engine, groups)
 
 
-def test_http_azfp_convert():
-    model = 'AZFP'
-    # http
-    azfp_path = 'https://rawdata.oceanobservatories.org/files/CE01ISSM/R00007/instrmts/dcl37/ZPLSC_sn55075/ce01issm_zplsc_55075_recovered_2017-10-27/DATA/201703/17032923.01A'
-    xml_path = 'https://rawdata.oceanobservatories.org/files/CE01ISSM/R00007/instrmts/dcl37/ZPLSC_sn55075/ce01issm_zplsc_55075_recovered_2017-10-27/DATA/201703/17032922.XML'
+def _file_export_checks(ec, model, export_engine, multiple_files):
+    if export_engine == "netcdf4":
+        out_file = f"./test_{model.lower()}.nc"
+        if multiple_files:
+            out_file = out_file.replace(".nc", "")
+        ec.to_netcdf(save_path=out_file, overwrite=True)
+    elif export_engine == "zarr":
+        out_file = f"./test_{model.lower()}.zarr"
+        if multiple_files:
+            out_file = out_file.replace(".zarr", "")
+        ec.to_zarr(save_path=out_file, overwrite=True)
 
-    ec = Convert(azfp_path, model=model, xml_path=xml_path)
+    _converted_group_checker(
+        model=model,
+        engine=export_engine,
+        out_file=out_file,
+        multiple_files=multiple_files,
+    )
 
-    assert ec.source_file[0] == azfp_path
+    # Cleanup
+    if os.path.isfile(out_file):
+        os.unlink(out_file)
+    else:
+        shutil.rmtree(out_file)
+
+
+@pytest.mark.skip()
+@pytest.mark.parametrize("model", ["AZFP"])
+@pytest.mark.parametrize(
+    "file",
+    [
+        "https://rawdata.oceanobservatories.org/files/CE01ISSM/R00007/instrmts/dcl37/ZPLSC_sn55075/ce01issm_zplsc_55075_recovered_2017-10-27/DATA/201703/17032923.01A"
+    ],
+)
+@pytest.mark.parametrize(
+    "xml_path",
+    [
+        "https://rawdata.oceanobservatories.org/files/CE01ISSM/R00007/instrmts/dcl37/ZPLSC_sn55075/ce01issm_zplsc_55075_recovered_2017-10-27/DATA/201703/17032922.XML"
+    ],
+)
+@pytest.mark.parametrize("storage_options", [{'anon': True}])
+@pytest.mark.parametrize("export_engine", ["netcdf4", "zarr"])
+def test_convert_azfp(model, file, xml_path, storage_options, export_engine):
+    if isinstance(file, str):
+        multiple_files = False
+        if not file.startswith("s3://"):
+            storage_options = {}
+    else:
+        multiple_files = True
+        if not file[0].startswith("s3://"):
+            storage_options = {}
+
+    ec = Convert(
+        file=file,
+        model=model,
+        xml_path=xml_path,
+        storage_options=storage_options,
+    )
+
+    if multiple_files:
+        assert sorted(ec.source_file) == sorted(file)
+    else:
+        assert ec.source_file[0] == file
     assert ec.xml_path == xml_path
 
-    _file_export_checks(ec, model)
+    _file_export_checks(ec, model, export_engine, multiple_files)
 
 
-def test_http_ek60_convert():
-    model = 'EK60'
-    # http
-    ek60_path = 'https://ncei-wcsd-archive.s3-us-west-2.amazonaws.com/data/raw/Bell_M._Shimada/SH1707/EK60/Summer2017-D20170615-T190214.raw'
+@pytest.mark.skip()
+@pytest.mark.parametrize("model", ["EK60"])
+@pytest.mark.parametrize(
+    "file",
+    [
+        "https://ncei-wcsd-archive.s3-us-west-2.amazonaws.com/data/raw/Bell_M._Shimada/SH1707/EK60/Summer2017-D20170615-T190214.raw",
+        "s3://ncei-wcsd-archive/data/raw/Bell_M._Shimada/SH1707/EK60/Summer2017-D20170615-T190214.raw",
+        [
+            'https://ncei-wcsd-archive.s3-us-west-2.amazonaws.com/data/raw/Bell_M._Shimada/SH1707/EK60/Summer2017-D20170615-T190214.raw',
+            'https://ncei-wcsd-archive.s3-us-west-2.amazonaws.com/data/raw/Bell_M._Shimada/SH1707/EK60/Summer2017-D20170615-T190843.raw',
+            'https://ncei-wcsd-archive.s3-us-west-2.amazonaws.com/data/raw/Bell_M._Shimada/SH1707/EK60/Summer2017-D20170615-T212409.raw',
+        ],
+    ],
+)
+@pytest.mark.parametrize("storage_options", [{'anon': True}])
+@pytest.mark.parametrize("export_engine", ["netcdf4", "zarr"])
+def test_convert_ek60(model, file, storage_options, export_engine):
+    if isinstance(file, str):
+        multiple_files = False
+        if not file.startswith("s3://"):
+            storage_options = {}
+    else:
+        multiple_files = True
+        if not file[0].startswith("s3://"):
+            storage_options = {}
 
-    ec = Convert(ek60_path, model=model)
+    ec = Convert(file=file, model=model, storage_options=storage_options)
 
-    assert ec.source_file[0] == ek60_path
+    if multiple_files:
+        assert sorted(ec.source_file) == sorted(file)
+    else:
+        assert ec.source_file[0] == file
 
-    _file_export_checks(ec, model)
-
-
-def test_http_ek80_convert():
-    model = 'EK80'
-    # http
-    ek80_path = 'https://ncei-wcsd-archive.s3-us-west-2.amazonaws.com/data/raw/Bell_M._Shimada/SH1707/EK80/D20170826-T205615.raw'
-
-    ec = Convert(ek80_path, model=model)
-
-    assert ec.source_file[0] == ek80_path
-
-    _file_export_checks(ec, model)
+    _file_export_checks(ec, model, export_engine, multiple_files)
 
 
-def test_s3_ek60_convert():
-    model = 'EK60'
-    # http
-    ek60_path = 's3://ncei-wcsd-archive/data/raw/Bell_M._Shimada/SH1707/EK60/Summer2017-D20170615-T190214.raw'
+@pytest.mark.skip()
+@pytest.mark.parametrize("model", ["EK80"])
+@pytest.mark.parametrize(
+    "file",
+    [
+        "https://ncei-wcsd-archive.s3-us-west-2.amazonaws.com/data/raw/Bell_M._Shimada/SH1707/EK80/D20170826-T205615.raw",
+        "s3://ncei-wcsd-archive/data/raw/Bell_M._Shimada/SH1707/EK80/D20170826-T205615.raw",
+    ],
+)
+@pytest.mark.parametrize("storage_options", [{'anon': True}])
+@pytest.mark.parametrize("export_engine", ["netcdf4", "zarr"])
+def test_convert_ek80(model, file, storage_options, export_engine):
+    if isinstance(file, str):
+        multiple_files = False
+        if not file.startswith("s3://"):
+            storage_options = {}
+    else:
+        multiple_files = True
+        if not file[0].startswith("s3://"):
+            storage_options = {}
 
-    ec = Convert(ek60_path, model=model, storage_options={'anon': True})
+    ec = Convert(file=file, model=model, storage_options=storage_options)
 
-    assert ec.source_file[0] == ek60_path
+    if multiple_files:
+        assert sorted(ec.source_file) == sorted(file)
+    else:
+        assert ec.source_file[0] == file
 
-    _file_export_checks(ec, model)
-
-
-def test_s3_ek80_convert():
-    model = 'EK80'
-    # http
-    ek80_path = 's3://ncei-wcsd-archive/data/raw/Bell_M._Shimada/SH1707/EK80/D20170826-T205615.raw'
-
-    ec = Convert(ek80_path, model=model, storage_options={'anon': True})
-
-    assert ec.source_file[0] == ek80_path
-
-    _file_export_checks(ec, model)
+    _file_export_checks(ec, model, export_engine, multiple_files)

--- a/echopype/tests/test_convert.py
+++ b/echopype/tests/test_convert.py
@@ -8,6 +8,21 @@ from pathlib import Path
 from ..convert import Convert
 
 
+@pytest.fixture(scope="session")
+def minio_bucket():
+    bucket_name = 'ooi-raw-data'
+    fs = fsspec.filesystem(
+        's3',
+        **dict(
+            client_kwargs=dict(endpoint_url='http://localhost:9000/'),
+            key='minioadmin',
+            secret='minioadmin',
+        ),
+    )
+    if not fs.exists(bucket_name):
+        fs.mkdir(bucket_name)
+
+
 @pytest.mark.parametrize("model", ["EK60"])
 @pytest.mark.parametrize("file_format", [".zarr"])
 @pytest.mark.parametrize(
@@ -24,36 +39,67 @@ from ..convert import Convert
         "./echopype/test_data/dump/",
         "./echopype/test_data/dump/tmp.zarr",
         "./echopype/test_data/dump/tmp.nc",
+        "s3://ooi-raw-data/dump/",
+        "s3://ooi-raw-data/dump/tmp.zarr",
+        "s3://ooi-raw-data/dump/tmp.nc",
     ],
 )
 def test_validate_path_single_source(
-    model, file_format, input_path, output_save_path
+    model, file_format, input_path, output_save_path, minio_bucket
 ):
+
+    output_storage_options = {}
+    if output_save_path and output_save_path.startswith('s3://'):
+        output_storage_options = dict(
+            client_kwargs=dict(endpoint_url='http://localhost:9000/'),
+            key='minioadmin',
+            secret='minioadmin',
+        )
     fsmap = fsspec.get_mapper(input_path)
     single_dir = os.path.dirname(fsmap.root)
     single_fname = os.path.splitext(os.path.basename(fsmap.root))[0]
     tmp_single = Convert(input_path, model=model)
+    tmp_single._output_storage_options = output_storage_options
 
     tmp_single._validate_path(
         file_format=file_format, save_path=output_save_path
     )
 
     if output_save_path is not None:
-        fsmap_tmp = fsspec.get_mapper(output_save_path)
-        if output_save_path.endswith('/'):
-            # if an output folder is given, below works with and without the slash at the end
-            assert tmp_single.output_file == [
-                os.path.join(fsmap_tmp.root, single_fname + '.zarr')
-            ]
-        elif output_save_path.endswith('.zarr'):
-            # if an output filename is given
-            assert tmp_single.output_file == [fsmap_tmp.root]
+        fsmap_tmp = fsspec.get_mapper(
+            output_save_path, **output_storage_options
+        )
+        fs = fsmap_tmp.fs
+        if not output_save_path.startswith('s3'):
+            if output_save_path.endswith('/'):
+                # if an output folder is given, below works with and without the slash at the end
+                assert tmp_single.output_file == [
+                    os.path.join(fsmap_tmp.root, single_fname + '.zarr')
+                ]
+            elif output_save_path.endswith('.zarr'):
+                # if an output filename is given
+                assert tmp_single.output_file == [fsmap_tmp.root]
+            else:
+                # force output file extension to the called type (here .zarr)
+                assert tmp_single.output_file == [
+                    os.path.splitext(fsmap_tmp.root)[0] + '.zarr'
+                ]
+            os.rmdir(os.path.dirname(tmp_single.output_file[0]))
         else:
-            # force output file extension to the called type (here .zarr)
-            assert tmp_single.output_file == [
-                os.path.splitext(fsmap_tmp.root)[0] + '.zarr'
-            ]
-        os.rmdir(os.path.dirname(tmp_single.output_file[0]))
+            if output_save_path.endswith('/'):
+                # if an output folder is given, below works with and without the slash at the end
+                assert tmp_single.output_file == [
+                    os.path.join(output_save_path, single_fname + '.zarr')
+                ]
+            elif output_save_path.endswith('.zarr'):
+                # if an output filename is given
+                assert tmp_single.output_file == [output_save_path]
+            else:
+                # force output file extension to the called type (here .zarr)
+                assert tmp_single.output_file == [
+                    os.path.splitext(output_save_path)[0] + '.zarr'
+                ]
+            fs.delete(tmp_single.output_file[0])
     else:
         if input_path.startswith('https') or input_path.startswith('s3'):
             current_dir = Path.cwd()
@@ -87,10 +133,13 @@ def test_validate_path_single_source(
         "./echopype/test_data/dump/",
         "./echopype/test_data/dump/tmp.zarr",
         "./echopype/test_data/dump/tmp.nc",
+        "s3://ooi-raw-data/dump/",
+        "s3://ooi-raw-data/dump/tmp.zarr",
+        "s3://ooi-raw-data/dump/tmp.nc",
     ],
 )
 def test_validate_path_multiple_source(
-    model, file_format, input_path, output_save_path
+    model, file_format, input_path, output_save_path, minio_bucket
 ):
     if isinstance(input_path, str):
         mult_path = glob.glob(input_path)
@@ -106,24 +155,45 @@ def test_validate_path_multiple_source(
 
     if output_save_path is not None:
         fsmap_tmp = fsspec.get_mapper(output_save_path)
-        if output_save_path.endswith('/'):
-            # if an output folder is given, below works with and without the slash at the end
-            assert tmp_mult.output_file == [
-                os.path.join(
-                    fsmap_tmp.root,
-                    os.path.splitext(os.path.basename(f))[0] + '.zarr',
-                )
-                for f in mult_path
-            ]
-        elif output_save_path.endswith('.zarr'):
-            # if an output filename is given: only use the directory
-            assert tmp_mult.output_file == [os.path.abspath(output_save_path)]
-        elif output_save_path.endswith('.nc'):
-            # force output file extension to the called type (here .zarr)
-            assert tmp_mult.output_file == [
-                os.path.abspath(output_save_path.replace('.nc', '.zarr'))
-            ]
-        os.rmdir(os.path.dirname(tmp_mult.output_file[0]))
+        fs = fsmap_tmp.fs
+        if not output_save_path.startswith('s3'):
+            if output_save_path.endswith('/'):
+                # if an output folder is given, below works with and without the slash at the end
+                assert tmp_mult.output_file == [
+                    os.path.join(
+                        fsmap_tmp.root,
+                        os.path.splitext(os.path.basename(f))[0] + '.zarr',
+                    )
+                    for f in mult_path
+                ]
+            elif output_save_path.endswith('.zarr'):
+                # if an output filename is given: only use the directory
+                assert tmp_mult.output_file == [os.path.abspath(output_save_path)]
+            elif output_save_path.endswith('.nc'):
+                # force output file extension to the called type (here .zarr)
+                assert tmp_mult.output_file == [
+                    os.path.abspath(output_save_path.replace('.nc', '.zarr'))
+                ]
+            os.rmdir(os.path.dirname(tmp_mult.output_file[0]))
+        else:
+            if output_save_path.endswith('/'):
+                # if an output folder is given, below works with and without the slash at the end
+                assert tmp_mult.output_file == [
+                    os.path.join(
+                        output_save_path,
+                        os.path.splitext(os.path.basename(f))[0] + '.zarr',
+                    )
+                    for f in mult_path
+                ]
+            elif output_save_path.endswith('.zarr'):
+                # if an output filename is given: only use the directory
+                assert tmp_mult.output_file == [output_save_path]
+            elif output_save_path.endswith('.nc'):
+                # force output file extension to the called type (here .zarr)
+                assert tmp_mult.output_file == [
+                    output_save_path.replace('.nc', '.zarr')
+                ]
+            fs.delete(tmp_mult.output_file[0])
     else:
         if input_path[0].startswith('https') or input_path[0].startswith('s3'):
             current_dir = Path.cwd()

--- a/echopype/tests/test_convert.py
+++ b/echopype/tests/test_convert.py
@@ -1,3 +1,13 @@
+"""test_convert.py
+
+This module contain all the various tests for echopype conversion 
+from a raw data to standard compliant zarr or netcdf file(s).
+
+**Note that in order to run this test, minio server is required for s3
+output tests.**
+"""
+
+
 import os
 import glob
 import fsspec
@@ -409,77 +419,66 @@ def test_convert_azfp(
     _check_output_files(export_engine, ec.output_file, output_storage_options)
 
 
-# def _converted_group_checker(engine, out_file, multiple_files):
-#     groups = [
-#         'Provenance',
-#         'Environment',
-#         'Beam',
-#         'Sonar',
-#         'Vendor',
-#         'Platform',
-#     ]
+@pytest.mark.parametrize("model", ["EK80"])
+@pytest.mark.parametrize(
+    "input_path",
+    [
+        "./echopype/test_data/ek80/ncei-wcsd/D20170826-T205615.raw",
+        "https://ncei-wcsd-archive.s3-us-west-2.amazonaws.com/data/raw/Bell_M._Shimada/SH1707/EK80/D20170826-T205615.raw",
+        "s3://ncei-wcsd-archive/data/raw/Bell_M._Shimada/SH1707/EK80/D20170826-T205615.raw",
+    ],
+)
+@pytest.mark.parametrize("export_engine", ["zarr", "netcdf4"])
+@pytest.mark.parametrize(
+    "output_save_path",
+    [
+        None,
+        "./echopype/test_data/dump/",
+        "./echopype/test_data/dump/tmp.zarr",
+        "./echopype/test_data/dump/tmp.nc",
+        "s3://ooi-raw-data/dump/",
+        "s3://ooi-raw-data/dump/tmp.zarr",
+        "s3://ooi-raw-data/dump/tmp.nc",
+    ],
+)
+@pytest.mark.parametrize("combine_files", [False])
+def test_convert_ek80(
+    model,
+    input_path,
+    export_engine,
+    output_save_path,
+    combine_files,
+    minio_bucket,
+):
+    output_storage_options = {}
+    ipath = input_path
+    if isinstance(input_path, list):
+        ipath = input_path[0]
 
-#     if multiple_files:
-#         dirname = os.path.abspath(out_file)
-#         out_files = [os.path.join(dirname, f) for f in os.listdir(dirname)]
-#         for data_file in out_files:
-#             _check_file_group(data_file, engine, groups)
-#     else:
-#         _check_file_group(out_file, engine, groups)
+    input_storage_options = {'anon': True} if ipath.startswith('s3://') else {}
+    if output_save_path and output_save_path.startswith('s3://'):
+        output_storage_options = dict(
+            client_kwargs=dict(endpoint_url='http://localhost:9000/'),
+            key='minioadmin',
+            secret='minioadmin',
+        )
 
+    ec = Convert(
+        file=input_path, model=model, storage_options=input_storage_options
+    )
 
-# def _file_export_checks(ec, model, export_engine, multiple_files):
-#     if export_engine == "netcdf4":
-#         out_file = f"./test_{model.lower()}.nc"
-#         if multiple_files:
-#             out_file = out_file.replace(".nc", "")
-#         ec.to_netcdf(save_path=out_file, overwrite=True)
-#     elif export_engine == "zarr":
-#         out_file = f"./test_{model.lower()}.zarr"
-#         if multiple_files:
-#             out_file = out_file.replace(".zarr", "")
-#         ec.to_zarr(save_path=out_file, overwrite=True)
+    if (
+        export_engine == 'netcdf4'
+        and output_save_path is not None
+        and output_save_path.startswith('s3://')
+    ):
+        return
+    ec._to_file(
+        convert_type=export_engine,
+        save_path=output_save_path,
+        overwrite=True,
+        combine=combine_files,
+        storage_options=output_storage_options,
+    )
 
-#     _converted_group_checker(
-#         model=model,
-#         engine=export_engine,
-#         out_file=out_file,
-#         multiple_files=multiple_files,
-#     )
-
-#     # Cleanup
-#     if os.path.isfile(out_file):
-#         os.unlink(out_file)
-#     else:
-#         shutil.rmtree(out_file)
-
-
-# @pytest.mark.skip()
-# @pytest.mark.parametrize("model", ["EK80"])
-# @pytest.mark.parametrize(
-#     "file",
-#     [
-#         "https://ncei-wcsd-archive.s3-us-west-2.amazonaws.com/data/raw/Bell_M._Shimada/SH1707/EK80/D20170826-T205615.raw",
-#         "s3://ncei-wcsd-archive/data/raw/Bell_M._Shimada/SH1707/EK80/D20170826-T205615.raw",
-#     ],
-# )
-# @pytest.mark.parametrize("storage_options", [{'anon': True}])
-# @pytest.mark.parametrize("export_engine", ["netcdf4", "zarr"])
-# def test_convert_ek80(model, file, storage_options, export_engine):
-#     if isinstance(file, str):
-#         multiple_files = False
-#         if not file.startswith("s3://"):
-#             storage_options = {}
-#     else:
-#         multiple_files = True
-#         if not file[0].startswith("s3://"):
-#             storage_options = {}
-
-#     ec = Convert(file=file, model=model, storage_options=storage_options)
-
-#     if multiple_files:
-#         assert sorted(ec.source_file) == sorted(file)
-#     else:
-#         assert ec.source_file[0] == file
-
-#     _file_export_checks(ec, model, export_engine, multiple_files)
+    _check_output_files(export_engine, ec.output_file, output_storage_options)

--- a/echopype/tests/test_convert.py
+++ b/echopype/tests/test_convert.py
@@ -250,7 +250,9 @@ def test_validate_path_multiple_source(
     )
 
     if output_save_path is not None:
-        fsmap_tmp = fsspec.get_mapper(output_save_path)
+        fsmap_tmp = fsspec.get_mapper(
+            output_save_path, **output_storage_options
+        )
         fs = fsmap_tmp.fs
         if not output_save_path.startswith('s3'):
             if output_save_path.endswith('/'):

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -45,6 +45,8 @@ def check_file_permissions(FILE_DIR):
     try:
         if isinstance(FILE_DIR, FSMap):
             base_dir = os.path.dirname(FILE_DIR.root)
+            if not base_dir:
+                base_dir = FILE_DIR.root
             TEST_FILE = os.path.join(base_dir, ".permission_test")
             with FILE_DIR.fs.open(TEST_FILE, "w") as f:
                 f.write("testing\n")

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -2,6 +2,7 @@
 echopype utilities for file handling
 """
 import os
+import sys
 from fsspec import FSMap
 from pathlib import Path
 
@@ -53,7 +54,12 @@ def check_file_permissions(FILE_DIR):
         elif isinstance(FILE_DIR, Path):
             TEST_FILE = FILE_DIR.joinpath(Path('.permission_test'))
             TEST_FILE.write_text("testing\n")
-            TEST_FILE.unlink(missing_ok=True)
+
+            # Do python version check since missing_ok is for python 3.9 and up
+            if sys.version_info >= (3, 9):
+                TEST_FILE.unlink(missing_ok=True)
+            else:
+                TEST_FILE.unlink()
         else:
             TEST_FILE = os.path.join(FILE_DIR, ".permission_test")
             with open(TEST_FILE, "w") as f:

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -4,6 +4,7 @@ echopype utilities for file handling
 import os
 from collections.abc import MutableMapping
 from fsspec import FSMap
+from pathlib import Path
 
 
 def get_files_from_dir(folder):
@@ -48,12 +49,14 @@ def check_file_permissions(FILE_DIR):
             with FILE_DIR.fs.open(TEST_FILE, "w") as f:
                 f.write("testing\n")
             FILE_DIR.fs.delete(TEST_FILE)
+        elif isinstance(FILE_DIR, Path):
+            TEST_FILE = FILE_DIR.joinpath(Path('.permission_test'))
+            TEST_FILE.write_text("testing\n")
+            TEST_FILE.unlink(missing_ok=True)
         else:
             TEST_FILE = os.path.join(FILE_DIR, ".permission_test")
             with open(TEST_FILE, "w") as f:
                 f.write("testing\n")
             os.remove(TEST_FILE)
-        return True
-    except Exception as e:  # pragma: no cover
-        print(e)
-        return False
+    except Exception:
+        raise PermissionError("Writing to specified path is not permitted.")

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -30,7 +30,7 @@ def get_file_format(file):
     """Gets the file format (either Netcdf4 or Zarr) from the file extension"""
     if isinstance(file, list):
         file = file[0]
-    elif isinstance(file, MutableMapping):
+    elif isinstance(file, FSMap):
         file = file.root
 
     if file.endswith('.nc'):

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -2,7 +2,6 @@
 echopype utilities for file handling
 """
 import os
-from collections.abc import MutableMapping
 from fsspec import FSMap
 from pathlib import Path
 

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -3,6 +3,7 @@ echopype utilities for file handling
 """
 import os
 from collections.abc import MutableMapping
+from fsspec import FSMap
 
 
 def get_files_from_dir(folder):
@@ -37,3 +38,22 @@ def get_file_format(file):
         return 'zarr'
     else:
         raise ValueError(f"Unsupported file format: {os.path.splitext(file)[1]}")
+
+
+def check_file_permissions(FILE_DIR):
+    try:
+        if isinstance(FILE_DIR, FSMap):
+            base_dir = os.path.dirname(FILE_DIR.root)
+            TEST_FILE = os.path.join(base_dir, ".permission_test")
+            with FILE_DIR.fs.open(TEST_FILE, "w") as f:
+                f.write("testing\n")
+            FILE_DIR.fs.delete(TEST_FILE)
+        else:
+            TEST_FILE = os.path.join(FILE_DIR, ".permission_test")
+            with open(TEST_FILE, "w") as f:
+                f.write("testing\n")
+            os.remove(TEST_FILE)
+        return True
+    except Exception as e:  # pragma: no cover
+        print(e)
+        return False


### PR DESCRIPTION
## Overview

This PR includes changes to the `Convert` part of echopype to be able to write to object store.

## Actions
- [X] `_to_file` able to write to object store with `overwrite=True/False`
- [X] Implement tests for conversion of EK60 (no combine)
- [X] Implement tests for conversion of EK80 (no combine)
- [X] Implement tests for conversion of AZFP (no combine)
- [X] Implement CI to run tests
- [X] Implement Python linting CI (currently allow failures)

## TODO

The conversions without combining seems to work and tests passed. However, I think I will make changes for combine in a separate PR since this one is getting large already and have CI additions.