### PR TITLE
Change AZFP ping_time date origin to 1900

### DIFF
--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -34,7 +34,7 @@ class SetGroupsAZFP(SetGroupsBase):
                                  'calendar': 'gregorian',
                                  'long_name': 'Timestamp of each ping',
                                  'standard_name': 'time',
-                                 'units': 'seconds since 1900-01-01'})},
+                                 'units': 'seconds since 1900-01-01 00:00:00Z'})},
                         attrs={'long_name': "Water temperature",
                                'units': "C"})
         return ds
@@ -142,7 +142,7 @@ class SetGroupsAZFP(SetGroupsBase):
                                                'calendar': 'gregorian',
                                                'long_name': 'Timestamp of each ping',
                                                'standard_name': 'time',
-                                               'units': 'seconds since 1900-01-01'}),
+                                               'units': 'seconds since 1900-01-01 00:00:00Z'}),
                                 'range_bin': (['range_bin'], range_bin)},
                         attrs={'beam_mode': '',
                                'conversion_equation_t': 'type_4',
@@ -209,7 +209,7 @@ class SetGroupsAZFP(SetGroupsBase):
                                'calendar': 'gregorian',
                                'long_name': 'Timestamp of each ping',
                                'standard_name': 'time',
-                               'units': 'seconds since 1900-01-01'}),
+                               'units': 'seconds since 1900-01-01 00:00:00Z'}),
                 'ancillary_len': (['ancillary_len'], list(range(len(unpacked_data['ancillary'][0])))),
                 'ad_len': (['ad_len'], list(range(len(unpacked_data['ad'][0]))))},
             attrs={

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -27,14 +27,14 @@ class SetGroupsAZFP(SetGroupsBase):
         """Set the Environment group.
         """
         # TODO Look at why this cannot be encoded without the modifications -- @ngkavin: what modification?
-        ping_time = (self.parser_obj.ping_time - np.datetime64('1970-01-01T00:00:00')) / np.timedelta64(1, 's')
+        ping_time = (self.parser_obj.ping_time - np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's')
         ds = xr.Dataset({'temperature': (['ping_time'], self.parser_obj.unpacked_data['temperature'])},
                         coords={'ping_time': (['ping_time'], ping_time,
                                 {'axis': 'T',
                                  'calendar': 'gregorian',
                                  'long_name': 'Timestamp of each ping',
                                  'standard_name': 'time',
-                                 'units': 'seconds since 1970-01-01'})},
+                                 'units': 'seconds since 1900-01-01'})},
                         attrs={'long_name': "Water temperature",
                                'units': "C"})
         return ds
@@ -209,7 +209,7 @@ class SetGroupsAZFP(SetGroupsBase):
                                'calendar': 'gregorian',
                                'long_name': 'Timestamp of each ping',
                                'standard_name': 'time',
