### PR TITLE
Add env and cal parameters to Sv output dataset

### DIFF
--- a/echopype/calibrate/calibrate_azfp.py
+++ b/echopype/calibrate/calibrate_azfp.py
@@ -137,6 +137,9 @@ class CalibrateAZFP(CalibrateBase):
         out = out.to_dataset()
         out = out.merge(self.range_meter)
 
+        # Add env and cal parameters
+        out = self._add_params_to_output(out)
+
         return out
 
     def compute_Sv(self, **kwargs):

--- a/echopype/calibrate/calibrate_base.py
+++ b/echopype/calibrate/calibrate_base.py
@@ -67,3 +67,16 @@ class CalibrateBase:
 
     def compute_Sp(self, **kwargs):
         pass
+
+    def _add_params_to_output(self, ds_out):
+        """Add all cal and env parameters to output Sv dataset.
+        """
+        # Add env_params
+        for key, val in self.env_params.items():
+            ds_out[key] = val
+
+        # Add cal_params
+        for key, val in self.cal_params.items():
+            ds_out[key] = val
+
+        return ds_out

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -175,6 +175,9 @@ class CalibrateEK(CalibrateBase):
         out = out.to_dataset()
         out = out.merge(range_meter)
 
+        # Add env and cal parameters
+        out = self._add_params_to_output(out)
+
         return out
 
 
@@ -561,6 +564,9 @@ class CalibrateEK80(CalibrateEK):
 
         # Attach calculated range (with units meter) into data set
         out = out.merge(range_meter)
+
+        # Add env and cal parameters
+        out = self._add_params_to_output(out)
 
         return out
 


### PR DESCRIPTION
This PR adds `cal_params` and `env_params` used in `calibrate.compute_Sv/Sp` to the output datasets. 

These parameters are important for provenance and for reproducing the cal results from raw data, in case user-specified cal and env parameters are used during calibration. The parameters are also needed for some downstream processing, such as noise removal based on background noise estimates.

Right now we are not following any specific convention for the calibrated dataset, so the cal and env parameters are encoded in the form used in echopype. 

@emiliom: tagging you here as this is relevant to the convention/processing level discussions going forward.