### PR TITLE
Delay EchoData groups.

### DIFF
--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -42,9 +42,18 @@ class SetGroupsBase:
         pass
 
     # TODO: change the set_XXX methods to return a dataset to be saved in the overarching save method
-    def set_toplevel(self, sonar_model, date_created=None) -> xr.Dataset:
+    def set_toplevel(self, sonar_model=None, date_created=None) -> xr.Dataset:
         """Set the top-level group.
         """
+        if sonar_model is None:
+            sonar_model = self.sonar_model
+
+        if date_created is None:
+            # Top-level date_created varies depending on sonar model
+            if sonar_model in ["EK60", "EK80"]:
+                date_created = self.parser_obj.config_datagram['timestamp']
+            else:
+                date_created = self.parser_obj.ping_time[0]
         # Collect variables
         tl_dict = {'conventions': 'CF-1.7, SONAR-netCDF4-1.0, ACDD-1.3',
                    'keywords': sonar_model,

--- a/echopype/convert/utils/ek_raw_io.py
+++ b/echopype/convert/utils/ek_raw_io.py
@@ -94,7 +94,7 @@ class RawSimradFile(BufferedReader):
 
         #  create a raw file object for the buffered reader
         fmap = fsspec.get_mapper(name, **storage_options)
-        if isinstance(fmap, LocalFileSystem):
+        if isinstance(fmap.fs, LocalFileSystem):
             fio = FileIO(name, mode=mode, closefd=closefd)
         else:
             fio = fmap.fs.open(fmap.root)

--- a/echopype/utils/funcs.py
+++ b/echopype/utils/funcs.py
@@ -1,0 +1,47 @@
+from typing import Union
+
+import xarray as xr
+
+from ..convert.parse_azfp import ParseAZFP
+from ..convert.parse_ek60 import ParseEK60
+from ..convert.parse_ek80 import ParseEK80
+from ..convert.set_groups_azfp import SetGroupsAZFP
+from ..convert.set_groups_ek60 import SetGroupsEK60
+from ..convert.set_groups_ek80 import SetGroupsEK80
+
+
+# Functions to help with dask delaying
+def __parse_raw(
+    parser_class, file, params, storage_options
+) -> Union[ParseAZFP, ParseEK60, ParseEK80]:
+    """
+    Delayes the parsing of raw file
+    """
+    parser = parser_class(
+        file=file, params=params, storage_options=storage_options
+    )
+    parser.parse_raw()
+    return parser
+
+
+def __get_set_grouper(
+    set_groups_class, parser, input_file, output_path, sonar_model, params
+) -> Union[SetGroupsAZFP, SetGroupsEK60, SetGroupsEK80]:
+    """
+    Delayes the set group function of converted file
+    """
+    setgrouper = set_groups_class(
+        parser_obj=parser,
+        input_file=input_file,
+        output_path=output_path,
+        sonar_model=sonar_model,
+        params=params,
+    )
+    return setgrouper
+
+
+def __set_func(setgrouper, func) -> xr.Dataset:
+    """
+    Runs the appropriate set_* function from the setgrouper object
+    """
+    return getattr(setgrouper, func)()


### PR DESCRIPTION
## Overview

This PR allowes for groups within EchoData to be delayed.

## Notes
Now `EchoData` has a `delayed` attribute and `load()`, `persist()` functions to load in delayed data. 

Currently the `delayed` attribute is manually set in `open_raw`... so this seems very sensitive. However, this can be improved if we do expect a user to be able to manually create `EchoData` object.

I still have to complete TODOs below. But wanted to put this PR up for suggestion as I further make changes. @leewujung I don't think this functionality will be ready for a Monday release :stuck_out_tongue:

## TODO
- [X] `open_raw` delaying opening groups
- [ ] `open_converted` delaying opening groups
- [ ] `to_file` ability to export file from delayed groups