### PR TITLE
Add docker-compose to dev requirement for contributors.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 black
 check-manifest
+docker-compose
 flake8
 flake8-builtins
 flake8-comprehensions


### PR DESCRIPTION
This PR adds `docker-compose` as part of the dev requirement so that users would have it rather than manually installing from docker instructions.