### PR TITLE
Add ABC decorators to SetGroupsBase

### DIFF
--- a/echopype/convert/set_groups_ad2cp.py
+++ b/echopype/convert/set_groups_ad2cp.py
@@ -374,4 +374,4 @@ class SetGroupsAd2cp(SetGroupsBase):
         return set_encodings(ds)
 
     def set_sonar(self) -> xr.Dataset:
-        return xr.Dataset()
+        return super().set_sonar()

--- a/echopype/convert/set_groups_ad2cp.py
+++ b/echopype/convert/set_groups_ad2cp.py
@@ -374,4 +374,4 @@ class SetGroupsAd2cp(SetGroupsBase):
         return set_encodings(ds)
 
     def set_sonar(self) -> xr.Dataset:
-        return super().set_sonar()
+        return xr.Dataset()

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -196,7 +196,7 @@ class SetGroupsAZFP(SetGroupsBase):
         return set_encodings(ds)
 
     def set_beam_complex(self) -> xr.Dataset:
-        return super().set_beam_complex()
+        return xr.Dataset()
 
     def set_vendor(self) -> xr.Dataset:
         """Set the Vendor-specific group."""

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -195,6 +195,9 @@ class SetGroupsAZFP(SetGroupsBase):
         )
         return set_encodings(ds)
 
+    def set_beam_complex(self) -> xr.Dataset:
+        return super().set_beam_complex()
+
     def set_vendor(self) -> xr.Dataset:
         """Set the Vendor-specific group."""
         unpacked_data = self.parser_obj.unpacked_data

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -1,3 +1,5 @@
+import abc
+import pynmea2
 from datetime import datetime as dt
 
 import numpy as np
@@ -94,7 +96,7 @@ def set_encodings(ds: xr.Dataset) -> xr.Dataset:
     return new_ds
 
 
