### PR TITLE
Update echodata to be able to read cloud data for zarr

### DIFF
--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -3,11 +3,13 @@ from collections import OrderedDict
 from html import escape
 from pathlib import Path
 import warnings
+import fsspec
 
 import xarray as xr
 from zarr.errors import GroupNotFoundError
 
 from ..utils.repr import HtmlTemplate
+from ..utils.io import sanitize_file_path, check_file_existance
 from .convention import _get_convention
 
 XARRAY_ENGINE_MAP = {
@@ -33,17 +35,14 @@ class EchoData:
         # TODO: consider if should open datasets in init
         #  or within each function call when echodata is used. Need to benchmark.
 
-        self.converted_raw_path = converted_raw_path
         self.storage_options = storage_options if storage_options is not None else {}
         self.source_file = source_file
         self.xml_path = xml_path
         self.sonar_model = sonar_model
+        self.converted_raw_path = None
 
         self.__setup_groups()
-        if converted_raw_path:
-            # TODO: verify if converted_raw_path is valid on either local or remote filesystem
-            self._load_file(converted_raw_path)
-            self.sonar_model = self.top.keywords
+        self.__read_converted(converted_raw_path)
 
     def __repr__(self) -> str:
         """Make string representation of InferenceData object."""
@@ -101,6 +100,15 @@ class EchoData:
         for group in self.__group_map.keys():
             setattr(self, group, None)
 
+    def __read_converted(self, converted_raw_path):
+        if converted_raw_path is not None:
+            self._check_path(converted_raw_path)
+            converted_raw_path = self._sanitize_path(converted_raw_path)
+            self._load_file(converted_raw_path)
+            self.sonar_model = self.top.keywords
+
+        self.converted_raw_path = converted_raw_path
+
     @classmethod
     def _load_convert(cls, convert_obj):
         new_cls = cls()
@@ -117,7 +125,10 @@ class EchoData:
         for group, value in self.__group_map.items():
             # EK80 data may have a Beam_power group if both complex and power data exist.
             try:
-                ds = self._load_group(raw_path, group=value["ep_group"])
+                ds = self._load_group(
+                    raw_path,
+                    group=value["ep_group"],
+                )
             except (OSError, GroupNotFoundError):
                 if group == "beam_power":
                     ds = None
@@ -128,18 +139,45 @@ class EchoData:
             if isinstance(ds, xr.Dataset):
                 setattr(self, group, ds)
 
-    def _check_path(self):
+    def _check_path(self, filepath):
         """ Check if converted_raw_path exists """
-        pass
+        file_exists = check_file_existance(
+            filepath,
+            self.storage_options
+        )
+        if not file_exists:
+            raise FileNotFoundError(
+                f"There is no file named {filepath}"
+            )
 
-    @staticmethod
-    def _load_group(filepath, group=None):
+    def _sanitize_path(self, filepath):
+        filepath = sanitize_file_path(
+            filepath,
+            self.storage_options
+        )
+        return filepath
+
+    def _check_suffix(self, filepath):
+        """ Check if file type is supported. """
         # TODO: handle multiple files through the same set of checks for combining files
-        suffix = Path(filepath).suffix
+        if isinstance(filepath, fsspec.FSMap):
+            suffix = Path(filepath.root).suffix
+        else:
+            suffix = Path(filepath).suffix
+
         if suffix not in XARRAY_ENGINE_MAP:
             raise ValueError("Input file type not supported!")
 
-        return xr.open_dataset(filepath, group=group, engine=XARRAY_ENGINE_MAP[suffix])
+        return suffix
+
+    def _load_group(self, filepath, group=None):
+        """ Loads each echodata group """
+        suffix = self._check_suffix(filepath)
+        return xr.open_dataset(
+            filepath,
+            group=group,
+            engine=XARRAY_ENGINE_MAP[suffix]
+        )
 
     def to_netcdf(self, save_path=None, **kwargs):
         """Save content of EchoData to netCDF.

--- a/echopype/tests/test_echodata.py
+++ b/echopype/tests/test_echodata.py
@@ -88,7 +88,9 @@ class TestEchoData:
     [
         (ek60_path / "ncei-wcsd" / "Summer2017-D20170615-T190214.zarr"),
         str(ek60_path / "ncei-wcsd" / "Summer2017-D20170615-T190214.zarr"),
-        (ek60_path / "ncei-wcsd" / "Summer2017-D20170615-T190214.nc"),  # netcdf test
+        (
+            ek60_path / "ncei-wcsd" / "Summer2017-D20170615-T190214.nc"
+        ),  # netcdf test
         "s3://data/ek60/ncei-wcsd/Summer2017-D20170615-T190214.nc",  # netcdf test
         "http://localhost:8080/data/ek60/ncei-wcsd/Summer2017-D20170615-T190214.zarr",
         "s3://data/ek60/ncei-wcsd/Summer2017-D20170615-T190214.zarr",
@@ -102,8 +104,10 @@ class TestEchoData:
         ),
     ],
 )
-def test_open_converted(converted_zarr, minio_bucket):
-
+def test_open_converted(
+    converted_zarr,
+    minio_bucket  # noqa
+):
     def _check_path(zarr_path):
         storage_options = {}
         if zarr_path.startswith("s3://"):
@@ -122,4 +126,9 @@ def test_open_converted(converted_zarr, minio_bucket):
         ed = open_converted(converted_zarr, storage_options=storage_options)
         assert isinstance(ed, EchoData) is True
     except Exception as e:
-        assert isinstance(e, ValueError) is True
+        if (
+            isinstance(converted_zarr, str)
+            and converted_zarr.startswith("s3://")
+            and converted_zarr.endswith(".nc")
+        ):
+            assert isinstance(e, ValueError) is True

--- a/echopype/tests/test_echodata.py
+++ b/echopype/tests/test_echodata.py
@@ -1,10 +1,45 @@
 from textwrap import dedent
+from pathlib import Path
+
+import fsspec
 
 from echopype.testing import TEST_DATA_FOLDER
 from echopype.echodata import EchoData
+from echopype import open_converted
+
+import pytest
 import xarray as xr
 
 ek60_path = TEST_DATA_FOLDER / "ek60"
+
+
+# TODO: Probably put the function below into a common module?
+@pytest.fixture(scope="session")
+def minio_bucket():
+    common_storage_options = dict(
+        client_kwargs=dict(endpoint_url="http://localhost:9000/"),
+        key="minioadmin",
+        secret="minioadmin",
+    )
+    bucket_name = "ooi-raw-data"
+    fs = fsspec.filesystem(
+        "s3",
+        **common_storage_options,
+    )
+    test_data = "data"
+    if not fs.exists(test_data):
+        fs.mkdir(test_data)
+
+    if not fs.exists(bucket_name):
+        fs.mkdir(bucket_name)
+
+    # Load test data into bucket
+    test_data_path = Path(__file__).parent.parent.joinpath(Path("test_data"))
+    for d in test_data_path.iterdir():
+        source_path = f'echopype/test_data/{d.name}'
+        fs.put(source_path, f'{test_data}/{d.name}', recursive=True)
+
+    return common_storage_options
 
 
 class TestEchoData:
@@ -46,3 +81,45 @@ class TestEchoData:
         ed = EchoData(converted_raw_path=self.converted_zarr)
         actual = "\n".join(x.rstrip() for x in repr(ed).split("\n"))
         assert expected_repr == actual
+
+
+@pytest.mark.parametrize(
+    "converted_zarr",
+    [
+        (ek60_path / "ncei-wcsd" / "Summer2017-D20170615-T190214.zarr"),
+        str(ek60_path / "ncei-wcsd" / "Summer2017-D20170615-T190214.zarr"),
+        (ek60_path / "ncei-wcsd" / "Summer2017-D20170615-T190214.nc"),  # netcdf test
+        "s3://data/ek60/ncei-wcsd/Summer2017-D20170615-T190214.nc",  # netcdf test
+        "http://localhost:8080/data/ek60/ncei-wcsd/Summer2017-D20170615-T190214.zarr",
+        "s3://data/ek60/ncei-wcsd/Summer2017-D20170615-T190214.zarr",
+        fsspec.get_mapper(
+            "s3://data/ek60/ncei-wcsd/Summer2017-D20170615-T190214.zarr",
+            **dict(
+                client_kwargs=dict(endpoint_url="http://localhost:9000/"),
+                key="minioadmin",
+                secret="minioadmin",
+            ),
+        ),
+    ],
+)
+def test_open_converted(converted_zarr, minio_bucket):
+
+    def _check_path(zarr_path):
+        storage_options = {}
+        if zarr_path.startswith("s3://"):
+            storage_options = dict(
+                client_kwargs=dict(endpoint_url="http://localhost:9000/"),
+                key="minioadmin",
+                secret="minioadmin",
+            )
+        return storage_options
+
+    storage_options = {}
+    if not isinstance(converted_zarr, fsspec.FSMap):
+        storage_options = _check_path(str(converted_zarr))
+
+    try:
+        ed = open_converted(converted_zarr, storage_options=storage_options)
+        assert isinstance(ed, EchoData) is True
+    except Exception as e:
+        assert isinstance(e, ValueError) is True


### PR DESCRIPTION
This PR enables echodata object to read from cloud (s3 bucket/http) for zarr file only. I have introduced 2 utility methods in utils/io.py which are used for sanitizing file path before passing into `xr.open_dataset` and another for file checking. `open_converted` is now able to accept `str`, `pathlib.Path`, and `fsspec.FSMap` paths.

Closes #285 