### PR TITLE
Update helpers to use latest tag and fix bug in script

### DIFF
--- a/.ci_helpers/docker/docker-compose.yaml
+++ b/.ci_helpers/docker/docker-compose.yaml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   minio:
-    image: cormorack/minioci:2021.04.06
+    image: cormorack/minioci:latest
     ports:
       - 9000:9000
     networks:
@@ -13,7 +13,7 @@ services:
     # it needs to be copied to the docker container
     # docker cp -L docker_httpserver_1:/usr/local/apache2/htdocs/data ./echopype/test_data
     # =====================================
-    image: cormorack/http:2021.04.06
+    image: cormorack/http:latest
     ports:
       - 8080:80
     networks:

--- a/.ci_helpers/docker/setup-services.py
+++ b/.ci_helpers/docker/setup-services.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
         print("Cannot have both --deploy and --tear-down. Exiting.")
         sys.exit(1)
 
-    if not all([args.deploy, args.tear_down]):
+    if not any([args.deploy, args.tear_down]):
         print(
             "Please provide either --deploy or --tear-down flags. For more help use --help flag."
         )


### PR DESCRIPTION
This PR fix a bug in setup-service script for testing. Also, now by default we'll use the `latest` tag of images that contain the test data.