### PR TITLE
Allow minor typing_extensions releases beyond 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ fsspec
 s3fs
 requests
 aiohttp
-typing-extensions~=3.10.0
+typing-extensions~=3.10


### PR DESCRIPTION
Changes the typing_extensions dependency version to be `~=3.10` instead of `~=3.10.0`. `~=3.10.0` will only allow `3.10.1`, `3.10.2`, etc., but `~=3.10` will allow `3.10.1, 3.10.2` and additionally `3.11.0, 3.11.1, 3.12.0, 3.13.0`, etc.