### PR TITLE
First input argument in `echodata.to_netcdf/zarr`

### DIFF
--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -141,7 +141,7 @@ class EchoData:
 
         return xr.open_dataset(filepath, group=group, engine=XARRAY_ENGINE_MAP[suffix])
 
-    def to_netcdf(self, save_path, **kwargs):
+    def to_netcdf(self, save_path=None, **kwargs):
         """Save content of EchoData to netCDF.
 
         Parameters
@@ -163,7 +163,7 @@ class EchoData:
 
         return to_file(self, "netcdf4", save_path=save_path, **kwargs)
 
-    def to_zarr(self, save_path, **kwargs):
+    def to_zarr(self, save_path=None, **kwargs):
         """Save content of EchoData to zarr.
 
         Parameters

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -141,7 +141,7 @@ class EchoData:
 
         return xr.open_dataset(filepath, group=group, engine=XARRAY_ENGINE_MAP[suffix])
 
-    def to_netcdf(self, **kwargs):
+    def to_netcdf(self, save_path, **kwargs):
         """Save content of EchoData to netCDF.
 
         Parameters
@@ -161,9 +161,9 @@ class EchoData:
         """
         from ..convert.api import to_file
 
-        return to_file(self, "netcdf4", **kwargs)
+        return to_file(self, "netcdf4", save_path=save_path, **kwargs)
 
-    def to_zarr(self, **kwargs):
+    def to_zarr(self, save_path, **kwargs):
         """Save content of EchoData to zarr.
 
         Parameters
@@ -183,7 +183,7 @@ class EchoData:
         """
         from ..convert.api import to_file
 
-        return to_file(self, "zarr", **kwargs)
+        return to_file(self, "zarr", save_path=save_path, **kwargs)
 
     # TODO: Remove below in future versions. They are for supporting old API calls.
     @property


### PR DESCRIPTION
This PR defaults the first input argument in `echodata.to_netcdf|zarr` the path to save the file to (`save_path`). Before users have to do `echodata.to_netcdf|zarr(save_path="some_path")`, which is a little redundant, and the operation actually would error out if `save_path` was not specified. The xarray/pandas design to have the first argument being the `save_path` is much more convenient and intuitive.