### PR TITLE
Add s3fs with pinned version to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ scipy
 xarray==0.16.2
 zarr
 fsspec==0.8.7
+s3fs==0.5.2
 requests
 aiohttp


### PR DESCRIPTION
Add s3fs to requirements.txt, pinned to the version currently found to work with the fsspec version that was already pinned.

Having s3fs in requirements.txt (and therefore in the pypi and conda packages) will make it easier for others to use the S3 I/O features.