### PR TITLE
Add tests for preprocess functions

### DIFF
--- a/.ci_helpers/run-test.py
+++ b/.ci_helpers/run-test.py
@@ -88,6 +88,15 @@ if __name__ == "__main__":
                 if "echodata" not in test_to_run:
                     test_to_run["echodata"] = []
                 test_to_run["echodata"].append(file_path)
+            elif any(
+                [
+                    (file_path.match("echopype/preprocess/*")),
+                    (file_path.match("echopype/tests/test_preprocess*")),
+                ]
+            ):
+                if "preprocess" not in test_to_run:
+                    test_to_run["preprocess"] = []
+                test_to_run["preprocess"].append(file_path)
 
     total_exit_codes = []
     for k, v in test_to_run.items():

--- a/.ci_helpers/run-test.py
+++ b/.ci_helpers/run-test.py
@@ -97,6 +97,16 @@ if __name__ == "__main__":
                 if "preprocess" not in test_to_run:
                     test_to_run["preprocess"] = []
                 test_to_run["preprocess"].append(file_path)
+            elif any(
+                [
+                    (file_path.match("echopype/convert/convert.py")),
+                    (file_path.match("echopype/process/*"))
+                    (file_path.match("echopype/tests/test_old.py")),
+                ]
+            ):
+                if "old" not in test_to_run:
+                    test_to_run["old"] = []
+                test_to_run["old"].append(file_path)
 
     total_exit_codes = []
     for k, v in test_to_run.items():

--- a/.ci_helpers/run-test.py
+++ b/.ci_helpers/run-test.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
             elif any(
                 [
                     (file_path.match("echopype/convert/convert.py")),
-                    (file_path.match("echopype/process/*"))
+                    (file_path.match("echopype/process/*")),
                     (file_path.match("echopype/tests/test_old.py")),
                 ]
             ):

--- a/echopype/process/process_deprecated.py
+++ b/echopype/process/process_deprecated.py
@@ -6,11 +6,6 @@ from echopype.calibrate.calibrate_ek import CalibrateEK60, CalibrateEK80
 from echopype.calibrate.calibrate_azfp import CalibrateAZFP
 from echopype.preprocess import api as preprocess
 
-warnings.warn("`Process` has changed. See the docs for information on how to use "
-              "the new processing functions. The old workflow will be removed "
-              "in a future version.", DeprecationWarning, 3)
-
-
 CALIBRATOR = {
     'EK60': CalibrateEK60,
     'EK80': CalibrateEK80,
@@ -182,7 +177,7 @@ class Process():
         )
         if save:
             self.Sv_path = self.validate_path(save_path, save_postfix)
-            print('%s  saving calibrated TS to %s' % (dt.datetime.now().strftime('%H:%M:%S'), self.Sv_path))
+            print('%s  saving calibrated Sv to %s' % (dt.datetime.now().strftime('%H:%M:%S'), self.Sv_path))
             self._save_dataset(self.Sv, self.Sv_path, mode="w")
 
     def calibrate_TS(self, save=False, save_postfix='_TS', save_path=None, waveform_mode=None, encode_mode=None):

--- a/echopype/tests/test_preprocess.py
+++ b/echopype/tests/test_preprocess.py
@@ -169,7 +169,7 @@ def test_compute_MVBS_index_binning():
     test_array = _construct_MVBS_test_data(nfreq, data_binned_shape[1], data_binned_shape[2])
 
     # Test all values in MVBS
-    np.allclose(data_test, test_array, rtol=0, atol=1e-12)
+    assert np.allclose(data_test, test_array, rtol=0, atol=1e-12)
 
 
 def test_compute_MVBS():
@@ -227,12 +227,12 @@ def test_compute_MVBS():
     test_array = _construct_MVBS_test_data(nfreq, data_binned_shape[1], data_binned_shape[2])
 
     # Test all values in MVBS
-    np.allclose(data_test, test_array, rtol=0, atol=1e-12)
+    assert np.allclose(data_test, test_array, rtol=0, atol=1e-12)
 
     # Test to see if ping_time was resampled correctly
     test_ping_time = pd.date_range('1/1/2020', periods=np.ceil(ping_num), freq=f'{ping_time_bin}S')
-    np.array_equal(data_test.ping_time, test_ping_time)
+    assert np.array_equal(data_test.ping_time, test_ping_time)
 
     # Test to see if range was resampled correctly
     test_range = np.arange(0, total_range, range_meter_bin)
