### PR TITLE
Re-attach sonar_model to combined EchoData object

### DIFF
--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -291,4 +291,7 @@ def combine_echodata(echodatas: List[EchoData], combine_attrs="override") -> Ech
         )
         result.provenance = result.provenance.assign({f"{group}_attrs": attrs})
 
+    # Add back sonar model
+    result.sonar_model = sonar_model
+
     return result


### PR DESCRIPTION
Right now the combined EchoData object contains an empty `sonar_model` attribute, although the correct `sonar_model` selection and checking is in place. This PR re-attach that to the combined output.

I found out about this when trying to calibrate a combined EchoData object. 