### PR TITLE
Replace os operations with pathlib

### DIFF
--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -348,7 +348,8 @@ def _set_convert_params(param_dict):
 
 
 def _check_file(file, model, xml_path=None, storage_options={}):
-    """Checks whether the file and/or xml file exists
+    """Checks whether the file and/or xml file exists and
+    whether they have the correct extensions.
 
     Parameters
     ----------
@@ -401,7 +402,7 @@ def _check_file(file, model, xml_path=None, storage_options={}):
 
     if file.suffix.upper() != ext.upper():
         raise ValueError(
-            f"Not all files are in the same format. Expecting a {ext} file but got {file}"
+            f"Expecting a {ext} file but got {file}"
         )
 
     return str(file), str(xml)
@@ -434,7 +435,7 @@ def open_raw(
         options for cloud storage
     """
     if (model is None) and (file is None):
-        print("Please specify paths to raw data files and the sonar model.")
+        print("Please specify the path to the raw data file and the sonar model.")
         return
 
     # Check inputs
@@ -475,7 +476,7 @@ def open_raw(
 
     # Check paths and file types
     if file is None:
-        raise FileNotFoundError("Please specify paths to raw data files.")
+        raise FileNotFoundError("Please specify the path to the raw data file.")
 
     # Check for path type
     if isinstance(file, Path):

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -439,7 +439,7 @@ def open_raw(
 
     Parameters
     ----------
-    file : str or list
+    file : str
         path to raw data file(s)
     model : str
         model of the sonar instrument
@@ -492,18 +492,17 @@ def open_raw(
             )
 
     # Check paths and file types
-    if file is not None:
-
-        # Check for path type
-        if not all(isinstance(elem, str) for elem in file):
-            raise ValueError("file must be a string or a list of string")
-
-        # Check file extension and existence
-        file_chk, xml_chk = _check_file(
-            file, model, xml_path, storage_options
-        )
-    else:
+    if file is None:
         raise FileNotFoundError("Please specify paths to raw data files.")
+
+    # Check for path type
+    if not isinstance(file, str):
+        raise ValueError("file must be a string or Path")
+
+    # Check file extension and existence
+    file_chk, xml_chk = _check_file(
+        file, model, xml_path, storage_options
+    )
 
     # TODO: the if-else below only works for the AZFP vs EK contrast,
     #  but is brittle since it is abusing params by using it implicitly


### PR DESCRIPTION
The current Echodata API mixes use with the `os` and `pathlib` libraries in order to perform operations on file paths. This PR replaces all occurances of the `os` library with the corresponding `pathlib` operations.

This PR also makes the `to_file` and `_validate_path` functions work with only 1 file at a time.

These changes are suggested as part of issue #286 