### PR TITLE
Allow local test run of everything

### DIFF
--- a/.ci_helpers/run-test.py
+++ b/.ci_helpers/run-test.py
@@ -6,6 +6,7 @@ Script to run tests in Github.
 import argparse
 import glob
 import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -23,12 +24,35 @@ EXIT_CODES = {
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run tests listed.")
-    parser.add_argument("touchedfiles", metavar="TOUCHED_FILES", type=str)
+    parser.add_argument(
+        "touchedfiles",
+        metavar="TOUCHED_FILES",
+        type=str,
+        nargs="?",
+        default="",
+        help="Comma separated list of changed files."
+    )
     parser.add_argument(
         "--pytest-args", type=str, help="Optional pytest args", default=""
     )
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Optional flag for running tests locally, not in continuous integration.",
+    )
     args = parser.parse_args()
-    file_list = args.touchedfiles.split(",")
+    if args.local:
+        temp_path = Path("temp_echopype_output")
+        dump_path = Path("echopype/test_data/dump")
+        if temp_path.exists():
+            shutil.rmtree(temp_path)
+
+        if dump_path.exists():
+            shutil.rmtree(dump_path)
+        echopype_folder = Path("echopype")
+        file_list = glob.glob(str(echopype_folder / "**" / "*.py"))
+    else:
+        file_list = args.touchedfiles.split(",")
     pytest_args = []
     if args.pytest_args:
         pytest_args = args.pytest_args.split(",")


### PR DESCRIPTION
This PR allows `run-test.py` to run locally of all the tests when user put `--local` flag.