### PR TITLE
Fix __all__ by using strings

### DIFF
--- a/echopype/__init__.py
+++ b/echopype/__init__.py
@@ -7,4 +7,4 @@ from .convert.api import open_raw
 from .echodata.api import open_converted
 from .process import Process  # noqa
 
-__all__ = [open_raw, open_converted, calibrate]
+__all__ = ["open_raw", "open_converted", "calibrate"]

--- a/echopype/calibrate/__init__.py
+++ b/echopype/calibrate/__init__.py
@@ -1,3 +1,3 @@
 from .api import compute_Sp, compute_Sv
 
-__all__ = [compute_Sv, compute_Sp]
+__all__ = ["compute_Sv", "compute_Sp"]

--- a/echopype/echodata/__init__.py
+++ b/echopype/echodata/__init__.py
@@ -4,4 +4,4 @@ It is used for calibration and other processing.
 """
 from .echodata import EchoData
 
-__all__ = [EchoData]
+__all__ = ["EchoData"]

--- a/echopype/preprocess/__init__.py
+++ b/echopype/preprocess/__init__.py
@@ -1,3 +1,3 @@
 from .api import compute_MVBS, compute_MVBS_index_binning, remove_noise
 
-__all__ = [compute_MVBS, compute_MVBS_index_binning, remove_noise]
+__all__ = ["compute_MVBS", "compute_MVBS_index_binning", "remove_noise"]

--- a/echopype/qc/__init__.py
+++ b/echopype/qc/__init__.py
@@ -1,3 +1,3 @@
 from .api import coerce_increasing_time, exist_reversed_time
 
-__all__ = [coerce_increasing_time, exist_reversed_time]
+__all__ = ["coerce_increasing_time", "exist_reversed_time"]


### PR DESCRIPTION
This PR fixes `__all__` errors in docs. This variable should be passed in list of strings, not list of objects!