### PR TITLE
Cast AZFP frequency to float64

### DIFF
--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -139,6 +139,8 @@ class ParseAZFP(ParseBase):
                 ping_num += 1
         self._check_uniqueness()
         self._get_ping_time()
+        # Explicitly cast frequency to a float in accordance with the SONAR-netCDF4 convention
+        self.unpacked_data['frequency'] = self.unpacked_data['frequency'].astype(np.float64)
 
     @staticmethod
     def _get_fields():


### PR DESCRIPTION
The current AFZP parser automatically assigns the dtype of `int32` or `int64` depending on the user's OS. This may cause issues in the case of frequency being type `int32` where calculations may cause an integer overflow. The SONAR-netCDF4 convention also states that the frequency should be a floating point number to account for fractional frequencies.

This small PR casts the AZFP frequency to be `float64` which fixes the aforementioned issues.

Addresses #307