### PR TITLE
Add PathNotFoundError in _load_convert for open_converted

### DIFF
--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Dict, Optional
 import fsspec
 import numpy as np
 import xarray as xr
-from zarr.errors import GroupNotFoundError, PathNotFoundError
+from zarr.errors import PathNotFoundError
 
 if TYPE_CHECKING:
     from ..core import EngineHint, FileFormatHint, PathHint, SonarModelsHint
@@ -472,7 +472,7 @@ class EchoData:
                     raw_path,
                     group=value["ep_group"],
                 )
-            except (OSError, GroupNotFoundError, PathNotFoundError):
+            except (OSError, PathNotFoundError):
                 # Skips group not found errors for EK80 and ADCP
                 ...
             if group == "top" and hasattr(ds, "keywords"):

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Dict, Optional
 import fsspec
 import numpy as np
 import xarray as xr
-from zarr.errors import GroupNotFoundError
+from zarr.errors import GroupNotFoundError, PathNotFoundError
 
 if TYPE_CHECKING:
     from ..core import EngineHint, FileFormatHint, PathHint, SonarModelsHint
@@ -472,7 +472,7 @@ class EchoData:
                     raw_path,
                     group=value["ep_group"],
                 )
-            except (OSError, GroupNotFoundError):
+            except (OSError, GroupNotFoundError, PathNotFoundError):
                 # Skips group not found errors for EK80 and ADCP
                 ...
             if group == "top" and hasattr(ds, "keywords"):

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Dict, Optional
 import fsspec
 import numpy as np
 import xarray as xr
-from zarr.errors import PathNotFoundError
+from zarr.errors import GroupNotFoundError, PathNotFoundError
 
 if TYPE_CHECKING:
     from ..core import EngineHint, FileFormatHint, PathHint, SonarModelsHint
@@ -472,7 +472,7 @@ class EchoData:
                     raw_path,
                     group=value["ep_group"],
                 )
-            except (OSError, PathNotFoundError):
+            except (OSError, GroupNotFoundError, PathNotFoundError):
                 # Skips group not found errors for EK80 and ADCP
                 ...
             if group == "top" and hasattr(ds, "keywords"):


### PR DESCRIPTION
`open_converted` failed on opening Zarr file without the `beam_power` group. The allowed exception `GroupNotFoundError` appears to only work for netCDF files but not with Zarr files:
```python
PathNotFoundError: nothing found at path 'Beam_power'
```
Adding `PathNotFoundError` resolved the problem.

I also tested the case to only use `PathNotFoundError` _without_ `GroupNotFoundError` and that works for both local netCDF and Zarr files. 

From the zarr code here
https://github.com/zarr-developers/zarr-python/blob/master/zarr/errors.py
`GroupNotFoundError` is for when "group not found at path {0!r}"
and 
`PathNotFoundError` is for when "nothing found at path {0!r}"

@imranmaj @lsetiawan : If I understand correctly right now the `beam_power` group is _always_ created regardless of the sonar_model, but may be empty. So, there will be no case with exception `GroupNotFoundError`. Is this correct?

The current PR replaces `GroupNotFoundError` with `PathNotFoundError`.
