### PR TITLE
Add version check for echopype installation

### DIFF
--- a/.ci_helpers/check-version.py
+++ b/.ci_helpers/check-version.py
@@ -1,0 +1,25 @@
+import argparse
+import sys
+
+import echopype
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Check current echopype version.")
+    parser.add_argument(
+        "expected_version",
+        type=str,
+        nargs="?",
+        default="0.5.0",
+        help="Expected Echopype Version to check",
+    )
+    args = parser.parse_args()
+    expected_version = args.expected_version
+    installed_version = echopype.__version__
+    if installed_version != expected_version:
+        print(
+            f"🛑 Installed version {installed_version} does not match expected version {expected_version}."  # noqa
+        )
+        sys.exit(1)
+    else:
+        print(f"✅ Installed version {installed_version} is expected.")
+        sys.exit(0)

--- a/.github/workflows/ep-install.yaml
+++ b/.github/workflows/ep-install.yaml
@@ -1,0 +1,52 @@
+name: EP Install Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_version:
+        description: 'Expected Echopype Version to check'
+        required: false
+        default: '0.5.0'
+
+jobs:
+  test-installs:
+    name: EP Install (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest", "macos-11"]
+    steps:
+      - name: Setup miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: echopype
+          miniconda-version: "latest"
+          environment-file: .ci_helpers/user_environment.yml
+          channel-priority: strict
+          show-channel-urls: true
+          use-only-tar-bz2: false
+      - name: Bash
+        if: contains(matrix.os, 'ubuntu')
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+
+          python .ci_helpers/check-version.py ${{ github.event.inputs.expected_version }}
+      - name: Sh
+        if: contains(matrix.os, 'macos')
+        shell: sh -l {0}
+        run: |
+          conda info
+          conda list
+
+          python .ci_helpers/check-version.py ${{ github.event.inputs.expected_version }}
+      - name: PowerShell
+        if: contains(matrix.os, 'windows')
+        shell: powershell
+        run: |
+          conda info
+          conda list
+
+          python .ci_helpers/check-version.py ${{ github.event.inputs.expected_version }}


### PR DESCRIPTION
This PR adds version check workflow that can be manually dispatched to test that echopype package is installed correctly from conda-forge.