### PR TITLE
Add nmea to expected_repr in test_echodata.py

### DIFF
--- a/echopype/echodata/convention/1.0.yml
+++ b/echopype/echodata/convention/1.0.yml
@@ -22,7 +22,7 @@ groups:
     ep_group: Platform
   nmea:
     name: Platform/NMEA
-    description: contains information specific to the NMEA protocol
+    description: contains information specific to the NMEA protocol.
     ep_group: Platform/NMEA
   provenance:
     name: Provenance

--- a/echopype/tests/test_echodata.py
+++ b/echopype/tests/test_echodata.py
@@ -73,6 +73,7 @@ class TestEchoData:
               > top: (Top-level) contains metadata about the SONAR-netCDF4 file format.
               > environment: (Environment) contains information relevant to acoustic propagation through water.
               > platform: (Platform) contains information about the platform on which the sonar is installed.
+              > nmea: (Platform/NMEA) contains information specific to the NMEA protocol.
               > provenance: (Provenance) contains metadata about how the SONAR-netCDF4 version of the data were obtained.
               > sonar: (Sonar) contains specific metadata for the sonar system.
               > beam: (Beam) contains backscatter data and other beam or channel-specific data.


### PR DESCRIPTION
This PR adds the missing nmea entry to `expected_repr` in `test_echodata.py`.