### PR TITLE
Address calibration issue with NaN ping

### DIFF
--- a/echopype/process/echodata.py
+++ b/echopype/process/echodata.py
@@ -94,6 +94,12 @@ class EchoData:
             return from_raw
         return wrapper
 
+    # TODO: overarching changes needed:
+    #  - basic cleaning of data to drop NaN pings before going forward for calibration etc
+    #  - cannot use combine='nested' but should force to have monotonically varying ping_time
+    #  - see convert/convert_combine.py for handling different sonar models
+
+
     @_check_key_param_consistency()
     def get_env_from_raw(self):
         """Open the Environment group from raw data files.
@@ -112,6 +118,8 @@ class EchoData:
     def get_beam_from_raw(self):
         """Open the Beam group from raw data files.
         """
+        # TODO: self._file_format is empty when this is called (so reading from .zarr fails),
+        #  there must be some logic or sequence error when _open and the calling methods are called
         return xr.open_mfdataset(self.raw_path, group='Beam', combine='nested',
                                  concat_dim='ping_time', data_vars='minimal', engine=self._file_format)
 

--- a/echopype/process/process.py
+++ b/echopype/process/process.py
@@ -101,7 +101,8 @@ class Process:
 
     # ---------------------------------------
     # TODO: Accessing Sv/TS/MVBS/Sv_clean from process is for backwards compatibility and
-    # will be replaced with EchoData
+    #  will be replaced with EchoData
+    # TODO: this is currently NOT working
     @property
     def Sv(self):
         return self._temp_ed.Sv
@@ -289,10 +290,10 @@ class Process:
         # Parameters that require additional computation
         # For EK80 BB mode, there is no sa correction table so the sa correction is saved as none
         if 'sa_correction' in valid_params:
-            params['sa_correction'] = self.process_obj.calc_cal_correction(ed=ed, param='sa_correction')
+            params['sa_correction'] = self.process_obj.get_power_cal_params(ed=ed, param='sa_correction')
             valid_params.remove('sa_correction')
         if 'gain_correction' in valid_params and 'gain_correction' not in ed.raw:
-            params['gain_correction'] = self.process_obj.calc_cal_correction(ed=ed, param='gain_correction')
+            params['gain_correction'] = self.process_obj.get_power_cal_params(ed=ed, param='gain_correction')
             valid_params.remove('gain_correction')
 
         for param in valid_params:
@@ -389,6 +390,7 @@ class Process:
         """
         # Check if we already have range calculated from .calibrate()
         # and if so we can just get range from there instead of re-calculating.
+        # TODO: actually do the above, currently the range is forced to be calculated
 
         # Check if sonar model matches
         self._check_model_echodata_match(ed)
@@ -499,6 +501,7 @@ class Process:
         self._check_initialized(['env', 'cal'])
         # Check to see if the data in the raw file matches the calibration function to be used
         self._check_model_echodata_match(ed)
+        # TODO: below print out the "[" and "]" when there is only one file
         print(f"{dt.now().strftime('%H:%M:%S')}  calibrating data in {ed.raw_path}")
         return self.process_obj.get_Sv(ed=ed, env_params=self.env_params, cal_params=self.cal_params,
                                        save=save, save_path=save_path, save_format=save_format)
@@ -529,6 +532,7 @@ class Process:
         self._check_initialized(['env', 'cal'])
         # Check to see if the data in the raw file matches the calibration function to be used
         self._check_model_echodata_match(ed)
+        # TODO: below print out the "[" and "]" when there is only one file
         print(f"{dt.now().strftime('%H:%M:%S')}  calibrating data in {ed.raw_path}")
         return self.process_obj.get_Sp(ed=ed, env_params=self.env_params, cal_params=self.cal_params,
                                        save=save, save_path=save_path, save_format=save_format)

--- a/echopype/process/process_ek60.py
+++ b/echopype/process/process_ek60.py
@@ -36,7 +36,7 @@ class ProcessEK60(ProcessEK):
         """Calculates range in meters.
         """
         sample_thickness = self.calc_sample_thickness(ed, env_params, cal_params)
-        # TODO Check with the AFSC about the half angle difference
+        # TODO: Check with the AFSC about the half sample difference in range
         range_meter = (ed.raw.range_bin -
                        self.tvg_correction_factor) * sample_thickness  # DataArray [frequency x range_bin]
         range_meter = range_meter.where(range_meter > 0, other=0)

--- a/echopype/process/process_ek60.py
+++ b/echopype/process/process_ek60.py
@@ -40,4 +40,6 @@ class ProcessEK60(ProcessEK):
         range_meter = (ed.raw.range_bin -
                        self.tvg_correction_factor) * sample_thickness  # DataArray [frequency x range_bin]
         range_meter = range_meter.where(range_meter > 0, other=0)
+        range_meter = range_meter.transpose('frequency', 'ping_time', 'range_bin')  # conform with backscatter_r and Sv
+        range_meter.name = 'range'  # add name to facilitate xr.merge
         return range_meter


### PR DESCRIPTION
This PR attempts to temporarily fix issues related to NaN pings in converted raw files.

@ngkavin : could you take a look to see if this fixes the problems with those files with channel 1 and 3 containing NaN pings?

Also I ran into issues with opening zarr due to self._file_format is None in `echodata.get_beam_from_raw`. It doesn't seem that you ran into this error?