### PR TITLE
Pinning s3fs to avoid the aiobotocore dependency issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ scipy
 xarray
 zarr
 fsspec
-s3fs
+s3fs==2021.10.1
 requests
 aiohttp
 typing-extensions~=3.10


### PR DESCRIPTION
## Overview

Seems like this is needed for s3fs. Currently, the dependency resolution in inconsistent, across installs, so I think it's better for us to pin the s3fs version, which pins the aiobotocore and fsspec.