### PR TITLE
Change `compute_MVBS_index_binning` input argument names

### DIFF
--- a/echopype/preprocess/api.py
+++ b/echopype/preprocess/api.py
@@ -76,9 +76,9 @@ def compute_MVBS_index_binning(ds_Sv, range_bin_num=100, ping_num=100):
     ds_Sv : xr.Dataset
         dataset containing Sv and range [m]
     range_bin_num : int
-        number of sample bins to average along the ``range_bin`` dimensionm in index number, default to 100
+        number of samples to average along the ``range_bin`` dimension, default to 100
     ping_num : int
-        number of pings to average along the ``ping_time`` dimension, in index number, default to 100
+        number of pings to average, default to 100
 
     Returns
     -------
@@ -119,7 +119,7 @@ def estimate_noise(ds_Sv, ping_num, range_bin_num, noise_max=None):
     ping_num : int
         number of pings to obtain noise estimates
     range_bin_num : int
-        number of samples along range to obtain noise estimates
+        number of samples along the ``range_bin`` dimension to obtain noise estimates
     noise_max : float
         the upper limit for background noise expected under the operating conditions
 
@@ -146,7 +146,7 @@ def remove_noise(ds_Sv, ping_num, range_bin_num, noise_max=None, SNR_threshold=3
     ping_num : int
         number of pings to obtain noise estimates
     range_bin_num : int
-        number of samples along range to obtain noise estimates
+        number of samples along the ``range_bin`` dimension to obtain noise estimates
     noise_max : float
         the upper limit for background noise expected under the operating conditions
     SNR_threshold : float

--- a/echopype/process/process_deprecated.py
+++ b/echopype/process/process_deprecated.py
@@ -313,8 +313,8 @@ class Process():
 
         self.MVBS = preprocess.compute_MVBS_index_binning(
             proc_data,
-            range_bin_interval=range_bin_size,
-            ping_num_interval=ping_size
+            range_bin_num=range_bin_size,
+            ping_num=ping_size
         ).rename({'Sv': 'MVBS'})
         # Save results in object and as a netCDF file
         if save:

--- a/echopype/tests/test_preprocess.py
+++ b/echopype/tests/test_preprocess.py
@@ -150,8 +150,8 @@ def test_compute_MVBS_index_binning():
     # Binned MVBS test
     ds_MVBS = ep.preprocess.compute_MVBS_index_binning(
         ds_Sv,
-        range_bin_interval=range_bin_num,
-        ping_num_interval=ping_num
+        range_bin_num=range_bin_num,
+        ping_num=ping_num
     )
     data_test = (10 ** (ds_MVBS.Sv / 10))    # Convert to linear domain
 


### PR DESCRIPTION
This PR makes a very small change on the input argument names of `preprocess.compute_MVBS_index_binning` so that the argument names conform with those used in `remove_noise` and `estimate_noise`, since these methods are all based on sample numbers (number of samples along `range_bin` and number of pings), as opposed to `compute_MVBS` which is based on the physical units (meters and seconds).