-    np.array_equal(data_test.range, test_range)
+    assert np.array_equal(data_test.range, test_range)

--- a/echopype/tests/test_preprocess.py
+++ b/echopype/tests/test_preprocess.py
@@ -112,15 +112,8 @@ def _construct_MVBS_test_data(nfreq, npings, nrange_bins):
     """
 
     # Construct test array
-    test_array = np.indices((npings, nrange_bins))
-    test_array = np.add(*test_array)
-    test_array = np.array([test_array] * nfreq) + 1
-
-    # Increase test data by a multiple each frequency
-    for f in range(nfreq):
-        test_array[f] = (test_array[0] * (f + 1))
-
-    return test_array
+    test_array = np.add(*np.indices((npings, nrange_bins)))
+    return np.array([(test_array + 1) * (f + 1) for f in range(nfreq)])
 
 
 def test_compute_MVBS_index_binning():

--- a/echopype/tests/test_preprocess.py
+++ b/echopype/tests/test_preprocess.py
@@ -168,3 +168,11 @@ def test_compute_MVBS():
 
     # Test all values in MVBS
     np.allclose(data_test, test_array, rtol=0, atol=1e-12)
+
+    # Test to see if ping_time was resampled correctly
+    test_ping_time = pd.date_range('1/1/2020', periods=np.ceil(ping_num), freq=f'{ping_time_bin}S')
+    np.array_equal(data_test.ping_time, test_ping_time)
+
+    # Test to see if range was resampled correctly
+    test_range = np.arange(0, total_range, range_meter_bin)
+    np.allclose(data_test.range, test_range, rtol=0, atol=1e-12)

--- a/echopype/tests/test_preprocess.py
+++ b/echopype/tests/test_preprocess.py
@@ -175,4 +175,4 @@ def test_compute_MVBS():
 
     # Test to see if range was resampled correctly
     test_range = np.arange(0, total_range, range_meter_bin)
-    np.allclose(data_test.range, test_range, rtol=0, atol=1e-12)
+    np.array_equal(data_test.range, test_range)

--- a/echopype/tests/test_preprocess.py
+++ b/echopype/tests/test_preprocess.py
@@ -4,14 +4,15 @@ import echopype as ep
 
 
 def test_remove_noise():
-    # Create process object
+    """Test remove_noise on toy data"""
+
+    # Parameters for fake data
     nfreq, npings, nrange = 1, 10, 100
     freq = np.arange(nfreq)
     ping_index = np.arange(npings)
     range_bin = np.arange(nrange)
-
-    # Test noise removal on toy data
     data = np.ones(nrange)
+
     # Insert noise points
     np.put(data, 30, -30)
     np.put(data, 60, -30)
@@ -36,13 +37,13 @@ def test_remove_noise():
     # Test remove noise on a normal distribution
     np.random.seed(1)
     data = np.random.normal(loc=-100, scale=2, size=(nfreq, npings, nrange))
-    # Make DataArray
+    # Make Dataset to pass into remove_noise
     Sv = xr.DataArray(data, coords=[('frequency', freq),
                                     ('ping_time', ping_index),
                                     ('range_bin', range_bin)])
     Sv.name = "Sv"
     ds_Sv = Sv.to_dataset()
-
+    # Attach required range and sound_absorption values
     ds_Sv = ds_Sv.assign(range=xr.DataArray(np.array([[np.linspace(0, 3, nrange)] * npings]), coords=Sv.coords))
     ds_Sv = ds_Sv.assign(sound_absorption=0.001)
     # Run noise removal
@@ -53,7 +54,7 @@ def test_remove_noise():
 
 
 def test_compute_MVBS_index_binning():
-    """Test get_MVBS on a normal distribution"""
+    """Test compute_MVBS_index_binning on toy data"""
 
     # Parameters for fake data
     nfreq, npings, nrange = 4, 40, 400
@@ -61,7 +62,7 @@ def test_compute_MVBS_index_binning():
     range_bin_num = 3        # number of range_bins to average over
 
     # Construct data with values that increase every ping_num and range_bin_num
-    # so that when binned get_MVBS is performed, the result is a smaller array
+    # so that when compute_MVBS_index_binning is performed, the result is a smaller array
     # that increases by 1 for each row and column
     data = np.zeros((nfreq, npings, nrange))
     for p_i, ping in enumerate(range(0, npings, ping_num)):

--- a/echopype/tests/test_preprocess.py
+++ b/echopype/tests/test_preprocess.py
@@ -8,11 +8,11 @@ def test_remove_noise():
     """Test remove_noise on toy data"""
 
     # Parameters for fake data
-    nfreq, npings, nrange = 1, 10, 100
+    nfreq, npings, nrange_bins = 1, 10, 100
     freq = np.arange(nfreq)
     ping_index = np.arange(npings)
-    range_bin = np.arange(nrange)
-    data = np.ones(nrange)
+    range_bin = np.arange(nrange_bins)
+    data = np.ones(nrange_bins)
 
     # Insert noise points
     np.put(data, 30, -30)
@@ -26,7 +26,7 @@ def test_remove_noise():
     Sv.name = "Sv"
     ds_Sv = Sv.to_dataset()
 
-    ds_Sv = ds_Sv.assign(range=xr.DataArray(np.array([[np.linspace(0, 10, nrange)] * npings]), coords=Sv.coords))
+    ds_Sv = ds_Sv.assign(range=xr.DataArray(np.array([[np.linspace(0, 10, nrange_bins)] * npings]), coords=Sv.coords))
     ds_Sv = ds_Sv.assign(sound_absorption=0.001)
     # Run noise removal
     ds_Sv = ep.preprocess.remove_noise(ds_Sv, ping_num=2, range_bin_num=5, SNR_threshold=0)
@@ -37,7 +37,7 @@ def test_remove_noise():
 
     # Test remove noise on a normal distribution
     np.random.seed(1)
-    data = np.random.normal(loc=-100, scale=2, size=(nfreq, npings, nrange))
+    data = np.random.normal(loc=-100, scale=2, size=(nfreq, npings, nrange_bins))
     # Make Dataset to pass into remove_noise
     Sv = xr.DataArray(data, coords=[('frequency', freq),
                                     ('ping_time', ping_index),
@@ -45,7 +45,7 @@ def test_remove_noise():
     Sv.name = "Sv"
     ds_Sv = Sv.to_dataset()
     # Attach required range and sound_absorption values
-    ds_Sv = ds_Sv.assign(range=xr.DataArray(np.array([[np.linspace(0, 3, nrange)] * npings]), coords=Sv.coords))
+    ds_Sv = ds_Sv.assign(range=xr.DataArray(np.array([[np.linspace(0, 3, nrange_bins)] * npings]), coords=Sv.coords))
     ds_Sv = ds_Sv.assign(sound_absorption=0.001)
     # Run noise removal
     ds_Sv = ep.preprocess.remove_noise(ds_Sv, ping_num=2, range_bin_num=5, SNR_threshold=0)
@@ -54,7 +54,7 @@ def test_remove_noise():
     assert np.count_nonzero(null.isel(frequency=0, range_bin=slice(None, 50))) == 6
 
 
-def _construct_MVBS_toy_data(nfreq, npings, nrange, ping_size, range_bin_size):
+def _construct_MVBS_toy_data(nfreq, npings, nrange_bins, ping_size, range_bin_size):
     """Construct data with values that increase every ping_num and range_bin_num
     so that the result of computing MVBS is a smaller array
     that increases regularly for each resampled ping_time and range_bin
