### PR TITLE
Allow AZFP extensions with more numbers and letters

### DIFF
--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -308,12 +308,11 @@ def _check_file(
     # TODO: https://github.com/OSOceanAcoustics/echopype/issues/229
     #  to add compatibility for pathlib.Path objects for local paths
     fsmap = fsspec.get_mapper(raw_file, **storage_options)
-    ext = SONAR_MODELS[sonar_model]["ext"]
+    validate_ext = SONAR_MODELS[sonar_model]["validate_ext"]
     if not fsmap.fs.exists(fsmap.root):
         raise FileNotFoundError(f"There is no file named {Path(raw_file).name}")
 
-    if Path(raw_file).suffix.upper() != ext.upper():
-        raise ValueError(f"Expecting a {ext} file but got {raw_file}")
+    validate_ext(Path(raw_file).suffix.upper())
 
     return str(raw_file), str(xml)
 

--- a/echopype/core.py
+++ b/echopype/core.py
@@ -32,7 +32,7 @@ def validate_azfp_ext(test_ext: str):
 
 def validate_ext(ext: str) -> Callable[[str], None]:
     def inner(test_ext: str):
-        if ext != test_ext:
+        if ext.casefold() != test_ext.casefold():
             raise ValueError(f"Expecting a {ext} file but got {test_ext}")
 
     return inner

--- a/echopype/tests/test_core.py
+++ b/echopype/tests/test_core.py
@@ -13,12 +13,16 @@ from ..core import SONAR_MODELS
     ("AZFP", ".12q"),
 
     ("EK60", ".raw"),
+    ("EK60", ".RAW"),
 
     ("EK80", ".raw"),
+    ("EK80", ".RAW"),
 
     ("EA640", ".raw"),
+    ("EA640", ".RAW"),
 
     ("AD2CP", ".ad2cp"),
+    ("AD2CP", ".AD2CP"),
 ])
 def test_file_extension_validation(sonar_model: "SonarModelsHint", ext: str):
     SONAR_MODELS[sonar_model]["validate_ext"](ext)

--- a/echopype/tests/test_core.py
+++ b/echopype/tests/test_core.py
@@ -1,0 +1,58 @@
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from ..core import SonarModelsHint
+from ..core import SONAR_MODELS
+
+@pytest.mark.parametrize(["sonar_model", "ext"], [
+    ("AZFP", ".01A"),
+    ("AZFP", ".01a"),
+    ("AZFP", ".05C"),
+    ("AZFP", ".12q"),
+
+    ("EK60", ".raw"),
+
+    ("EK80", ".raw"),
+
+    ("EA640", ".raw"),
+
+    ("AD2CP", ".ad2cp"),
+])
+def test_file_extension_validation(sonar_model: "SonarModelsHint", ext: str):
+    SONAR_MODELS[sonar_model]["validate_ext"](ext)
+
+
+@pytest.mark.parametrize(["sonar_model", "ext"], [
+    ("AZFP", ".001A"),
+    ("AZFP", ".01AA"),
+    ("AZFP", ".01aa"),
+    ("AZFP", ".05AA"),
+    ("AZFP", ".07!"),
+    ("AZFP", ".01!"),
+    ("AZFP", ".0!A"),
+    ("AZFP", ".012"),
+    ("AZFP", ".0AA"),
+    ("AZFP", ".AAA"),
+    ("AZFP", "01A"),
+
+    ("EK60", "raw"),
+    ("EK60", ".foo"),
+
+    ("EK80", "raw"),
+    ("EK80", ".foo"),
+
+    ("EA640", "raw"),
+    ("EA640", ".foo"),
+
+    ("AD2CP", "ad2cp"),
+    ("AD2CP", ".foo"),
+])
+def test_file_extension_validation_should_fail(sonar_model: "SonarModelsHint", ext: str):
+    try:
+        SONAR_MODELS[sonar_model]["validate_ext"](ext)
+    except ValueError:
+        pass
+    else:
+        raise ValueError(f"\"{ext}\" should have been rejected for sonar model {sonar_model}")


### PR DESCRIPTION
Allows any extension in the form ".XXY" where XX is a number and Y is a letter.

Fixes #418 