### PR TITLE
Add update_platform method to EchoData

### DIFF
--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -328,7 +328,7 @@ class EchoData:
             - `"longitude"`
             - `"water_level"`
 
-        Only `sonar_model`s of `"EK60"`, `"EK80"`, and `"EA640"` are currently supported.
+        Only `sonar_model`s of `"EK60"`, `"EK80"`, `"EA640"`, and `"AZFP"` are currently supported.
 
         Parameters
         ----------
@@ -342,7 +342,7 @@ class EchoData:
         Raises
         ------
         ValueError
-            If the `sonar_model` is not one of `"EK60"`, `"EK80"`, or `"EA640"`.
+            If the `sonar_model` is not one of `"EK60"`, `"EK80"`, `"EA640"`, or `"AZFP"`.
 
         Examples
         --------
@@ -365,6 +365,8 @@ class EchoData:
         if self.sonar_model in ["EK80", "EA640"]:
             time = "mru_time"
         elif self.sonar_model == "EK60":
+            time = "location_time"
+        elif self.sonar_model == "AZFP":
             time = "location_time"
         else:
             raise ValueError("unsupported sonar_model for adding platform data")

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -392,7 +392,7 @@ class EchoData:
 
         num_obs = len(extra_platform_data[time_dim])
 
-        def mapping_get_multiple(mapping, keys, default=None):
+        def mapping_search_variable(mapping, keys, default=None):
             for key in keys:
                 if key in mapping:
                     return mapping[key].data
