### PR TITLE
Determine AD2CP raw transmit based on header id

### DIFF
--- a/echopype/convert/parse_ad2cp.py
+++ b/echopype/convert/parse_ad2cp.py
@@ -437,16 +437,10 @@ class Ad2cpDataPacket:
                 raise ValueError("invalid burst/average data record version")
         elif self.data_exclude["id"] in (0x17, 0x1B):  # bottom track
             self.data_record_type = DataRecordType.BOTTOM_TRACK
-        elif self.data_exclude["id"] in (0x23, 0x24):  # echosounder raw
-            if (
-                self.parser.get_pulse_compressed() > 0
-                and len(self.parser.echosounder_raw_transmit_packets) == 0
-            ):
-                # first echosounder raw packet is the transmit packet
-                # if pulse compression is enabled
-                self.data_record_type = DataRecordType.ECHOSOUNDER_RAW_TRANSMIT
-            else:
-                self.data_record_type = DataRecordType.ECHOSOUNDER_RAW
+        elif self.data_exclude["id"] == 0x23:  # echosounder raw
+            self.data_record_type = DataRecordType.ECHOSOUNDER_RAW
+        elif self.data_exclude["id"] == 0x24:  # echosounder raw transmit
+            self.data_record_type = DataRecordType.ECHOSOUNDER_RAW_TRANSMIT
         elif self.data_exclude["id"] == 0x1A:  # burst altimeter
             # altimeter is only supported by burst/average version 3
             self.data_record_type = DataRecordType.BURST_VERSION3


### PR DESCRIPTION
Fixes a bug where raw transmit data is placed in `echosounder_raw_samples_i/q` instead of `echosounder_raw_transmit_samples_i/q` by interpreting any packet with the header id for echosounder raw transmit data as echosounder raw transmit data.