### PR TITLE
Change echodata.to_netcdf/to_zarr to return nothing

### DIFF
--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -186,8 +186,6 @@ def to_file(
     # Link path to saved file with attribute as if from open_converted
     echodata.converted_raw_path = output_file
 
-    return echodata
-
 
 def _save_groups_to_file(echodata, output_path, engine, compress=True):
     """Serialize all groups to file."""


### PR DESCRIPTION
Currently `echodata.to_netcdf/to_zarr` would return an `EchoData` object. This PR changes that to return nothing, which is consistent with the xarray to_netcdf/to_zarr behavior and likely more the anticipated from users.