-                               'units': 'seconds since 1970-01-01'}),
+                               'units': 'seconds since 1900-01-01'}),
                 'ancillary_len': (['ancillary_len'], list(range(len(unpacked_data['ancillary'][0])))),
                 'ad_len': (['ad_len'], list(range(len(unpacked_data['ad'][0]))))},
             attrs={

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -98,7 +98,7 @@ class SetGroupsBase:
         """
         # Save nan if nmea data is not encoded in the raw file
         if len(self.parser_obj.nmea['nmea_string']) != 0:
-            # Convert np.datetime64 numbers to seconds since 1900-01-01
+            # Convert np.datetime64 numbers to seconds since 1900-01-01 00:00:00Z
             # due to xarray.to_netcdf() error on encoding np.datetime64 objects directly
             time = (self.parser_obj.nmea['timestamp'] -
                     np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's')
@@ -116,7 +116,7 @@ class SetGroupsBase:
                                        'calendar': 'gregorian',
                                        'long_name': 'Timestamps for NMEA datagrams',
                                        'standard_name': 'time',
-                                       'units': 'seconds since 1900-01-01'})},
+                                       'units': 'seconds since 1900-01-01 00:00:00Z'})},
             attrs={'description': 'All NMEA sensor datagrams'})
 
         return ds

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -54,7 +54,7 @@ class SetGroupsEK60(SetGroupsBase):
                                          'calendar': 'gregorian',
                                          'long_name': 'Timestamps for NMEA position datagrams',
                                          'standard_name': 'time',
-                                         'units': 'seconds since 1900-01-01'})})
+                                         'units': 'seconds since 1900-01-01 00:00:00Z'})})
             # Attach frequency dimension/coordinate
             ds_tmp = ds_tmp.expand_dims(
                 {'frequency': [self.parser_obj.config_datagram['transceivers'][ch]['frequency']]})
@@ -68,7 +68,7 @@ class SetGroupsEK60(SetGroupsBase):
         # Merge data from all channels
         ds = xr.merge(ds_env)
 
-        # Convert np.datetime64 numbers to seconds since 1900-01-01
+        # Convert np.datetime64 numbers to seconds since 1900-01-01 00:00:00Z
         # due to xarray.to_netcdf() error on encoding np.datetime64 objects directly
         ds = ds.assign_coords({'ping_time': (['ping_time'], (ds['ping_time'] -
                                              np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's'),
@@ -120,11 +120,11 @@ class SetGroupsEK60(SetGroupsBase):
                                        'calendar': 'gregorian',
                                        'long_name': 'Timestamps for NMEA position datagrams',
                                        'standard_name': 'time',
-                                       'units': 'seconds since 1900-01-01'})})
+                                       'units': 'seconds since 1900-01-01 00:00:00Z'})})
         ds = ds.chunk({'location_time': DEFAULT_CHUNK_SIZE['ping_time']})
 
         if not NMEA_only:
-            # Convert np.datetime64 numbers to seconds since 1900-01-01
+            # Convert np.datetime64 numbers to seconds since 1900-01-01 00:00:00Z
             # due to xarray.to_netcdf() error on encoding np.datetime64 objects directly
             ch_ids = list(self.parser_obj.config_datagram['transceivers'].keys())
 
@@ -164,7 +164,7 @@ class SetGroupsEK60(SetGroupsBase):
                                            'calendar': 'gregorian',
                                            'long_name': 'Timestamps for position datagrams',
                                            'standard_name': 'time',
-                                           'units': 'seconds since 1900-01-01'})},
+                                           'units': 'seconds since 1900-01-01 00:00:00Z'})},
                     attrs={'platform_code_ICES': self.ui_param['platform_code_ICES'],
                            'platform_name': self.ui_param['platform_name'],
                            'platform_type': self.ui_param['platform_type']})
@@ -187,7 +187,7 @@ class SetGroupsEK60(SetGroupsBase):
             # Merge with NMEA data
             ds = xr.merge([ds, ds_plat], combine_attrs='override')
 
-            # Convert np.datetime64 numbers to seconds since 1900-01-01
+            # Convert np.datetime64 numbers to seconds since 1900-01-01 00:00:00Z
             # due to xarray.to_netcdf() error on encoding np.datetime64 objects directly
             ds = ds.assign_coords({
                 'ping_time': (['ping_time'],
@@ -361,7 +361,7 @@ class SetGroupsEK60(SetGroupsBase):
                                        'calendar': 'gregorian',
                                        'long_name': 'Timestamp of each ping',
                                        'standard_name': 'time',
-                                       'units': 'seconds since 1900-01-01'}),
+                                       'units': 'seconds since 1900-01-01 00:00:00Z'}),
                         'range_bin': (['range_bin'], np.arange(data_shape[1]))})
 
             # TODO: below needs to be changed to use self.convert_obj.ping_data_dict['mode'][ch] == 3

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -60,7 +60,7 @@ class SetGroupsEK80(SetGroupsBase):
                                            'calendar': 'gregorian',
                                            'long_name': 'Timestamp of each ping',
                                            'standard_name': 'time',
-                                           'units': 'seconds since 1900-01-01'})})
+                                           'units': 'seconds since 1900-01-01 00:00:00Z'})})
         # ds = ds.assign_coords({'ping_time': (['ping_time'], (ds['ping_time'] -
         #                                      np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's'),
         #                                      ds.ping_time.attrs)})
@@ -106,7 +106,7 @@ class SetGroupsEK80(SetGroupsBase):
                   'Value set to NaN.')
 
         location_time, msg_type, lat, lon = self._parse_NMEA()
-        # Convert MRU np.datetime64 numbers to seconds since 1900-01-01
+        # Convert MRU np.datetime64 numbers to seconds since 1900-01-01 00:00:00Z
         # due to xarray.to_netcdf() error on encoding np.datetime64 objects directly
         mru_time = self.parser_obj.mru.get('timestamp', None)
         mru_time = (np.array(mru_time) - np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's') if \
@@ -151,13 +151,13 @@ class SetGroupsEK80(SetGroupsBase):
                                   'calendar': 'gregorian',
                                   'long_name': 'Timestamps for MRU datagrams',
                                   'standard_name': 'time',
-                                  'units': 'seconds since 1900-01-01'}),
+                                  'units': 'seconds since 1900-01-01 00:00:00Z'}),
                     'location_time': (['location_time'], location_time,
                                       {'axis': 'T',
                                        'calendar': 'gregorian',
                                        'long_name': 'Timestamps for NMEA datagrams',
                                        'standard_name': 'time',
-                                       'units': 'seconds since 1900-01-01'})
+                                       'units': 'seconds since 1900-01-01 00:00:00Z'})
                     },
             attrs={'platform_code_ICES': self.ui_param['platform_code_ICES'],
                    'platform_name': self.ui_param['platform_name'],
@@ -283,7 +283,7 @@ class SetGroupsEK80(SetGroupsBase):
                                'calendar': 'gregorian',
                                'long_name': 'Timestamp of each ping',
                                'standard_name': 'time',
-                               'units': 'seconds since 1900-01-01'}),
+                               'units': 'seconds since 1900-01-01 00:00:00Z'}),
                 'range_bin': (['range_bin'], np.arange(data_shape[1])),
                 'quadrant': (['quadrant'], np.arange(num_transducer_sectors)),
             }
@@ -313,7 +313,7 @@ class SetGroupsEK80(SetGroupsBase):
                                    'calendar': 'gregorian',
                                    'long_name': 'Timestamp of each ping',
                                    'standard_name': 'time',
-                                   'units': 'seconds since 1900-01-01'}),
+                                   'units': 'seconds since 1900-01-01 00:00:00Z'}),
                 }
             )
             ds_tmp = xr.merge([ds_tmp, ds_f_start_end],
@@ -336,7 +336,7 @@ class SetGroupsEK80(SetGroupsBase):
                                'calendar': 'gregorian',
                                'long_name': 'Timestamp of each ping',
                                'standard_name': 'time',
-                               'units': 'seconds since 1900-01-01'}),
+                               'units': 'seconds since 1900-01-01 00:00:00Z'}),
                 'range_bin': (['range_bin'], np.arange(data_shape[1])),
             }
         )
@@ -388,7 +388,7 @@ class SetGroupsEK80(SetGroupsBase):
                                'calendar': 'gregorian',
                                'long_name': 'Timestamp of each ping',
                                'standard_name': 'time',
-                               'units': 'seconds since 1900-01-01'}),
+                               'units': 'seconds since 1900-01-01 00:00:00Z'}),
                 'range_bin': (['range_bin'], np.arange(range_bin_size)),
             }
         )
@@ -408,7 +408,7 @@ class SetGroupsEK80(SetGroupsBase):
             else:
                 ds_combine = xr.merge([ds_invariant_power, ds_combine],
                                       combine_attrs='override')  # override keeps the Dataset attributes
-            # Convert np.datetime64 numbers to seconds since 1900-01-01
+            # Convert np.datetime64 numbers to seconds since 1900-01-01 00:00:00Z
             #  due to xarray.to_netcdf() error on encoding np.datetime64 objects directly
             ds_combine = ds_combine.assign_coords(
                 {'ping_time': (['ping_time'], (ds_combine['ping_time']


### PR DESCRIPTION
The environment group used seconds since 1970. This was changed to 1900

The vendor group used both which resulted in an incorrect datetime. This is fixed.