### PR TITLE
Fix datetime inconsistency and add test

### DIFF
--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -3,7 +3,7 @@ Class to save unpacked echosounder data to appropriate groups in netcdf or zarr.
 """
 import xarray as xr
 import numpy as np
-from .set_groups_base import SetGroupsBase
+from .set_groups_base import SetGroupsBase, set_encodings
 
 
 class SetGroupsAZFP(SetGroupsBase):
@@ -13,17 +13,16 @@ class SetGroupsAZFP(SetGroupsBase):
         """Set the Environment group.
         """
         # TODO Look at why this cannot be encoded without the modifications -- @ngkavin: what modification?
-        ping_time = (self.parser_obj.ping_time - np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's')
+        ping_time = self.parser_obj.ping_time
         ds = xr.Dataset({'temperature': (['ping_time'], self.parser_obj.unpacked_data['temperature'])},
                         coords={'ping_time': (['ping_time'], ping_time,
                                 {'axis': 'T',
-                                 'calendar': 'gregorian',
                                  'long_name': 'Timestamp of each ping',
-                                 'standard_name': 'time',
-                                 'units': 'seconds since 1900-01-01 00:00:00Z'})},
+                                 'standard_name': 'time'})},
                         attrs={'long_name': "Water temperature",
                                'units': "C"})
-        return ds
+
+        return set_encodings(ds)
 
     def set_sonar(self) -> xr.Dataset:
         """Set the Sonar group.
@@ -61,7 +60,7 @@ class SetGroupsAZFP(SetGroupsBase):
         anc = np.array(unpacked_data['ancillary'])   # convert to np array for easy slicing
         dig_rate = unpacked_data['dig_rate']         # dim: freq
         freq = np.array(unpacked_data['frequency']) * 1000    # Frequency in Hz
-        ping_time = (self.parser_obj.ping_time - np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's')
+        ping_time = self.parser_obj.ping_time
 
         # Build variables in the output xarray Dataset
         N = []   # for storing backscatter_r values for each frequency
@@ -125,10 +124,8 @@ class SetGroupsAZFP(SetGroupsBase):
                                                'valid_min': 0.0}),
                                 'ping_time': (['ping_time'], ping_time,
                                               {'axis': 'T',
-                                               'calendar': 'gregorian',
                                                'long_name': 'Timestamp of each ping',
-                                               'standard_name': 'time',
-                                               'units': 'seconds since 1900-01-01 00:00:00Z'}),
+                                               'standard_name': 'time'}),
                                 'range_bin': (['range_bin'], range_bin)},
                         attrs={'beam_mode': '',
                                'conversion_equation_t': 'type_4',
@@ -151,7 +148,7 @@ class SetGroupsAZFP(SetGroupsBase):
                                'tilt_Y_b': parameters['Y_b'],
                                'tilt_Y_c': parameters['Y_c'],
                                'tilt_Y_d': parameters['Y_d']})
-        return ds
+        return set_encodings(ds)
 
     def set_vendor(self) -> xr.Dataset:
         """Set the Vendor-specific group.
@@ -159,7 +156,7 @@ class SetGroupsAZFP(SetGroupsBase):
         unpacked_data = self.parser_obj.unpacked_data
         parameters = self.parser_obj.parameters
         freq = np.array(unpacked_data['frequency']) * 1000    # Frequency in Hz
-        ping_time = (self.parser_obj.ping_time - np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's')
+        ping_time = self.parser_obj.ping_time
         tdn = np.array(parameters['pulse_length']) / 1e6
 
         ds = xr.Dataset(
@@ -192,10 +189,8 @@ class SetGroupsAZFP(SetGroupsBase):
                                'valid_min': 0.0}),
                 'ping_time': (['ping_time'], ping_time,
                               {'axis': 'T',
-                               'calendar': 'gregorian',
                                'long_name': 'Timestamp of each ping',
-                               'standard_name': 'time',
-                               'units': 'seconds since 1900-01-01 00:00:00Z'}),
+                               'standard_name': 'time'}),
                 'ancillary_len': (['ancillary_len'], list(range(len(unpacked_data['ancillary'][0])))),
                 'ad_len': (['ad_len'], list(range(len(unpacked_data['ad'][0]))))},
             attrs={
@@ -211,4 +206,4 @@ class SetGroupsAZFP(SetGroupsBase):
                 'phase': unpacked_data['phase'],
                 'number_of_channels': unpacked_data['num_chan']}
         )
-        return ds
+        return set_encodings(ds)

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -3,6 +3,8 @@ from datetime import datetime as dt
 import xarray as xr
 import numpy as np
 import zarr
+from cftime import num2date
+import pandas as pd
 from _echopype_version import version as ECHOPYPE_VERSION
 
 COMPRESSION_SETTINGS = {
@@ -14,6 +16,68 @@ DEFAULT_CHUNK_SIZE = {
     'range_bin': 25000,
     'ping_time': 2500
 }
+
+DEFAULT_ENCODINGS = {
+    'ping_time': {
+        'units': 'seconds since 1900-01-01T00:00:00+00:00',
+        'calendar': 'gregorian',
+        '_FillValue': -9999,
+        'dtype': np.dtype('int64'),
+    },
+    'mru_time': {
+        'units': 'seconds since 1900-01-01T00:00:00+00:00',
+        'calendar': 'gregorian',
+        '_FillValue': -9999,
+        'dtype': np.dtype('int64'),
+    },
+    'location_time': {
+        'units': 'seconds since 1900-01-01T00:00:00+00:00',
+        'calendar': 'gregorian',
+        '_FillValue': -9999,
+        'dtype': np.dtype('int64'),
+    }
+}
+
+
+def _round_datetimes(data, unit='s'):
+    """Round dates to nearest second"""
+    return pd.to_datetime(data).round(unit).values
+
+
+def set_encodings(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Set the default encoding for variables.
+    """
+    new_ds = ds.copy(deep=True)
+    for var, encoding in DEFAULT_ENCODINGS.items():
+        if var in new_ds:
+            da = new_ds[var].copy()
+            if "_time" in var:
+                if da.dtype in [np.float64, np.int64]:
+                    # Convert values to datetime for time variables
+                    new_ds[var] = xr.apply_ufunc(
+                        num2date,
+                        da,
+                        keep_attrs=True,
+                        kwargs={
+                            "units": encoding["units"],
+                            "calendar": encoding["calendar"],
+                            "only_use_cftime_datetimes": False,
+                            "only_use_python_datetimes": False
+                        })
+
+                # Round the dates to nearest second
+                # rather than nanosecond since it will get
+                # written into disk as such
+                new_ds[var] = xr.apply_ufunc(
+                    _round_datetimes,
+                    da,
+                    keep_attrs=True
+                )
+
+            new_ds[var].encoding = encoding
+
+    return new_ds
 
 
 class SetGroupsBase:

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -2,7 +2,7 @@ from typing import List
 from collections import defaultdict
 import xarray as xr
 import numpy as np
