### PR TITLE
Remove unused assets from SetGroups

### DIFF
--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -4,8 +4,6 @@ Class to save unpacked echosounder data to appropriate groups in netcdf or zarr.
 import xarray as xr
 import numpy as np
 from .set_groups_base import SetGroupsBase
-from ..utils import io
-from .set_groups_base import DEFAULT_CHUNK_SIZE
 
 
 class SetGroupsAZFP(SetGroupsBase):

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -4,7 +4,6 @@ import xarray as xr
 import numpy as np
 import zarr
 from _echopype_version import version as ECHOPYPE_VERSION
-from ..utils import io
 
 COMPRESSION_SETTINGS = {
     'netcdf4': {'zlib': True, 'complevel': 4},

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -2,7 +2,6 @@ import xarray as xr
 import numpy as np
 from collections import defaultdict
 from .set_groups_base import SetGroupsBase
-from ..utils import io
 from .set_groups_base import DEFAULT_CHUNK_SIZE
 
 

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -2,9 +2,7 @@ from typing import List
 from collections import defaultdict
 import xarray as xr
 import numpy as np
-from ..utils import io
 from .set_groups_base import SetGroupsBase
-from .set_groups_base import DEFAULT_CHUNK_SIZE
 
 
 class SetGroupsEK80(SetGroupsBase):


### PR DESCRIPTION
Saving is now done in the EchoData, so the `save` function in SetGroups is no longer needed. This PR removes the `save` function from all of the SetGroups scripts. It also cleans up some imports.