### PR TITLE
EchoData.update_platform: use location_time instead of time2; clip location_time range to EchoData.beam["ping_time"]; created utils/coding.py to centralize encodings

### DIFF
--- a/echopype/convert/set_groups_ad2cp.py
+++ b/echopype/convert/set_groups_ad2cp.py
@@ -3,8 +3,9 @@ from typing import List, Optional
 import numpy as np
 import xarray as xr
 
+from ..utils.coding import set_encodings
 from .parse_ad2cp import Ad2cpDataPacket, Field, HeaderOrDataRecordFormats
-from .set_groups_base import SetGroupsBase, set_encodings
+from .set_groups_base import SetGroupsBase
 
 
 def merge_attrs(datasets: List[xr.Dataset]) -> List[xr.Dataset]:

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -4,7 +4,8 @@ Class to save unpacked echosounder data to appropriate groups in netcdf or zarr.
 import numpy as np
 import xarray as xr
 
-from .set_groups_base import SetGroupsBase, set_encodings
+from ..utils.coding import set_encodings
+from .set_groups_base import SetGroupsBase
 
 
 class SetGroupsAZFP(SetGroupsBase):

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -4,68 +4,11 @@ from datetime import datetime as dt
 import numpy as np
 import pynmea2
 import xarray as xr
-import zarr
 from _echopype_version import version as ECHOPYPE_VERSION
-from xarray import coding
 
-COMPRESSION_SETTINGS = {
-    "netcdf4": {"zlib": True, "complevel": 4},
-    "zarr": {"compressor": zarr.Blosc(cname="zstd", clevel=3, shuffle=2)},
-}
+from ..utils.coding import COMPRESSION_SETTINGS, set_encodings
 
 DEFAULT_CHUNK_SIZE = {"range_bin": 25000, "ping_time": 2500}
-
-DEFAULT_TIME_ENCODING = {
-    "units": "seconds since 1900-01-01T00:00:00+00:00",
-    "calendar": "gregorian",
-    "_FillValue": np.nan,
-    "dtype": np.dtype("float64"),
-}
-
-DEFAULT_ENCODINGS = {
-    "ping_time": DEFAULT_TIME_ENCODING,
-    "ping_time_burst": DEFAULT_TIME_ENCODING,
-    "ping_time_average": DEFAULT_TIME_ENCODING,
-    "ping_time_echosounder": DEFAULT_TIME_ENCODING,
-    "ping_time_echosounder_raw": DEFAULT_TIME_ENCODING,
-    "ping_time_echosounder_raw_transmit": DEFAULT_TIME_ENCODING,
-    "location_time": DEFAULT_TIME_ENCODING,
-    "mru_time": DEFAULT_TIME_ENCODING,
-}
-
-
-def _encode_dataarray(da, dtype):
-    """Encodes and decode datetime64 array similar to writing to file"""
-    if da.size == 0:
-        return da
-    read_encoding = {
-        "units": "seconds since 1900-01-01T00:00:00+00:00",
-        "calendar": "gregorian",
-    }
-
-    if dtype in [np.float64, np.int64]:
-        encoded_data = da
-    else:
-        encoded_data, _, _ = coding.times.encode_cf_datetime(da, **read_encoding)
-    return coding.times.decode_cf_datetime(encoded_data, **read_encoding)
-
-
-def set_encodings(ds: xr.Dataset) -> xr.Dataset:
-    """
-    Set the default encoding for variables.
-    """
-    new_ds = ds.copy(deep=True)
-    for var, encoding in DEFAULT_ENCODINGS.items():
-        if var in new_ds:
-            da = new_ds[var].copy()
-            if "_time" in var:
-                new_ds[var] = xr.apply_ufunc(
-                    _encode_dataarray, da, keep_attrs=True, kwargs={"dtype": da.dtype}
-                )
-
-            new_ds[var].encoding = encoding
-
-    return new_ds
 
 
 class SetGroupsBase(abc.ABC):

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -6,7 +6,8 @@ import numpy as np
 import xarray as xr
 from _echopype_version import version as ECHOPYPE_VERSION
 
-from .set_groups_base import DEFAULT_CHUNK_SIZE, SetGroupsBase, set_encodings
+from ..utils.coding import set_encodings
+from .set_groups_base import DEFAULT_CHUNK_SIZE, SetGroupsBase
 
 
 class SetGroupsEK60(SetGroupsBase):

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -4,7 +4,8 @@ from typing import List
 import numpy as np
 import xarray as xr
 
