### PR TITLE
add docs and docstring for sonar_model in open_raw

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx_rtd_theme
 sphinx-automodapi
 sphinxcontrib-mermaid
 numpydoc
+docutils<0.18

--- a/docs/source/convert.rst
+++ b/docs/source/convert.rst
@@ -39,7 +39,7 @@ create a fully parsed ``EchoData`` object.
 
 Use the parameter ``sonar_model`` to indicate the echosounder type:
     - ``EK60``: Kongsberg Simrad EK60 echosounder
-    - ``EK80``: Kongsberg Simrad EK60 and Kongsberg EA640 echsoounders
+    - ``EK80``: Kongsberg Simrad EK80 and Kongsberg EA640 echsoounders
     - ``AZFP``: ASL Environmental Sciences AZFP echosounder
     - ``AD2CP``: Nortek Signature series ADCP
       (tested with Signature 500 and Signature 1000)

--- a/docs/source/convert.rst
+++ b/docs/source/convert.rst
@@ -37,11 +37,14 @@ File conversion for different types of echosounders is achieved by
 using the single function ``open_raw`` to parse the raw data and
 create a fully parsed ``EchoData`` object.
 
-For data files from EK60, EK80 and  EA640 echosounders,
-use the parameter ``sonar_model`` to indicate the echosounder type,
-since there is no specific information in the extension ``.raw``
-that includes information about the echosounder type.
-In this example, ``open_raw`` is used to convert a raw EK80 file,
+Use the parameter ``sonar_model`` to indicate the echosounder type:
+    - ``EK60``: Kongsberg Simrad EK60 echosounder
+    - ``EK80``: Kongsberg Simrad EK60 and Kongsberg EA640 echsoounders
+    - ``AZFP``: ASL Environmental Sciences AZFP echosounder
+    - ``AD2CP``: Nortek Signature series ADCP
+      (tested with Signature 500 and Signature 1000)
+
+In the following example, ``open_raw`` is used to convert a raw EK80 file,
 return the EchoData object ``ed``, and generate a converted
 netCDF file named ``FILENAME.nc`` saved to the directory path
 ``./unpacked_files``:

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -337,7 +337,7 @@ def open_raw(
         model of the sonar instrument
 
         - ``EK60``: Kongsberg Simrad EK60 echosounder
-        - ``EK80``: Kongsberg Simrad EK60 and Kongsberg EA640 echsoounders
+        - ``EK80``: Kongsberg Simrad EK80 and Kongsberg EA640 echsoounders
         - ``AZFP``: ASL Environmental Sciences AZFP echosounder
         - ``AD2CP``: Nortek Signature series ADCP
           (tested with Signature 500 and Signature 1000)

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -335,6 +335,13 @@ def open_raw(
         path to raw data file
     sonar_model : str
         model of the sonar instrument
+
+        - ``EK60``: Kongsberg Simrad EK60 echosounder
+        - ``EK80``: Kongsberg Simrad EK60 and Kongsberg EA640 echsoounders
+        - ``AZFP``: ASL Environmental Sciences AZFP echosounder
+        - ``AD2CP``: Nortek Signature series ADCP
+          (tested with Signature 500 and Signature 1000)
+          
     xml_path : str
         path to XML config file used by AZFP
     convert_params : dict

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -341,7 +341,7 @@ def open_raw(
         - ``AZFP``: ASL Environmental Sciences AZFP echosounder
         - ``AD2CP``: Nortek Signature series ADCP
           (tested with Signature 500 and Signature 1000)
-          
+
     xml_path : str
         path to XML config file used by AZFP
     convert_params : dict


### PR DESCRIPTION
This PR addresses #461 by improving documentation and docstring for `open_raw`.