@@ -402,7 +402,7 @@ class EchoData:
             {
                 "pitch": (
                     "time2",
-                    mapping_get_multiple(
+                    mapping_search_variable(
                         extra_platform_data,
                         ["pitch", "PITCH"],
                         platform.get("pitch", np.full(num_obs, np.nan)),
@@ -410,7 +410,7 @@ class EchoData:
                 ),
                 "roll": (
                     "time2",
-                    mapping_get_multiple(
+                    mapping_search_variable(
                         extra_platform_data,
                         ["roll", "ROLL"],
                         platform.get("roll", np.full(num_obs, np.nan)),
@@ -418,7 +418,7 @@ class EchoData:
                 ),
                 "heave": (
                     "time2",
-                    mapping_get_multiple(
+                    mapping_search_variable(
                         extra_platform_data,
                         ["heave", "HEAVE"],
                         platform.get("heave", np.full(num_obs, np.nan)),
@@ -426,7 +426,7 @@ class EchoData:
                 ),
                 "latitude": (
                     "time2",
-                    mapping_get_multiple(
+                    mapping_search_variable(
                         extra_platform_data,
                         ["lat", "latitude", "LATITUDE"],
                         default=platform.get("latitude", np.full(num_obs, np.nan)),
@@ -434,7 +434,7 @@ class EchoData:
                 ),
                 "longitude": (
                     "time2",
-                    mapping_get_multiple(
+                    mapping_search_variable(
                         extra_platform_data,
                         ["lon", "longitude", "LONGITUDE"],
                         default=platform.get("longitude", np.full(num_obs, np.nan)),
@@ -442,7 +442,7 @@ class EchoData:
                 ),
                 "water_level": (
                     "time2",
-                    mapping_get_multiple(
+                    mapping_search_variable(
                         extra_platform_data,
                         ["water_level", "WATER_LEVEL"],
                         default=platform.get("water_level", np.zeros(num_obs)),

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -354,7 +354,7 @@ class EchoData:
             extra_platform_data = extra_platform_data.sel(
                 {"trajectory": extra_platform_data["trajectory"][0]}
             )
-            extra_platform_data = extra_platform_data.drop("trajectory")
+            extra_platform_data = extra_platform_data.drop_vars("trajectory")
             extra_platform_data = extra_platform_data.swap_dims({"obs": "time"})
 
         if self.sonar_model in ["EK80", "EA640"]:

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -383,7 +383,7 @@ class EchoData:
                 dropped_vars.append(var)
         if len(dropped_vars) > 0:
             warnings.warn(
-                f"some variables will be overwritten by platform data: {', '.join(dropped_vars)}"
+                f"some variables in the original Platform group will be overwritten: {', '.join(dropped_vars)}"  # noqa
             )
         platform = platform.drop_vars(
             ["pitch", "roll", "heave", "latitude", "longitude", "water_level"],

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -357,11 +357,16 @@ class EchoData:
         # Handle data stored as a CF Trajectory Discrete Sampling Geometry
         # http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#trajectory-data
         # The Saildrone sample data file follows this convention
-        if ('featureType' in extra_platform_data.attrs and
-                extra_platform_data.attrs['featureType'].lower() == 'trajectory'):
+        if (
+            "featureType" in extra_platform_data.attrs
+            and extra_platform_data.attrs["featureType"].lower() == "trajectory"
+        ):
             for coordvar in extra_platform_data.coords:
-                if ('cf_role' in extra_platform_data[coordvar].attrs and
-                        extra_platform_data[coordvar].attrs['cf_role'] == 'trajectory_id'):
+                if (
+                    "cf_role" in extra_platform_data[coordvar].attrs
+                    and extra_platform_data[coordvar].attrs["cf_role"]
+                    == "trajectory_id"
+                ):
                     trajectory_var = coordvar
 
             # assumes there's only one trajectory in the dataset (index 0)

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -379,7 +379,7 @@ class EchoData:
 
         dropped_vars = []
         for var in ["pitch", "roll", "heave", "latitude", "longitude", "water_level"]:
-            if var in platform and platform[var].isnull().all():
+            if var in platform and (~platform[var].isnull()).all():
                 dropped_vars.append(var)
         if len(dropped_vars) > 0:
             warnings.warn(

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -378,7 +378,7 @@ class EchoData:
         def mapping_get_multiple(mapping, keys, default=None):
             for key in keys:
                 if key in mapping:
-                    return mapping[key]
+                    return mapping[key].data
             return default
 
         self.platform = platform.update(

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -373,6 +373,9 @@ class EchoData:
         platform = self.platform.assign_coords(
             time2=extra_platform_data[time_dim].values
         )
+        platform["time2"].attrs[
+            "long_name"
+        ] = "time dimension for external platform data"
 
         dropped_vars = []
         for var in ["pitch", "roll", "heave", "latitude", "longitude", "water_level"]:

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -445,7 +445,7 @@ class EchoData:
                     mapping_get_multiple(
                         extra_platform_data,
                         ["water_level", "WATER_LEVEL"],
-                        default=np.ones(num_obs),
+                        default=np.zeros(num_obs),
                     ),
                 ),
             }

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -9,6 +9,7 @@ from echopype import open_converted
 
 import pytest
 import xarray as xr
+import numpy as np
 
 ek60_path = TEST_DATA_FOLDER / "ek60"
 ek80_path = TEST_DATA_FOLDER / "ek80"
@@ -146,3 +147,20 @@ def test_compute_range(filepath, sonar_model, azfp_xml_path, azfp_cal_type, ek_w
     else:
         range = ed.compute_range(env_params, azfp_cal_type, ek_waveform_mode, )
         assert isinstance(range, xr.DataArray)
+
+def test_update_platform():
+    saildrone_path = ek80_path / "saildrone"
+    raw_file = saildrone_path / "SD2019_WCS_v05-Phase0-D20190617-T125959-0.raw"
+    extra_platform_data_file = saildrone_path / "saildrone-gen_5-fisheries-acoustics-code-sprint-sd1039-20190617T130000-20190618T125959-1_hz-v1.1595357449818.nc"
+
+    ed = echopype.open_raw(raw_file, "EK80")
+
+    updated = ["pitch", "roll", "latitude", "longitude", "water_level"]
+    for variable in updated:
+        assert np.isnan(ed.platform[variable].values).all()
+
+    extra_platform_data = xr.open_dataset(extra_platform_data_file)
+    ed.update_platform(extra_platform_data)
+
+    for variable in updated:
+        assert not np.isnan(ed.platform[variable].values).all()


### PR DESCRIPTION
Part of #201 

Adds an `EchoData.update_platform` method which can be used to update the `EchoData.platform` group with additional external platform data.

Partially adapted from https://github.com/ngkavin/echopype/pull/2, https://github.com/ngkavin/echopype/pull/3