-from .set_groups_base import SetGroupsBase, set_encodings
+from ..utils.coding import set_encodings
+from .set_groups_base import SetGroupsBase
 
 
 class SetGroupsEK80(SetGroupsBase):

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -375,6 +375,15 @@ class EchoData:
             extra_platform_data = extra_platform_data.drop_vars(trajectory_var)
             extra_platform_data = extra_platform_data.swap_dims({"obs": time_dim})
 
+        extra_platform_data = extra_platform_data.sel(
+            {
+                time_dim: np.logical_and(
+                    self.beam["ping_time"].min() < extra_platform_data[time_dim],
+                    extra_platform_data[time_dim] < self.beam["ping_time"].max(),
+                )
+            }
+        )
+
         platform = self.platform
         platform = platform.drop_dims("location_time", errors="ignore")
         platform = platform.assign_coords(

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -331,7 +331,8 @@ class EchoData:
             - `"latitude"`
             - `"longitude"`
             - `"water_level"`
-        The data inserted into the Platform group will be indexed by a dimension named `"time2"`.
+        The data inserted into the Platform group will be indexed by a dimension named
+        `"location_time"`.
 
         Parameters
         ----------
@@ -374,10 +375,12 @@ class EchoData:
             extra_platform_data = extra_platform_data.drop_vars(trajectory_var)
             extra_platform_data = extra_platform_data.swap_dims({"obs": time_dim})
 
-        platform = self.platform.assign_coords(
-            time2=extra_platform_data[time_dim].values
+        platform = self.platform
+        platform = platform.drop_dims("location_time", errors="ignore")
+        platform = platform.assign_coords(
+            location_time=extra_platform_data[time_dim].values
         )
-        platform["time2"].attrs[
+        platform["location_time"].attrs[
             "long_name"
         ] = "time dimension for external platform data"
 
@@ -405,7 +408,7 @@ class EchoData:
         self.platform = platform.update(
             {
                 "pitch": (
-                    "time2",
+                    "location_time",
                     mapping_search_variable(
                         extra_platform_data,
                         ["pitch", "PITCH"],
@@ -413,7 +416,7 @@ class EchoData:
                     ),
                 ),
                 "roll": (
-                    "time2",
+                    "location_time",
                     mapping_search_variable(
                         extra_platform_data,
                         ["roll", "ROLL"],
@@ -421,7 +424,7 @@ class EchoData:
                     ),
                 ),
                 "heave": (
-                    "time2",
+                    "location_time",
                     mapping_search_variable(
                         extra_platform_data,
                         ["heave", "HEAVE"],
@@ -429,7 +432,7 @@ class EchoData:
                     ),
                 ),
                 "latitude": (
-                    "time2",
+                    "location_time",
                     mapping_search_variable(
                         extra_platform_data,
                         ["lat", "latitude", "LATITUDE"],
@@ -437,7 +440,7 @@ class EchoData:
                     ),
                 ),
                 "longitude": (
-                    "time2",
+                    "location_time",
                     mapping_search_variable(
                         extra_platform_data,
                         ["lon", "longitude", "LONGITUDE"],
@@ -445,7 +448,7 @@ class EchoData:
                     ),
                 ),
                 "water_level": (
-                    "time2",
+                    "location_time",
                     mapping_search_variable(
                         extra_platform_data,
                         ["water_level", "WATER_LEVEL"],

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -470,8 +470,13 @@ class EchoData:
         )
         if extra_platform_data_file_name:
             history_attr += ", from file " + extra_platform_data_file_name
-        location_time_attrs = {**DEFAULT_PLATFORM_COORD_ATTRS['location_time'], **{'history': history_attr}}
-        platform["location_time"] = platform["location_time"].assign_attrs(**location_time_attrs)
+        location_time_attrs = {
+            **DEFAULT_PLATFORM_COORD_ATTRS["location_time"],
+            **{"history": history_attr},
+        }
+        platform["location_time"] = platform["location_time"].assign_attrs(
+            **location_time_attrs
+        )
 
         dropped_vars = []
         for var in ["pitch", "roll", "heave", "latitude", "longitude", "water_level"]:

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -32,9 +32,11 @@ TVG_CORRECTION_FACTOR = {
 }
 
 DEFAULT_PLATFORM_COORD_ATTRS = {
-    "axis": "T",
-    "long_name": "Timestamps for NMEA datagrams",
-    "standard_name": "time",
+    "location_time": {
+        "axis": "T",
+        "long_name": "Timestamps for NMEA datagrams",
+        "standard_name": "time",
+    }
 }
 
 # ---- Duplicated everything in this block from ..convert.set_groups_base -----
@@ -73,6 +75,7 @@ def _encode_dataarray(da, dtype):
         encoded_data, _, _ = coding.times.encode_cf_datetime(da, **read_encoding)
     return coding.times.decode_cf_datetime(encoded_data, **read_encoding)
 
+
 def set_encodings(ds: xr.Dataset) -> xr.Dataset:
     """
     Set the default encoding for variables.
@@ -90,6 +93,7 @@ def set_encodings(ds: xr.Dataset) -> xr.Dataset:
 
     return new_ds
 # ------------ End of duplicated block ----------------------------------------
+
 
 class EchoData:
     """Echo data model class for handling raw converted data,
@@ -459,11 +463,11 @@ class EchoData:
         platform = platform.assign_coords(
             location_time=extra_platform_data[time_dim].values
         )
-        platform["location_time"].assign_attrs(**DEFAULT_PLATFORM_COORD_ATTRS)
         history_attr = f"{datetime.datetime.utcnow()} +00:00. Added from external platform data"
         if extra_platform_data_file_name:
             history_attr += ", from file " + extra_platform_data_file_name
-        platform["location_time"].assign_attrs(history=history_attr)
+        location_time_attrs = {**DEFAULT_PLATFORM_COORD_ATTRS['location_time'], **{'history': history_attr}}
+        platform["location_time"] = platform["location_time"].assign_attrs(**location_time_attrs)
 
         dropped_vars = []
         for var in ["pitch", "roll", "heave", "latitude", "longitude", "water_level"]:

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -9,16 +9,15 @@ from typing import TYPE_CHECKING, Dict, Optional
 import fsspec
 import numpy as np
 import xarray as xr
-from xarray import coding
 from zarr.errors import GroupNotFoundError, PathNotFoundError
 
 if TYPE_CHECKING:
     from ..core import EngineHint, FileFormatHint, PathHint, SonarModelsHint
 
+from ..utils.coding import set_encodings
 from ..utils.io import check_file_existence, sanitize_file_path
 from ..utils.repr import HtmlTemplate
 from ..utils.uwa import calc_sound_speed
-# from ..convert.set_groups_base import set_encodings
 from .convention import _get_convention
 
 XARRAY_ENGINE_MAP: Dict["FileFormatHint", "EngineHint"] = {
@@ -38,63 +37,6 @@ DEFAULT_PLATFORM_COORD_ATTRS = {
         "standard_name": "time",
     }
 }
-
-# ---- Duplicated everything in this block from ..convert.set_groups_base -----
-# ---- to circumvent circular imports error
-DEFAULT_TIME_ENCODING = {
-    "units": "seconds since 1900-01-01T00:00:00+00:00",
-    "calendar": "gregorian",
-    "_FillValue": np.nan,
-    "dtype": np.dtype("float64"),
-}
-
-DEFAULT_ENCODINGS = {
-    "ping_time": DEFAULT_TIME_ENCODING,
-    "ping_time_burst": DEFAULT_TIME_ENCODING,
-    "ping_time_average": DEFAULT_TIME_ENCODING,
-    "ping_time_echosounder": DEFAULT_TIME_ENCODING,
-    "ping_time_echosounder_raw": DEFAULT_TIME_ENCODING,
-    "ping_time_echosounder_raw_transmit": DEFAULT_TIME_ENCODING,
-    "location_time": DEFAULT_TIME_ENCODING,
-    "mru_time": DEFAULT_TIME_ENCODING,
-}
-
-
-def _encode_dataarray(da, dtype):
-    """Encodes and decode datetime64 array similar to writing to file"""
-    if da.size == 0:
-        return da
-    read_encoding = {
-        "units": "seconds since 1900-01-01T00:00:00+00:00",
-        "calendar": "gregorian",
-    }
-
-    if dtype in [np.float64, np.int64]:
-        encoded_data = da
-    else:
-        encoded_data, _, _ = coding.times.encode_cf_datetime(da, **read_encoding)
-    return coding.times.decode_cf_datetime(encoded_data, **read_encoding)
-
-
-def set_encodings(ds: xr.Dataset) -> xr.Dataset:
-    """
-    Set the default encoding for variables.
-    """
-    new_ds = ds.copy(deep=True)
-    for var, encoding in DEFAULT_ENCODINGS.items():
-        if var in new_ds:
-            da = new_ds[var].copy()
-            if "_time" in var:
-                new_ds[var] = xr.apply_ufunc(
-                    _encode_dataarray, da, keep_attrs=True, kwargs={"dtype": da.dtype}
-                )
-
-            new_ds[var].encoding = encoding
-
-    return new_ds
-
-
-# ------------ End of duplicated block ----------------------------------------
 
 
 class EchoData:

--- a/echopype/tests/convert/test_convert.py
+++ b/echopype/tests/convert/test_convert.py
@@ -14,7 +14,7 @@ import xarray as xr
 import pytest
 from echopype import open_raw
 from echopype.testing import TEST_DATA_FOLDER
-from echopype.convert.set_groups_base import DEFAULT_ENCODINGS
+from echopype.utils.coding import DEFAULT_ENCODINGS
 
 
 def _check_file_group(data_file, engine, groups):

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -151,7 +151,8 @@ def test_compute_range(filepath, sonar_model, azfp_xml_path, azfp_cal_type, ek_w
 def test_update_platform():
     saildrone_path = ek80_path / "saildrone"
     raw_file = saildrone_path / "SD2019_WCS_v05-Phase0-D20190617-T125959-0.raw"
-    extra_platform_data_file = saildrone_path / "saildrone-gen_5-fisheries-acoustics-code-sprint-sd1039-20190617T130000-20190618T125959-1_hz-v1.1595357449818.nc"
+    extra_platform_data_file_name = "saildrone-gen_5-fisheries-acoustics-code-sprint-sd1039-20190617T130000-20190618T125959-1_hz-v1.1595357449818.nc"
+    extra_platform_data_file = saildrone_path / extra_platform_data_file_name
 
     ed = echopype.open_raw(raw_file, "EK80")
 
@@ -160,7 +161,10 @@ def test_update_platform():
         assert np.isnan(ed.platform[variable].values).all()
 
     extra_platform_data = xr.open_dataset(extra_platform_data_file)
-    ed.update_platform(extra_platform_data)
+    ed.update_platform(
+        extra_platform_data,
+        extra_platform_data_file_name=extra_platform_data_file_name
+    )
 
     for variable in updated:
         assert not np.isnan(ed.platform[variable].values).all()

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -1,0 +1,69 @@
+import numpy as np
+import xarray as xr
+import zarr
+from xarray import coding
+
+COMPRESSION_SETTINGS = {
+    "netcdf4": {"zlib": True, "complevel": 4},
+    "zarr": {"compressor": zarr.Blosc(cname="zstd", clevel=3, shuffle=2)},
+}
+
+DEFAULT_TIME_ENCODING = {
+    "units": "seconds since 1900-01-01T00:00:00+00:00",
+    "calendar": "gregorian",
+    "_FillValue": np.nan,
+    "dtype": np.dtype("float64"),
+}
+
+
+DEFAULT_ENCODINGS = {
+    "ping_time": DEFAULT_TIME_ENCODING,
+    "ping_time_burst": DEFAULT_TIME_ENCODING,
+    "ping_time_average": DEFAULT_TIME_ENCODING,
+    "ping_time_echosounder": DEFAULT_TIME_ENCODING,
+    "ping_time_echosounder_raw": DEFAULT_TIME_ENCODING,
+    "ping_time_echosounder_raw_transmit": DEFAULT_TIME_ENCODING,
+    "location_time": DEFAULT_TIME_ENCODING,
+    "mru_time": DEFAULT_TIME_ENCODING,
+}
+
+
+def _encode_dataarray(da, dtype):
+    """Encodes and decode datetime64 array similar to writing to file"""
+    if da.size == 0:
+        return da
+    read_encoding = {
+        "units": "seconds since 1900-01-01T00:00:00+00:00",
+        "calendar": "gregorian",
+    }
+
+    if dtype in [np.float64, np.int64]:
+        encoded_data = da
+    else:
+        # fmt: off
+        encoded_data, _, _ = coding.times.encode_cf_datetime(
+            da, **read_encoding
+        )
+        # fmt: on
+    return coding.times.decode_cf_datetime(encoded_data, **read_encoding)
+
+
+def set_encodings(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Set the default encoding for variables.
+    """
+    new_ds = ds.copy(deep=True)
+    for var, encoding in DEFAULT_ENCODINGS.items():
+        if var in new_ds:
+            da = new_ds[var].copy()
+            if "_time" in var:
+                new_ds[var] = xr.apply_ufunc(
+                    _encode_dataarray,
+                    da,
+                    keep_attrs=True,
+                    kwargs={"dtype": da.dtype},
+                )
+
+            new_ds[var].encoding = encoding
+
+    return new_ds


### PR DESCRIPTION
* Uses `location_time` instead of `time2` as the index for the incoming platform data in `EchoData.update_platform`
* Limits the range of the incoming `location_time` to between the minimum and maximum values of `EchoData.beam["ping_time"]`

Fixes #460 