-class SetGroupsBase:
+class SetGroupsBase(abc.ABC):
     """Base class for saving groups to netcdf or zarr from echosounder data files."""
 
     def __init__(
@@ -162,22 +164,27 @@ class SetGroupsBase:
         ds = ds.assign_attrs(prov_dict)
         return ds
 
+    @abc.abstractmethod
     def set_env(self) -> xr.Dataset:
         """Set the Environment group."""
         pass
 
+    @abc.abstractmethod
     def set_sonar(self) -> xr.Dataset:
         """Set the Sonar group."""
         pass
 
+    @abc.abstractmethod
     def set_beam(self) -> xr.Dataset:
         """Set the Beam group."""
         pass
 
+    @abc.abstractmethod
     def set_beam_complex(self) -> xr.Dataset:
         """Set the Beam_complex group"""
         pass
 
+    @abc.abstractmethod
     def set_platform(self) -> xr.Dataset:
         """Set the Platform group."""
         pass
@@ -222,6 +229,7 @@ class SetGroupsBase:
 
         return ds
 
+    @abc.abstractmethod
     def set_vendor(self) -> xr.Dataset:
         """Set the Vendor group."""
         pass

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -1,5 +1,4 @@
 import abc
-import pynmea2
 from datetime import datetime as dt
 
 import numpy as np
@@ -166,32 +165,27 @@ class SetGroupsBase(abc.ABC):
 
     @abc.abstractmethod
     def set_env(self) -> xr.Dataset:
-        """Set the Environment group.
-        """
+        """Set the Environment group."""
         raise NotImplementedError
 
     @abc.abstractmethod
     def set_sonar(self) -> xr.Dataset:
-        """Set the Sonar group.
-        """
+        """Set the Sonar group."""
         raise NotImplementedError
 
     @abc.abstractmethod
     def set_beam(self) -> xr.Dataset:
-        """Set the Beam group.
-        """
+        """Set the Beam group."""
         raise NotImplementedError
 
     @abc.abstractmethod
     def set_beam_complex(self) -> xr.Dataset:
-        """Set the Beam_complex group
-        """
+        """Set the Beam_complex group"""
         raise NotImplementedError
 
     @abc.abstractmethod
     def set_platform(self) -> xr.Dataset:
-        """Set the Platform group.
-        """
+        """Set the Platform group."""
         raise NotImplementedError
 
     def set_nmea(self) -> xr.Dataset:
@@ -236,8 +230,7 @@ class SetGroupsBase(abc.ABC):
 
     @abc.abstractmethod
     def set_vendor(self) -> xr.Dataset:
-        """Set the Vendor group.
-        """
+        """Set the Vendor group."""
         raise NotImplementedError
 
     # TODO: move this to be part of parser as it is not a "set" operation

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -166,28 +166,33 @@ class SetGroupsBase(abc.ABC):
 
     @abc.abstractmethod
     def set_env(self) -> xr.Dataset:
-        """Set the Environment group."""
-        pass
+        """Set the Environment group.
+        """
+        raise NotImplementedError
 
     @abc.abstractmethod
     def set_sonar(self) -> xr.Dataset:
-        """Set the Sonar group."""
-        pass
+        """Set the Sonar group.
+        """
+        raise NotImplementedError
 
     @abc.abstractmethod
     def set_beam(self) -> xr.Dataset:
-        """Set the Beam group."""
-        pass
+        """Set the Beam group.
+        """
+        raise NotImplementedError
 
     @abc.abstractmethod
     def set_beam_complex(self) -> xr.Dataset:
-        """Set the Beam_complex group"""
-        pass
+        """Set the Beam_complex group
+        """
+        raise NotImplementedError
 
     @abc.abstractmethod
     def set_platform(self) -> xr.Dataset:
-        """Set the Platform group."""
-        pass
+        """Set the Platform group.
+        """
+        raise NotImplementedError
 
     def set_nmea(self) -> xr.Dataset:
         """Set the Platform/NMEA group."""
@@ -231,8 +236,9 @@ class SetGroupsBase(abc.ABC):
 
     @abc.abstractmethod
     def set_vendor(self) -> xr.Dataset:
-        """Set the Vendor group."""
-        pass
+        """Set the Vendor group.
+        """
+        raise NotImplementedError
 
     # TODO: move this to be part of parser as it is not a "set" operation
     def _parse_NMEA(self):

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -572,6 +572,9 @@ class SetGroupsEK60(SetGroupsBase):
 
         return set_encodings(ds)
 
+    def set_beam_complex(self) -> xr.Dataset:
+        return super().set_beam_complex()
+
     def set_vendor(self) -> xr.Dataset:
         # Retrieve pulse length and sa correction
         config = self.parser_obj.config_datagram["transceivers"]

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -573,7 +573,7 @@ class SetGroupsEK60(SetGroupsBase):
         return set_encodings(ds)
 
     def set_beam_complex(self) -> xr.Dataset:
-        return super().set_beam_complex()
+        return xr.Dataset()
 
     def set_vendor(self) -> xr.Dataset:
         # Retrieve pulse length and sa correction

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -654,7 +654,7 @@ class SetGroupsEK80(SetGroupsBase):
         return [ds_beam, ds_beam_power]
 
     def set_beam_complex(self) -> xr.Dataset:
-        return super().set_beam_complex()
+        return xr.Dataset()
 
     def set_vendor(self) -> xr.Dataset:
         """Set the Vendor-specific group."""

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -653,6 +653,9 @@ class SetGroupsEK80(SetGroupsBase):
 
         return [ds_beam, ds_beam_power]
 
+    def set_beam_complex(self) -> xr.Dataset:
+        return super().set_beam_complex()
+
     def set_vendor(self) -> xr.Dataset:
         """Set the Vendor-specific group."""
         config = self.parser_obj.config_datagram["configuration"]


### PR DESCRIPTION
Adds ABC decorators to SetGroupsBase. This will help to catch errors by requiring that subclasses of SetGroupsBase override the required methods.