-from .set_groups_base import SetGroupsBase
+from .set_groups_base import SetGroupsBase, set_encodings
 
 
 class SetGroupsEK80(SetGroupsBase):
@@ -17,8 +17,7 @@ class SetGroupsEK80(SetGroupsBase):
         else:
             ping_time = list(self.parser_obj.ping_time.values())[0][0]
         # Select the first available ping_time
-        ping_time = np.array([(ping_time.astype('datetime64[ns]') -
-                               np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's')])
+        ping_time = np.array([ping_time.astype('datetime64[ns]')])
 
         # Collect variables
         ds = xr.Dataset({'temperature': (['ping_time'], [self.parser_obj.environment['temperature']]),
@@ -29,14 +28,9 @@ class SetGroupsEK80(SetGroupsBase):
                         coords={
                             'ping_time': (['ping_time'], ping_time,
                                           {'axis': 'T',
-                                           'calendar': 'gregorian',
                                            'long_name': 'Timestamp of each ping',
-                                           'standard_name': 'time',
-                                           'units': 'seconds since 1900-01-01 00:00:00Z'})})
-        # ds = ds.assign_coords({'ping_time': (['ping_time'], (ds['ping_time'] -
-        #                                      np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's'),
-        #                                      ds.ping_time.attrs)})
-        return ds
+                                           'standard_name': 'time'})})
+        return set_encodings(ds)
 
     def set_sonar(self) -> xr.Dataset:
         # Collect unique variables
@@ -78,11 +72,8 @@ class SetGroupsEK80(SetGroupsBase):
                   'Value set to NaN.')
 
         location_time, msg_type, lat, lon = self._parse_NMEA()
-        # Convert MRU np.datetime64 numbers to seconds since 1900-01-01 00:00:00Z
-        # due to xarray.to_netcdf() error on encoding np.datetime64 objects directly
         mru_time = self.parser_obj.mru.get('timestamp', None)
-        mru_time = (np.array(mru_time) - np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's') if \
-            mru_time is not None else [np.nan]
+        mru_time = np.array(mru_time) if mru_time is not None else [np.nan]
 
         # Assemble variables into a dataset: variables filled with nan if do not exist
         ds = xr.Dataset(
@@ -120,16 +111,12 @@ class SetGroupsEK80(SetGroupsBase):
             },
             coords={'mru_time': (['mru_time'], mru_time,
                                  {'axis': 'T',
-                                  'calendar': 'gregorian',
                                   'long_name': 'Timestamps for MRU datagrams',
-                                  'standard_name': 'time',
-                                  'units': 'seconds since 1900-01-01 00:00:00Z'}),
+                                  'standard_name': 'time'}),
                     'location_time': (['location_time'], location_time,
                                       {'axis': 'T',
-                                       'calendar': 'gregorian',
                                        'long_name': 'Timestamps for NMEA datagrams',
-                                       'standard_name': 'time',
-                                       'units': 'seconds since 1900-01-01 00:00:00Z'})
+                                       'standard_name': 'time'})
                     },
             attrs={'platform_code_ICES': self.ui_param['platform_code_ICES'],
                    'platform_name': self.ui_param['platform_name'],
@@ -137,7 +124,7 @@ class SetGroupsEK80(SetGroupsBase):
                    # TODO: check what this 'drop_keel_offset' is
                    'drop_keel_offset': (self.parser_obj.environment['drop_keel_offset'] if
                                         hasattr(self.parser_obj.environment, 'drop_keel_offset') else np.nan)})
