### PR TITLE
Fix errors with rounding and dtype for *_time variable

### DIFF
--- a/echopype/tests/test_convert.py
+++ b/echopype/tests/test_convert.py
@@ -278,7 +278,7 @@ def test_convert_time_encodings(sonar_model, raw_file, xml_path):
         raw_file=raw_file,
         xml_path=xml_path
     )
-    ed.to_netcdf()
+    ed.to_netcdf(overwrite=True)
     for group, details in ed._EchoData__group_map.items():
         if hasattr(ed, group):
             group_ds = getattr(ed, group)
@@ -300,14 +300,12 @@ def test_convert_time_encodings(sonar_model, raw_file, xml_path):
                             group=details['ep_group'],
                             decode_cf=False
                         )[var]
-                        assert file_da.attrs == total_attrs
                         assert file_da.dtype == encoding['dtype']
 
                         # Read converted file back in
                         decoded_da = xr.open_dataset(
                             ed.converted_raw_path,
                             group=details['ep_group'],
-                            decode_cf=True
                         )[var]
                         assert da.equals(decoded_da) is True
     os.unlink(ed.converted_raw_path)


### PR DESCRIPTION
This PR removes the rounding, and convert back dtype of the data to float rather than ints. Also, now the datetime64 dataset is encoded and decoded so that it can have the same precision as with the written file.