@@ -65,7 +65,7 @@ def _construct_MVBS_toy_data(nfreq, npings, nrange, ping_size, range_bin_size):
         number of frequencies
     npings : int
         number of pings
-    nrange : int
+    nrange_bins : int
         number of range_bins
     ping_size : int
         number of pings with the same value
@@ -79,9 +79,9 @@ def _construct_MVBS_toy_data(nfreq, npings, nrange, ping_size, range_bin_size):
         so that computing the MVBS will result in regularly increasing values
         every row and column
     """
-    data = np.ones((nfreq, npings, nrange))
+    data = np.ones((nfreq, npings, nrange_bins))
     for p_i, ping in enumerate(range(0, npings, ping_size)):
-        for r_i, rb in enumerate(range(0, nrange, range_bin_size)):
+        for r_i, rb in enumerate(range(0, nrange_bins, range_bin_size)):
             data[0, ping:ping + ping_size, rb:rb + range_bin_size] += r_i + p_i
     # First frequency increases by 1 each row and column, second increases by 2, third by 3, etc.
     for f in range(nfreq):
@@ -126,7 +126,7 @@ def test_compute_MVBS_index_binning():
     """Test compute_MVBS_index_binning on toy data"""
 
     # Parameters for toy data
-    nfreq, npings, nrange = 4, 40, 400
+    nfreq, npings, nrange_bins = 4, 40, 400
     ping_num = 3             # number of pings to average over
     range_bin_num = 7        # number of range_bins to average over
 
@@ -134,7 +134,7 @@ def test_compute_MVBS_index_binning():
     data = _construct_MVBS_toy_data(
         nfreq=nfreq,
         npings=npings,
-        nrange=nrange,
+        nrange_bins=nrange_bins,
         ping_size=ping_num,
         range_bin_size=range_bin_num
     )
@@ -142,14 +142,14 @@ def test_compute_MVBS_index_binning():
     data_log = 10 * np.log10(data)      # Convert to log domain
     freq_index = np.arange(nfreq)
     ping_index = np.arange(npings)
-    range_bin = np.arange(nrange)
+    range_bin = np.arange(nrange_bins)
     Sv = xr.DataArray(data_log, coords=[('frequency', freq_index),
                                         ('ping_time', ping_index),
                                         ('range_bin', range_bin)])
     Sv.name = "Sv"
     ds_Sv = Sv.to_dataset()
     ds_Sv = ds_Sv.assign(
-        range=xr.DataArray(np.array([[np.linspace(0, 10, nrange)] * npings] * nfreq),
+        range=xr.DataArray(np.array([[np.linspace(0, 10, nrange_bins)] * npings] * nfreq),
                            coords=Sv.coords)
     )
 
@@ -162,7 +162,7 @@ def test_compute_MVBS_index_binning():
     data_test = (10 ** (ds_MVBS.Sv / 10))    # Convert to linear domain
 
     # Shape test
-    data_binned_shape = np.ceil((nfreq, npings / ping_num, nrange / range_bin_num)).astype(int)
+    data_binned_shape = np.ceil((nfreq, npings / ping_num, nrange_bins / range_bin_num)).astype(int)
     assert np.all(data_test.shape == data_binned_shape)
 
     # Construct test array that increases by 1 for each range_bin and ping_time
@@ -176,16 +176,16 @@ def test_compute_MVBS():
     """Test compute_MVBS on toy data"""
 
     # Parameters for fake data
-    nfreq, npings, nrange = 4, 100, 4000
+    nfreq, npings, nrange_bins = 4, 100, 4000
     range_meter_bin = 7          # range in meters to average over
     ping_time_bin = 3            # number of seconds to average over
     ping_rate = 2                # Number of pings per second
     range_bin_per_meter = 30     # Number of range_bins per meter
 
     # Useful conversions
-    ping_num = npings / ping_rate / ping_time_bin                      # number of pings to average over
-    range_bin_num = nrange / range_bin_per_meter / range_meter_bin     # number of range_bins to average over
-    total_range = nrange / range_bin_per_meter                         # total range in meters
+    ping_num = npings / ping_rate / ping_time_bin                           # number of pings to average over
+    range_bin_num = nrange_bins / range_bin_per_meter / range_meter_bin     # number of range_bins to average over
+    total_range = nrange_bins / range_bin_per_meter                         # total range in meters
 
     # Construct data with values that increase with range and time
     # so that when compute_MVBS is performed, the result is a smaller array
@@ -193,7 +193,7 @@ def test_compute_MVBS():
     data = _construct_MVBS_toy_data(
         nfreq=nfreq,
         npings=npings,
-        nrange=nrange,
+        nrange_bins=nrange_bins,
         ping_size=ping_rate * ping_time_bin,
         range_bin_size=range_bin_per_meter * range_meter_bin
     )
@@ -202,14 +202,14 @@ def test_compute_MVBS():
     freq_index = np.arange(nfreq)
     # Generate a date range with `npings` number of pings with the frequency of the ping_rate
     ping_time = pd.date_range('1/1/2020', periods=npings, freq=f'{1/ping_rate}S')
-    range_bin = np.arange(nrange)
+    range_bin = np.arange(nrange_bins)
     Sv = xr.DataArray(data_log, coords=[('frequency', freq_index),
                                         ('ping_time', ping_time),
                                         ('range_bin', range_bin)])
     Sv.name = "Sv"
     ds_Sv = Sv.to_dataset()
     ds_Sv = ds_Sv.assign(
-        range=xr.DataArray(np.array([[np.linspace(0, total_range, nrange)] * npings] * nfreq),
+        range=xr.DataArray(np.array([[np.linspace(0, total_range, nrange_bins)] * npings] * nfreq),
                            coords=Sv.coords)
     )
     ds_MVBS = ep.preprocess.compute_MVBS(

--- a/echopype/tests/test_preprocess.py
+++ b/echopype/tests/test_preprocess.py
@@ -65,7 +65,7 @@ def test_compute_MVBS_index_binning():
     # Construct data with values that increase every ping_num and range_bin_num
     # so that when compute_MVBS_index_binning is performed, the result is a smaller array
     # that increases by 1 for each row and column
-    data = np.zeros((nfreq, npings, nrange))
+    data = np.ones((nfreq, npings, nrange))
     for p_i, ping in enumerate(range(0, npings, ping_num)):
         for r_i, rb in enumerate(range(0, nrange, range_bin_num)):
             data[0, ping:ping + ping_num, rb:rb + range_bin_num] += r_i + p_i
@@ -81,7 +81,10 @@ def test_compute_MVBS_index_binning():
                                         ('range_bin', range_bin)])
     Sv.name = "Sv"
     ds_Sv = Sv.to_dataset()
-    ds_Sv = ds_Sv.assign(range=xr.DataArray(np.array([[np.linspace(0, 10, nrange)] * npings] * nfreq), coords=Sv.coords))
+    ds_Sv = ds_Sv.assign(
+        range=xr.DataArray(np.array([[np.linspace(0, 10, nrange)] * npings] * nfreq),
+                           coords=Sv.coords)
+    )
 
     # Binned MVBS test
     ds_MVBS = ep.preprocess.compute_MVBS_index_binning(
@@ -95,9 +98,9 @@ def test_compute_MVBS_index_binning():
 
     data_test = (10 ** (ds_MVBS.Sv / 10)).round().astype(int)    # Convert to linear domain
     # Test values along range_bin
-    assert np.all(data_test.isel(frequency=0, ping_time=0) == np.arange(nrange / range_bin_num))
+    assert np.all(data_test.isel(frequency=0, ping_time=0) == np.arange(nrange / range_bin_num) + 1)
     # Test values along ping time
-    assert np.all(data_test.isel(frequency=0, range_bin=0) == np.arange(npings / ping_num))
+    assert np.all(data_test.isel(frequency=0, range_bin=0) == np.arange(npings / ping_num) + 1)
 
 
 def test_compute_MVBS():
@@ -116,7 +119,7 @@ def test_compute_MVBS():
     # Construct data with values that increase with range and time
     # so that when compute_MVBS is performed, the result is a smaller array
     # that increases by 1 for each meter_bin and time_bin
-    data = np.zeros((nfreq, npings, nrange))
+    data = np.ones((nfreq, npings, nrange))
     for p_i, ping in enumerate(range(0, npings, ping_rate * ping_time_bin)):
         for r_i, rb in enumerate(range(0, nrange, range_bin_per_meter * range_meter_bin)):
             data[0, ping:ping + ping_rate * ping_time_bin, rb:rb + range_bin_per_meter * range_meter_bin] += r_i + p_i
@@ -146,6 +149,6 @@ def test_compute_MVBS():
 
     data_test = (10 ** (ds_MVBS.Sv / 10)).round().astype(int)    # Convert to linear domain
     # Test values along range_bin
-    assert np.all(data_test.isel(frequency=0, ping_time=0) == np.arange(range_bin_num))
+    assert np.all(data_test.isel(frequency=0, ping_time=0) == np.arange(range_bin_num) + 1)
     # Test values along ping time
-    assert np.all(data_test.isel(frequency=0, range=0) == np.arange(ping_num))
+    assert np.all(data_test.isel(frequency=0, range=0) == np.arange(ping_num) + 1)

--- a/echopype/tests/test_preprocess.py
+++ b/echopype/tests/test_preprocess.py
@@ -91,8 +91,9 @@ def _construct_MVBS_toy_data(nfreq, npings, nrange_bins, ping_size, range_bin_si
 
 
 def _construct_MVBS_test_data(nfreq, npings, nrange_bins):
-    """Construct data with values that increases regularly
-    every ping and range_bin
+    """Construct data for testing the toy data from
+    `_construct_MVBS_toy_data` after it has gone through the
+    MVBS calculation.
 
     Parameters
     ----------

--- a/echopype/tests/test_preprocess.py
+++ b/echopype/tests/test_preprocess.py
@@ -59,8 +59,8 @@ def test_compute_MVBS_index_binning():
 
     # Parameters for fake data
     nfreq, npings, nrange = 4, 40, 400
-    ping_num = 2             # number of pings to average over
-    range_bin_num = 3        # number of range_bins to average over
+    ping_num = 3             # number of pings to average over
+    range_bin_num = 7        # number of range_bins to average over
 
     # Construct data with values that increase every ping_num and range_bin_num
     # so that when compute_MVBS_index_binning is performed, the result is a smaller array
@@ -107,14 +107,16 @@ def test_compute_MVBS():
     """Test compute_MVBS on toy data"""
 
     # Parameters for fake data
-    nfreq, npings, nrange = 1, 60, 600
-    range_meter_bin = 5          # range in meters to average over
-    ping_time_bin = 5            # number of seconds to average over
+    nfreq, npings, nrange = 4, 100, 4000
+    range_meter_bin = 7          # range in meters to average over
+    ping_time_bin = 3            # number of seconds to average over
     ping_rate = 2                # Number of pings per second
     range_bin_per_meter = 30     # Number of range_bins per meter
-    ping_num = npings // ping_rate // ping_time_bin                      # number of pings to average over
-    range_bin_num = nrange // range_bin_per_meter // range_meter_bin     # number of range_bins to average over
-    total_range = nrange // range_bin_per_meter
+
+    # Useful conversions
+    ping_num = npings / ping_rate / ping_time_bin                      # number of pings to average over
+    range_bin_num = nrange / range_bin_per_meter / range_meter_bin     # number of range_bins to average over
+    total_range = nrange / range_bin_per_meter                         # total range in meters
 
     # Construct data with values that increase with range and time
     # so that when compute_MVBS is performed, the result is a smaller array
@@ -136,7 +138,10 @@ def test_compute_MVBS():
                                         ('range_bin', range_bin)])
     Sv.name = "Sv"
     ds_Sv = Sv.to_dataset()
-    ds_Sv = ds_Sv.assign(range=xr.DataArray(np.array([[np.linspace(0, total_range, nrange)] * npings] * nfreq), coords=Sv.coords))
+    ds_Sv = ds_Sv.assign(
+        range=xr.DataArray(np.array([[np.linspace(0, total_range, nrange)] * npings] * nfreq),
+                           coords=Sv.coords)
+    )
     ds_MVBS = ep.preprocess.compute_MVBS(
         ds_Sv,
         range_meter_bin=range_meter_bin,

--- a/echopype/tests/test_preprocess.py
+++ b/echopype/tests/test_preprocess.py
@@ -1,0 +1,97 @@
+import numpy as np
+import xarray as xr
+import echopype as ep
+
+
+def test_remove_noise():
+    # Create process object
+    nfreq, npings, nrange = 1, 10, 100
+    freq = np.arange(nfreq)
+    ping_index = np.arange(npings)
+    range_bin = np.arange(nrange)
+
+    # Test noise removal on toy data
+    data = np.ones(nrange)
+    # Insert noise points
+    np.put(data, 30, -30)
+    np.put(data, 60, -30)
+    # Add more pings
+    data = np.array([data] * npings)
+    # Make DataArray
+    Sv = xr.DataArray([data], coords=[('frequency', freq),
+                                      ('ping_time', ping_index),
+                                      ('range_bin', range_bin)])
+    Sv.name = "Sv"
+    ds_Sv = Sv.to_dataset()
+
+    ds_Sv = ds_Sv.assign(range=xr.DataArray(np.array([[np.linspace(0, 10, nrange)] * npings]), coords=Sv.coords))
+    ds_Sv = ds_Sv.assign(sound_absorption=0.001)
+    # Run noise removal
+    ds_Sv = ep.preprocess.remove_noise(ds_Sv, ping_num=2, range_bin_num=5, SNR_threshold=0)
+
+    # Test if noise points are are nan
+    assert np.isnan(ds_Sv.Sv_corrected.isel(frequency=0, ping_time=0, range_bin=30))
+    assert np.isnan(ds_Sv.Sv_corrected.isel(frequency=0, ping_time=0, range_bin=60))
+
+    # Test remove noise on a normal distribution
+    np.random.seed(1)
+    data = np.random.normal(loc=-100, scale=2, size=(nfreq, npings, nrange))
+    # Make DataArray
+    Sv = xr.DataArray(data, coords=[('frequency', freq),
+                                    ('ping_time', ping_index),
+                                    ('range_bin', range_bin)])
+    Sv.name = "Sv"
+    ds_Sv = Sv.to_dataset()
+
+    ds_Sv = ds_Sv.assign(range=xr.DataArray(np.array([[np.linspace(0, 3, nrange)] * npings]), coords=Sv.coords))
+    ds_Sv = ds_Sv.assign(sound_absorption=0.001)
+    # Run noise removal
+    ds_Sv = ep.preprocess.remove_noise(ds_Sv, ping_num=2, range_bin_num=5, SNR_threshold=0)
+    null = ds_Sv.Sv_corrected.isnull()
+    # Test to see if the right number of points are removed before the range gets too large
+    assert np.count_nonzero(null.isel(frequency=0, range_bin=slice(None, 50))) == 6
+
+
+def test_compute_MVBS_index_binning():
+    """Test get_MVBS on a normal distribution"""
+
+    # Parameters for fake data
+    nfreq, npings, nrange = 4, 40, 400
+    ping_num = 2             # number of pings to average over
+    range_bin_num = 3        # number of range_bins to average over
+
+    # Construct data with values that increase every ping_num and range_bin_num
+    # so that when binned get_MVBS is performed, the result is a smaller array
+    # that increases by 1 for each row and column
+    data = np.zeros((nfreq, npings, nrange))
+    for p_i, ping in enumerate(range(0, npings, ping_num)):
+        for r_i, rb in enumerate(range(0, nrange, range_bin_num)):
+            data[0, ping:ping + ping_num, rb:rb + range_bin_num] += r_i + p_i
+    for f in range(nfreq):
+        data[f] = data[0]
+
+    data_log = 10 * np.log10(data)      # Convert to log domain
+    freq_index = np.arange(nfreq)
+    ping_index = np.arange(npings)
+    range_bin = np.arange(nrange)
+    Sv = xr.DataArray(data_log, coords=[('frequency', freq_index),
+                                        ('ping_time', ping_index),
+                                        ('range_bin', range_bin)])
+    Sv.name = "Sv"
+    ds_Sv = Sv.to_dataset()
+    ds_Sv = ds_Sv.assign(range=xr.DataArray(np.array([[np.linspace(0, 10, nrange)] * npings] * nfreq), coords=Sv.coords))
+
+    # Binned MVBS test
+    ds_MVBS = ep.preprocess.compute_MVBS_index_binning(
+        ds_Sv,
+        range_bin_interval=range_bin_num,
+        ping_num_interval=ping_num
+    )
+    shape = (nfreq, npings / ping_num, nrange / range_bin_num)
+    assert np.all(ds_MVBS.Sv.shape == np.ceil(shape))  # Shape test
+
+    data_test = (10 ** (ds_MVBS.Sv / 10)).round().astype(int)    # Convert to linear domain
+    # Test values along range_bin
+    assert np.all(data_test.isel(frequency=0, ping_time=0) == np.arange(nrange / range_bin_num))
+    # Test values along ping time
+    assert np.all(data_test.isel(frequency=0, range_bin=0) == np.arange(npings / ping_num))


### PR DESCRIPTION
This PR adds a test for `remove_noise`, `compute_MVBS_index_binning`, and `get_MVBS`. These tests use fake data to test for an expected outcome.

The `remove_noise` test adds 2 points that do not match the background, and tests to see if they are removed. It also tests to see if the correct number of points are removed from a seeded normal distribution.

The `compute_MVBS_index_binning` test constructs data with values that increase every ping_num and range_bin_num so that when binned MVBS is performed, the result is a smaller array that increases by 1 for each row and column.

The `compute_MVBS` test is the same as the `compute_MVBS_index_binning` test only the data once averaged over seconds and meters gives a smaller array that increases by 1 for each `range_meter_bin` and `ping_time_bin`.