### PR TITLE
Add removal note to deprecation warnings

### DIFF
--- a/echopype/convert/convert.py
+++ b/echopype/convert/convert.py
@@ -23,7 +23,7 @@ CONVERT_PARAMS = [
 # TODO: Used for backwards compatibility. Delete in future versions
 def ConvertEK80(_filename=""):
     warnings.warn(
-        "`ConvertEK80` is deprecated, use echopype.open_raw(raw_file, sonar_model='EK80', ...) instead.",  # noqa
+        "`ConvertEK80` is deprecated and will be removed in a future version, use echopype.open_raw(raw_file, sonar_model='EK80', ...) instead.",  # noqa
         DeprecationWarning,
         2,
     )
@@ -37,7 +37,7 @@ class Convert:
 
     def __new__(cls, file=None, xml_path=None, model=None, storage_options=None):
         warnings.warn(
-            "Calling `echopype.Convert` is deprecated, "
+            "Calling `echopype.Convert` is deprecated and will be removed in a future version, "
             "use `echopype.open_raw(raw_file, sonar_model, ...)` instead.",
             DeprecationWarning,
             2,

--- a/echopype/convert/convert.py
+++ b/echopype/convert/convert.py
@@ -23,7 +23,7 @@ CONVERT_PARAMS = [
 # TODO: Used for backwards compatibility. Delete in future versions
 def ConvertEK80(_filename=""):
     warnings.warn(
-        "`ConvertEK80` is deprecated and will be removed in a future version, use echopype.open_raw(raw_file, sonar_model='EK80', ...) instead.",  # noqa
+        "`ConvertEK80` is deprecated and will be removed in the next release, use echopype.open_raw(raw_file, sonar_model='EK80', ...) instead.",  # noqa
         DeprecationWarning,
         2,
     )
@@ -37,7 +37,7 @@ class Convert:
 
     def __new__(cls, file=None, xml_path=None, model=None, storage_options=None):
         warnings.warn(
-            "Calling `echopype.Convert` is deprecated and will be removed in a future version, "
+            "Calling `echopype.Convert` is deprecated and will be removed in the next release, "
             "use `echopype.open_raw(raw_file, sonar_model, ...)` instead.",
             DeprecationWarning,
             2,

--- a/echopype/process/process_deprecated.py
+++ b/echopype/process/process_deprecated.py
@@ -19,7 +19,8 @@ class Process():
     the new Calibrate and Preprocess functions under the hood.
     """
     def __init__(self, file_path="", salinity=27.9, pressure=59, temperature=None):
-        warnings.warn("Initializing a Process object is deprecated. "
+        warnings.warn("Initializing a Process object is deprecated "
+                      "and it will be removed in a future version. "
                       "More information on how to use the new processing "
                       "functions can be found in the echopype documentation.",
                       DeprecationWarning, 3)

--- a/echopype/process/process_deprecated.py
+++ b/echopype/process/process_deprecated.py
@@ -20,7 +20,7 @@ class Process():
     """
     def __init__(self, file_path="", salinity=27.9, pressure=59, temperature=None):
         warnings.warn("Initializing a Process object is deprecated "
-                      "and it will be removed in a future version. "
+                      "and it will be removed in the next release. "
                       "More information on how to use the new processing "
                       "functions can be found in the echopype documentation.",
                       DeprecationWarning, 3)


### PR DESCRIPTION
Adds an additional note to deprecation warnings stating that the deprecated types will be removed in a future version of echopype.