-        return ds
+        return set_encodings(ds)
 
     def _assemble_ds_ping_invariant(self, params, data_type):
         """Assemble dataset for ping-invariant params in the Beam group.
@@ -252,10 +239,8 @@ class SetGroupsEK80(SetGroupsBase):
             coords={
                 'ping_time': (['ping_time'], self.parser_obj.ping_time[ch],
                               {'axis': 'T',
-                               'calendar': 'gregorian',
                                'long_name': 'Timestamp of each ping',
-                               'standard_name': 'time',
-                               'units': 'seconds since 1900-01-01 00:00:00Z'}),
+                               'standard_name': 'time'}),
                 'range_bin': (['range_bin'], np.arange(data_shape[1])),
                 'quadrant': (['quadrant'], np.arange(num_transducer_sectors)),
             }
@@ -282,16 +267,14 @@ class SetGroupsEK80(SetGroupsBase):
                 coords={
                     'ping_time': (['ping_time'], self.parser_obj.ping_time[ch],
                                   {'axis': 'T',
-                                   'calendar': 'gregorian',
                                    'long_name': 'Timestamp of each ping',
-                                   'standard_name': 'time',
-                                   'units': 'seconds since 1900-01-01 00:00:00Z'}),
+                                   'standard_name': 'time'}),
                 }
             )
             ds_tmp = xr.merge([ds_tmp, ds_f_start_end],
                               combine_attrs='override')  # override keeps the Dataset attributes
 
-        return ds_tmp
+        return set_encodings(ds_tmp)
 
     def _assemble_ds_power(self, ch):
         data_shape = self.parser_obj.ping_data_dict['power'][ch].shape
@@ -305,10 +288,8 @@ class SetGroupsEK80(SetGroupsBase):
             coords={
                 'ping_time': (['ping_time'], self.parser_obj.ping_time[ch],
                               {'axis': 'T',
-                               'calendar': 'gregorian',
                                'long_name': 'Timestamp of each ping',
-                               'standard_name': 'time',
-                               'units': 'seconds since 1900-01-01 00:00:00Z'}),
+                               'standard_name': 'time'}),
                 'range_bin': (['range_bin'], np.arange(data_shape[1])),
             }
         )
@@ -325,7 +306,7 @@ class SetGroupsEK80(SetGroupsBase):
                                         {'long_name': 'electrical alongship angle'}),
                 })
 
-        return ds_tmp
+        return set_encodings(ds_tmp)
 
     def _assemble_ds_common(self, ch, range_bin_size):
         """Variables common to complex and power/angle data.
@@ -357,14 +338,12 @@ class SetGroupsEK80(SetGroupsBase):
             coords={
                 'ping_time': (['ping_time'], self.parser_obj.ping_time[ch],
                               {'axis': 'T',
-                               'calendar': 'gregorian',
                                'long_name': 'Timestamp of each ping',
-                               'standard_name': 'time',
-                               'units': 'seconds since 1900-01-01 00:00:00Z'}),
+                               'standard_name': 'time'}),
                 'range_bin': (['range_bin'], np.arange(range_bin_size)),
             }
         )
-        return ds_common
+        return set_encodings(ds_common)
 
     def set_beam(self) -> List[xr.Dataset]:
         """Set the Beam group.
@@ -380,13 +359,7 @@ class SetGroupsEK80(SetGroupsBase):
             else:
                 ds_combine = xr.merge([ds_invariant_power, ds_combine],
                                       combine_attrs='override')  # override keeps the Dataset attributes
-            # Convert np.datetime64 numbers to seconds since 1900-01-01 00:00:00Z
-            #  due to xarray.to_netcdf() error on encoding np.datetime64 objects directly
-            ds_combine = ds_combine.assign_coords(
-                {'ping_time': (['ping_time'], (ds_combine['ping_time']
-                                               - np.datetime64('1900-01-01T00:00:00')) / np.timedelta64(1, 's'),
-                               ds_combine.ping_time.attrs)})
-            return ds_combine
+            return set_encodings(ds_combine)
             # # Save to file
             # io.save_file(ds_combine.chunk({'range_bin': DEFAULT_CHUNK_SIZE['range_bin'],
             #                                'ping_time': DEFAULT_CHUNK_SIZE['ping_time']}),


### PR DESCRIPTION
This PR fixes the inconsistencies between `open_raw` and `open_converted` on `*_time` variables. It does the following:
1. Set the encodings rather than attributes for `units` and `calendar`. Additionally the encoding also include the specific `dtype` and `fillvalue`, in this case `int64` and `-9999`.
2. Since the unit is seconds since, and xarray rounds the values to the nearest second, we also round during set groups.

I have also added test to ensure that the proper encoding/attribute are store correctly, and data arrays are equal.

Closes #329