### PR TITLE
Add function to correct ping_time reversal

### DIFF
--- a/echopype/qc/__init__.py
+++ b/echopype/qc/__init__.py
@@ -1,2 +1,2 @@
-from .api import coerce_increasing_ping_time, exist_reversed_time
+from .api import coerce_increasing_time, exist_reversed_time
 

--- a/echopype/qc/__init__.py
+++ b/echopype/qc/__init__.py
@@ -1,1 +1,1 @@
-from .api import coerce_increasing_ping_time
+from .api import coerce_increasing_ping_time, exist_reversed_ping_time

--- a/echopype/qc/__init__.py
+++ b/echopype/qc/__init__.py
@@ -1,1 +1,2 @@
-from .api import coerce_increasing_ping_time, exist_reversed_ping_time
+from .api import coerce_increasing_ping_time, exist_reversed_time
+

--- a/echopype/qc/__init__.py
+++ b/echopype/qc/__init__.py
@@ -1,0 +1,1 @@
+from .api import coerce_increasing_ping_time

--- a/echopype/qc/api.py
+++ b/echopype/qc/api.py
@@ -20,26 +20,28 @@ def _clean_ping_time(ping_time_old, local_win_len=100):
         return ping_time_old  # no negative diff
 
 
-def coerce_increasing_ping_time(ds, local_win_len=100):
-    """Coerce ``ping_time`` to always flow forward.
+def coerce_increasing_time(ds, time_name='ping_time', local_win_len=100):
+    """Coerce a time coordinate to always flow forward.
 
     This is to correct for problems sometimes observed in EK60 data
-    where ``ping_time`` would suddenly go backward for one ping
-    but with the rest of the pinging interval undisturbed.
+    where a time coordinate (``ping_time`` or ``location_time``)
+    would suddenly go backward for one ping but with the rest of the pinging interval undisturbed.
 
     Parameters
     ----------
     ds : xr.Dataset
-        a dataset with a ``ping_time`` dimension/coordinate
+        a dataset for which the time coordinate needs to be corrected
+    time_name : str
+        name of the time coordinate to be corrected
     local_win_len : int
         half length of the local window within which the median pinging interval
         is used to infer the correct next ping time
 
     Returns
     -------
-    the input dataset but with ``ping_time`` coerced to flow forward
+    the input dataset but with specified time coordinate coerced to flow forward
     """
-    ds['ping_time'] = _clean_ping_time(ds['ping_time'].values, local_win_len=local_win_len)
+    ds[time_name] = _clean_ping_time(ds[time_name].values, local_win_len=local_win_len)
     return ds
 
 

--- a/echopype/qc/api.py
+++ b/echopype/qc/api.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+
+def _clean_ping_time(ping_time_old, local_win_len=100):
+    ping_time_old_diff = np.diff(ping_time_old)
+    neg_idx = np.argwhere(ping_time_old_diff < np.timedelta64(0, 'ns'))  # indices with negative diff
+    if neg_idx.size !=0:
+        ni = neg_idx[0][0]
+        local_win = np.arange(-local_win_len, local_win_len)
+        local_pt_diff = ping_time_old_diff[ni + local_win]
+        local_pt_median = np.median(np.delete(local_pt_diff, local_win_len))  # median after removing negative element
+        ping_time_new = np.hstack((
+            ping_time_old[:ni + 1],
+            ping_time_old[ni] + np.cumsum(
+                np.hstack((local_pt_median, ping_time_old_diff[(ni + 1):]))
+            )
+        ))
+        return _clean_ping_time(ping_time_new, local_win_len=local_win_len)
+    else:
+        return ping_time_old  # no negative diff
+
+
+def coerce_increasing_ping_time(ds, local_win_len=100):
+    """Coerce ``ping_time`` to always flow forward.
+
+    This is to correct for problems sometimes observed in EK60 data
+    where ``ping_time`` would suddenly go backward for one ping
+    but with the rest of the pinging interval undisturbed.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        a dataset with a ``ping_time`` dimension/coordinate
+    local_win_len : int
+        half length of the local window within which the median pinging interval
+        is used to infer the correct next ping time
+
+    Returns
+    -------
+    the input dataset but with ``ping_time`` coerced to flow forward
+    """
+    ds['ping_time'] = _clean_ping_time(ds['ping_time'].values, local_win_len=local_win_len)
+    return ds

--- a/echopype/qc/api.py
+++ b/echopype/qc/api.py
@@ -43,5 +43,5 @@ def coerce_increasing_ping_time(ds, local_win_len=100):
     return ds
 
 
-def exist_reversed_ping_time(ds):
-    return (np.diff(ds['ping_time']) < np.timedelta64(0, 'ns')).any()
+def exist_reversed_time(ds, time_name):
+    return (np.diff(ds[time_name]) < np.timedelta64(0, 'ns')).any()

--- a/echopype/qc/api.py
+++ b/echopype/qc/api.py
@@ -41,3 +41,7 @@ def coerce_increasing_ping_time(ds, local_win_len=100):
     """
     ds['ping_time'] = _clean_ping_time(ds['ping_time'].values, local_win_len=local_win_len)
     return ds
+
+
+def exist_reversed_ping_time(ds):
+    return (np.diff(ds['ping_time']) < np.timedelta64(0, 'ns')).any()


### PR DESCRIPTION
This PR adds a function to detect and correct reversed `ping_time` sometimes observed in EK60. 

If no `ping_time` reversal is detected the original timestamps are returned.

If reversed `ping_time` exists, the function uses the median `ping_time` difference within a local window to infer and correct the timestamp.

@emiliom : could you try this on the hake survey file you've seen this problem before? Thanks!

