### PR TITLE
Securing and improving CI

### DIFF
--- a/.ci_helpers/py3.7.yaml
+++ b/.ci_helpers/py3.7.yaml
@@ -15,5 +15,5 @@ dependencies:
   - fsspec>=0.8
   - requests
   - aiohttp
-  - s3fs==0.5.2
+  - s3fs>=0.5
   - mamba

--- a/.ci_helpers/py3.8.yaml
+++ b/.ci_helpers/py3.8.yaml
@@ -15,5 +15,5 @@ dependencies:
   - fsspec>=0.8
   - requests
   - aiohttp
-  - s3fs==0.5.2
+  - s3fs>=0.5
   - mamba

--- a/.ci_helpers/py3.9.yaml
+++ b/.ci_helpers/py3.9.yaml
@@ -15,5 +15,5 @@ dependencies:
   - fsspec>=0.8
   - requests
   - aiohttp
-  - s3fs==0.5.2
+  - s3fs>=0.5
   - mamba

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_ORG: cormorack
   CONDA_ENV: echopype
-  TAG: "2021.04.06"
 
 jobs:
   test:
@@ -29,12 +27,13 @@ jobs:
         - python-version: 3.9
           experimental: true
     services:
+      # TODO: figure out how to update tag when there's a new one
       minio:
-        image: ${env.DOCKER_ORG}/minioci:${env.TAG}
+        image: cormorack/minioci:2021.04.06
         ports:
           - 9000:9000
       httpserver:
-        image: ${env.DOCKER_ORG}/http:${env.TAG}
+        image: cormorack/http:2021.04.06
         ports:
           - 8080:80
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,11 +30,11 @@ jobs:
           experimental: true
     services:
       minio:
-        image: ${DOCKER_ORG}/minioci:${TAG}
+        image: ${env.DOCKER_ORG}/minioci:${env.TAG}
         ports:
           - 9000:9000
       httpserver:
-        image: ${DOCKER_ORG}/http:${TAG}
+        image: ${env.DOCKER_ORG}/http:${env.TAG}
         ports:
           - 8080:80
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,15 +5,15 @@ on:
     branches:
       - master
       - class-redesign
-    paths-ignore: [".ci_helpers/docker/**"]
-  pull_request_target:
-    paths-ignore: [".ci_helpers/docker/**", "**/ci.yaml", "**/docker.yaml"]
+    paths-ignore: [".ci_helpers/docker/**", "**/docker.yaml"]
   pull_request:
     paths-ignore: [".ci_helpers/docker/**", "**/docker.yaml"]
   workflow_dispatch:
 
 env:
+  DOCKER_ORG: cormorack
   CONDA_ENV: echopype
+  TAG: "2021.04.06"
 
 jobs:
   test:
@@ -30,23 +30,19 @@ jobs:
           experimental: true
     services:
       minio:
-        image: cormorack/minioci
+        image: ${DOCKER_ORG}/minioci:${TAG}
         ports:
           - 9000:9000
       httpserver:
-        image: httpd:2.4
+        image: ${DOCKER_ORG}/http:${TAG}
         ports:
           - 8080:80
     steps:
       - uses: actions/checkout@v2
-      - name: Retrieve test data
-        uses: ./.github/actions/gdrive-rclone
-        env:
-          GOOGLE_SERVICE_JSON: ${{ secrets.GOOGLE_SERVICE_JSON }}
-          ROOT_FOLDER_ID: ${{ secrets.TEST_DATA_FOLDER_ID }}
       - name: Copying test data to http server
         run: |
-          docker cp -L ./echopype/test_data ${{ job.services.httpserver.id }}:/usr/local/apache2/htdocs/data
+          rm -rf ./echopype/test_data
+          docker cp -L ${{ job.services.httpserver.id }}:/usr/local/apache2/htdocs/data ./echopype/test_data
 
           # Check data endpoint
           curl http://localhost:8080/data/

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,12 +2,12 @@ name: Build Docker Images
 
 on:
   pull_request:
-    paths: [".ci_helpers/docker/**"]
+    paths: [".ci_helpers/docker/**", "**/docker.yaml"]
   push:
     branches:
       - master
       - class-redesign
-    paths: [".ci_helpers/docker/**"]
+    paths: [".ci_helpers/docker/**", "**/docker.yaml"]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
This PR improves the CI by using the test data contained within the http image. This also secures the CI since now we are not using `pull_request_target` and it doesn't need the google secrets stuff anymore.