### PR TITLE
run-test.py can now accept and process touchedfiles in local mode

### DIFF
--- a/.ci_helpers/run-test.py
+++ b/.ci_helpers/run-test.py
@@ -60,16 +60,18 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.local:
         temp_path = Path("temp_echopype_output")
+        temp_path.mkdir(exist_ok=True)
         dump_path = Path("echopype/test_data/dump")
-        if temp_path.exists():
-            shutil.rmtree(temp_path)
-
-        if dump_path.exists():
-            shutil.rmtree(dump_path)
-        echopype_folder = Path("echopype")
-        file_list = glob.glob(str(echopype_folder / "**" / "*.py"), recursive=True)
+        dump_path.mkdir(exist_ok=True)
+        
+        if args.touchedfiles == "":
+            echopype_folder = Path("echopype")
+            file_list = glob.glob(str(echopype_folder / "**" / "*.py"), recursive=True)
+        else:
+            file_list = args.touchedfiles.split(",")
     else:
         file_list = args.touchedfiles.split(",")
+    
     pytest_args = []
     if args.pytest_args:
         pytest_args = args.pytest_args.split(",")


### PR DESCRIPTION
See https://github.com/OSOceanAcoustics/echopype/issues/387#issuecomment-932611642, pasted here:

@lsetiawan I was going through `run_test.py` to understand this functionality. It looks like the ability to test only a subset of modules, where those modules are passed as arguments at run time, does not apply to local runs (when `--local` is used). The `touchedfiles` arg is only [handled](https://github.com/OSOceanAcoustics/echopype/blob/main/.ci_helpers/run-test.py#L72) when `args.local` is False. Assuming I'm getting this right, it looks like it could be modified fairly easily for a local context by checking if `args.touchedfiles` is not empty. That would be handy!