### PR TITLE
Revert back to not do multi CPU on running tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
       - name: Running Tests
         shell: bash -l {0}
         run: |
-          python .ci_helpers/run-test.py --pytest-args="--numprocesses=4,--log-cli-level=WARNING,-vv,--disable-warnings" ${{ steps.files.outputs.added_modified }} |& tee ci_test_log.log
+          python .ci_helpers/run-test.py --pytest-args="--log-cli-level=WARNING,-vv,--disable-warnings" ${{ steps.files.outputs.added_modified }} |& tee ci_test_log.log
       - name: Upload ci test log
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This PR reverts back the pytest to not use multi CPU for now. Seems like the tests are not setup in a way to be able to handle these, causing some tests to failed even if they are passing when only using single CPU. Maybe in v0.5.1 we can improve to be able to do this! I think this is what's causing #328 to fail. Sorry @ngkavin! Once this is merged, you can close and reopen your PR, and things should pass. Trying to be fancy and speed up the tests, but I guess it wasn't that simple :stuck_out_tongue_closed_eyes: