### PR TITLE
Skip unneeded datagrams

### DIFF
--- a/echopype/convert/utils/ek_raw_io.py
+++ b/echopype/convert/utils/ek_raw_io.py
@@ -85,7 +85,7 @@ class RawSimradFile(BufferedReader):
                       }
 
 
-    def __init__(self, name, mode='rb', closefd=True, 
+    def __init__(self, name, mode='rb', closefd=True,
                  return_raw=False, buffer_size=1024*1024,
                  storage_options={}):
 
@@ -472,7 +472,7 @@ class RawSimradFile(BufferedReader):
             dgram_header['channel'] = struct.unpack('h', self._read_bytes(2))[0]
             self._seek_bytes(-18, SEEK_CUR)
         elif dgram_header['type'].startswith('RAW3'):
-            chan_id = struct.unpack('128s', self._read_bytes(128))
+            chan_id = struct.unpack('128s', self._read_bytes(128))[0].decode("utf-8")
             dgram_header['channel_id'] = chan_id.strip('\x00')
             self._seek_bytes(-(16 + 128), SEEK_CUR)
         else:


### PR DESCRIPTION
When selecting certain datatypes to save such as the GPS information, all data in the raw files was parsed and the unneeded datagrams were ignored. This change peeks at the next datagram and parses it only if it is needed, which will save computation time in cases where the whole raw file does not need to be saved.

Also fixes a bug in the peek function from the parser.