### PR TITLE
Fix CI for testing

### DIFF
--- a/.ci_helpers/docker/docker-compose.yaml
+++ b/.ci_helpers/docker/docker-compose.yaml
@@ -2,10 +2,7 @@
 version: "3"
 services:
   minio:
-    build:
-      context: ../../.ci_helpers/docker
-      dockerfile: ./minioci.dockerfile
-    image: cormorack/minioci:latest
+    image: cormorack/minioci:2021.04.06
     ports:
       - 9000:9000
     networks:
@@ -14,27 +11,13 @@ services:
     # NOTE ====================================
     # For httpserver test data,
     # it needs to be copied to the docker container
-    # docker cp -L ./echopype/test_data docker_httpserver_1:/usr/local/apache2/htdocs/data
+    # docker cp -L docker_httpserver_1:/usr/local/apache2/htdocs/data ./echopype/test_data
     # =====================================
-    image: httpd:2.4
-    depends_on:
-      - rclone
+    image: cormorack/http:2021.04.06
     ports:
       - 8080:80
     networks:
       - echopypenetwork
-  rclone:
-    build:
-      context: ../../.github/actions/gdrive-rclone
-      dockerfile: ./Dockerfile
-    image: gdrive-rclone
-    environment:
-      - GITHUB_WORKSPACE=/data/echopype
-      - GOOGLE_SERVICE_JSON=${GOOGLE_SERVICE_JSON}
-      - ROOT_FOLDER_ID=${TEST_DATA_FOLDER_ID}
-    volumes:
-      - ../../../echopype:/data/echopype:consistent
-
 networks:
   echopypenetwork:
       

--- a/.ci_helpers/docker/setup-services.py
+++ b/.ci_helpers/docker/setup-services.py
@@ -1,0 +1,67 @@
+"""setup-services.py
+
+Script to help bring up docker services for testing.
+
+"""
+import os
+import shutil
+import sys
+from pathlib import Path
+import argparse
+
+HERE = Path('.').absolute()
+BASE = Path(__file__).parent.absolute()
+COMPOSE_FILE = BASE / "docker-compose.yaml"
+TEST_DATA_PATH = HERE / "echopype" / "test_data"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Setup services for testing')
+    parser.add_argument(
+        '--deploy', action='store_true', help="Flag to setup docker services"
+    )
+    parser.add_argument(
+        '--tear-down',
+        action='store_true',
+        help="Flag to tear down docker services",
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if all([args.deploy, args.tear_down]):
+        print("Cannot have both --deploy and --tear-down. Exiting.")
+        sys.exit(1)
+
+    if not all([args.deploy, args.tear_down]):
+        print(
+            "Please provide either --deploy or --tear-down flags. For more help use --help flag."
+        )
+        sys.exit(0)
+
+    if args.deploy:
+        print("1) Starting test services deployment.")
+        print("2) Clearing up past services.")
+        os.system(f"docker-compose -f {COMPOSE_FILE} down --remove-orphans")
+
+        print("3) Bringing up services for testing.")
+        os.system(f"docker-compose -f {COMPOSE_FILE} up -d --remove-orphans")
+
+        print(f"4) Deleting old test folder at {TEST_DATA_PATH}")
+        shutil.rmtree(TEST_DATA_PATH)
+
+        print("5) Copying new test folder from http service")
+        os.system(
+            f"docker cp -L docker_httpserver_1:/usr/local/apache2/htdocs/data {TEST_DATA_PATH}"
+        )
+
+        print("6) Done.")
+        os.system("docker ps --last 2")
+
+    if args.tear_down:
+        print("1) Stopping test services deployment.")
+        os.system(f"docker-compose -f {COMPOSE_FILE} down --remove-orphans")
+        print("2) Done.")
+        os.system("docker ps --last 2")

--- a/.ci_helpers/py3.7.yaml
+++ b/.ci_helpers/py3.7.yaml
@@ -12,7 +12,7 @@ dependencies:
   - scipy
   - xarray==0.16.2
   - zarr
-  - fsspec>=0.8
+  - fsspec==0.8.5
   - requests
   - aiohttp
   - s3fs>=0.5

--- a/.ci_helpers/py3.7.yaml
+++ b/.ci_helpers/py3.7.yaml
@@ -12,7 +12,7 @@ dependencies:
   - scipy
   - xarray==0.16.2
   - zarr
-  - fsspec==0.8.5
+  - fsspec==0.8.7
   - requests
   - aiohttp
   - s3fs>=0.5

--- a/.ci_helpers/py3.8.yaml
+++ b/.ci_helpers/py3.8.yaml
@@ -12,7 +12,7 @@ dependencies:
   - scipy
   - xarray==0.16.2
   - zarr
-  - fsspec>=0.8
+  - fsspec==0.8.5
   - requests
   - aiohttp
   - s3fs>=0.5

--- a/.ci_helpers/py3.8.yaml
+++ b/.ci_helpers/py3.8.yaml
@@ -12,7 +12,7 @@ dependencies:
   - scipy
   - xarray==0.16.2
   - zarr
-  - fsspec==0.8.5
+  - fsspec==0.8.7
   - requests
   - aiohttp
   - s3fs>=0.5

--- a/.ci_helpers/py3.9.yaml
+++ b/.ci_helpers/py3.9.yaml
@@ -12,7 +12,7 @@ dependencies:
   - scipy
   - xarray==0.16.2
   - zarr
-  - fsspec>=0.8
+  - fsspec==0.8.5
   - requests
   - aiohttp
   - s3fs>=0.5

--- a/.ci_helpers/py3.9.yaml
+++ b/.ci_helpers/py3.9.yaml
@@ -12,7 +12,7 @@ dependencies:
   - scipy
   - xarray==0.16.2
   - zarr
-  - fsspec==0.8.5
+  - fsspec==0.8.7
   - requests
   - aiohttp
   - s3fs>=0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pytz
 scipy
 xarray==0.16.2
 zarr
-fsspec==0.8.5
+fsspec==0.8.7
 requests
 aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pytz
 scipy
 xarray==0.16.2
 zarr
-fsspec>=0.8
+fsspec==0.8.5
 requests
 aiohttp


### PR DESCRIPTION
## Overview

This PR attempts to fix the current failing tests. Initial investigation leads to the need to pin fsspec version to a known working version of `0.8.5` seems like the current fsspec verison of `0.9.0` broke the CI.