### PR TITLE
Fix calibration using old API

### DIFF
--- a/echopype/process/process_deprecated.py
+++ b/echopype/process/process_deprecated.py
@@ -49,6 +49,7 @@ class Process():
             env_params=self._env_params,
             cal_params=None,
             waveform_mode=self.waveform_mode,
+            encode_mode=self.encode_mode
         )
         # Deprecated data attributes
         self.Sv = None


### PR DESCRIPTION
This PR adds `encode_mode` to `process_deprecated.Process` to allow calibration using old API.