### PR TITLE
Generalize assignment of beam coordinate var attributes

### DIFF
--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -4,7 +4,7 @@ Class to save unpacked echosounder data to appropriate groups in netcdf or zarr.
 import numpy as np
 import xarray as xr
 
-from .set_groups_base import SetGroupsBase, set_encodings
+from .set_groups_base import DEFAULT_BEAM_COORD_ATTRS, SetGroupsBase, set_encodings
 
 
 class SetGroupsAZFP(SetGroupsBase):
@@ -157,17 +157,21 @@ class SetGroupsAZFP(SetGroupsBase):
                 ),
             },
             coords={
-                "frequency": (["frequency"], freq, {"units": "Hz", "valid_min": 0.0}),
+                "frequency": (
+                    ["frequency"],
+                    freq,
+                    DEFAULT_BEAM_COORD_ATTRS["frequency"],
+                ),
                 "ping_time": (
                     ["ping_time"],
                     ping_time,
-                    {
-                        "axis": "T",
-                        "long_name": "Timestamp of each ping",
-                        "standard_name": "time",
-                    },
+                    DEFAULT_BEAM_COORD_ATTRS["ping_time"],
                 ),
-                "range_bin": (["range_bin"], range_bin),
+                "range_bin": (
+                    ["range_bin"],
+                    range_bin,
+                    DEFAULT_BEAM_COORD_ATTRS["range_bin"],
+                ),
             },
             attrs={
                 "beam_mode": "",

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -27,9 +27,7 @@ DEFAULT_BEAM_COORD_ATTRS = {
         "standard_name": "time",
         "axis": "T",
     },
-    "range_bin": {
-        "long_name": "Along-range bin (sample) number, base 0"
-    }
+    "range_bin": {"long_name": "Along-range bin (sample) number, base 0"},
 }
 
 DEFAULT_TIME_ENCODING = {

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -15,6 +15,23 @@ COMPRESSION_SETTINGS = {
 
 DEFAULT_CHUNK_SIZE = {"range_bin": 25000, "ping_time": 2500}
 
+DEFAULT_BEAM_COORD_ATTRS = {
+    "frequency": {
+        "long_name": "Transducer frequency",
+        # TODO: is there an appropriate standard_name for frequency?
+        "units": "Hz",
+        "valid_min": 0.0,
+    },
+    "ping_time": {
+        "long_name": "Timestamp of each ping",
+        "standard_name": "time",
+        "axis": "T",
+    },
+    "range_bin": {
+        "long_name": "Along-range bin (sample) number, base 0"
+    }
+}
+
 DEFAULT_TIME_ENCODING = {
     "units": "seconds since 1900-01-01T00:00:00+00:00",
     "calendar": "gregorian",

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -6,7 +6,9 @@ import numpy as np
 import xarray as xr
 from _echopype_version import version as ECHOPYPE_VERSION
 
-from .set_groups_base import DEFAULT_CHUNK_SIZE, SetGroupsBase, set_encodings
+from .set_groups_base import (
+    DEFAULT_CHUNK_SIZE, DEFAULT_BEAM_COORD_ATTRS, SetGroupsBase, set_encodings
+)
 
 
 class SetGroupsEK60(SetGroupsBase):
@@ -514,11 +516,7 @@ class SetGroupsEK60(SetGroupsBase):
                 "frequency": (
                     ["frequency"],
                     freq,
-                    {
-                        "units": "Hz",
-                        "long_name": "Transducer frequency",
-                        "valid_min": 0.0,
-                    },
+                    DEFAULT_BEAM_COORD_ATTRS["frequency"],
                 )
             },
             attrs={"beam_mode": "vertical", "conversion_equation_t": "type_3"},
@@ -600,13 +598,13 @@ class SetGroupsEK60(SetGroupsBase):
                     "ping_time": (
                         ["ping_time"],
                         self.parser_obj.ping_time[ch],
-                        {
-                            "axis": "T",
-                            "long_name": "Timestamp of each ping",
-                            "standard_name": "time",
-                        },
+                        DEFAULT_BEAM_COORD_ATTRS["ping_time"],
                     ),
-                    "range_bin": (["range_bin"], np.arange(data_shape[1])),
+                    "range_bin": (
+                        ["range_bin"],
+                        np.arange(data_shape[1]),
+                        DEFAULT_BEAM_COORD_ATTRS["range_bin"],
+                    ),
                 },
             )
 

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -7,7 +7,10 @@ import xarray as xr
 from _echopype_version import version as ECHOPYPE_VERSION
 
 from .set_groups_base import (
-    DEFAULT_CHUNK_SIZE, DEFAULT_BEAM_COORD_ATTRS, SetGroupsBase, set_encodings
+    DEFAULT_BEAM_COORD_ATTRS,
+    DEFAULT_CHUNK_SIZE,
+    SetGroupsBase,
+    set_encodings,
 )
 
 

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -4,7 +4,7 @@ from typing import List
 import numpy as np
 import xarray as xr
 
-from .set_groups_base import SetGroupsBase, set_encodings
+from .set_groups_base import DEFAULT_BEAM_COORD_ATTRS, SetGroupsBase, set_encodings
 
 
 class SetGroupsEK80(SetGroupsBase):
@@ -347,11 +347,7 @@ class SetGroupsEK80(SetGroupsBase):
                 "frequency": (
                     ["frequency"],
                     freq,
-                    {
-                        "units": "Hz",
-                        "long_name": "Transducer frequency",
-                        "valid_min": 0.0,
-                    },
+                    DEFAULT_BEAM_COORD_ATTRS["frequency"],
                 ),
             },
             attrs={"beam_mode": "vertical", "conversion_equation_t": "type_3"},
@@ -394,14 +390,17 @@ class SetGroupsEK80(SetGroupsBase):
                 "ping_time": (
                     ["ping_time"],
                     self.parser_obj.ping_time[ch],
-                    {
-                        "axis": "T",
-                        "long_name": "Timestamp of each ping",
-                        "standard_name": "time",
-                    },
+                    DEFAULT_BEAM_COORD_ATTRS["ping_time"],
                 ),
-                "range_bin": (["range_bin"], np.arange(data_shape[1])),
-                "quadrant": (["quadrant"], np.arange(num_transducer_sectors)),
+                "range_bin": (
+                    ["range_bin"],
+                    np.arange(data_shape[1]),
+                    DEFAULT_BEAM_COORD_ATTRS["range_bin"],
+                ),
+                "quadrant": (
+                    ["quadrant"],
+                    np.arange(num_transducer_sectors)
+                ),
             },
         )
 
@@ -469,13 +468,13 @@ class SetGroupsEK80(SetGroupsBase):
                 "ping_time": (
                     ["ping_time"],
                     self.parser_obj.ping_time[ch],
-                    {
-                        "axis": "T",
-                        "long_name": "Timestamp of each ping",
-                        "standard_name": "time",
-                    },
+                    DEFAULT_BEAM_COORD_ATTRS["ping_time"],
                 ),
-                "range_bin": (["range_bin"], np.arange(data_shape[1])),
+                "range_bin": (
+                    ["range_bin"],
+                    np.arange(data_shape[1]),
+                    DEFAULT_BEAM_COORD_ATTRS["range_bin"],
+                ),
             },
         )
 
@@ -548,13 +547,13 @@ class SetGroupsEK80(SetGroupsBase):
                 "ping_time": (
                     ["ping_time"],
                     self.parser_obj.ping_time[ch],
-                    {
-                        "axis": "T",
-                        "long_name": "Timestamp of each ping",
-                        "standard_name": "time",
-                    },
+                    DEFAULT_BEAM_COORD_ATTRS["ping_time"],
                 ),
-                "range_bin": (["range_bin"], np.arange(range_bin_size)),
+                "range_bin": (
+                    ["range_bin"],
+                    np.arange(range_bin_size),
+                    DEFAULT_BEAM_COORD_ATTRS["range_bin"],
+                ),
             },
         )
         return set_encodings(ds_common)
@@ -630,9 +629,7 @@ class SetGroupsEK80(SetGroupsBase):
                 }
             )
             ds_data["frequency"] = ds_data["frequency"].assign_attrs(
-                units="Hz",
-                long_name="Transducer frequency",
-                valid_min=0.0,
+                **DEFAULT_BEAM_COORD_ATTRS["frequency"]
             )
             if ch in self.parser_obj.ch_ids["complex"]:
                 ds_complex.append(ds_data)
@@ -698,11 +695,7 @@ class SetGroupsEK80(SetGroupsBase):
                 "frequency": (
                     ["frequency"],
                     param_dict["transducer_frequency"],
-                    {
-                        "units": "Hz",
-                        "long_name": "Transducer frequency",
-                        "valid_min": 0.0,
-                    },
+                    DEFAULT_BEAM_COORD_ATTRS["frequency"],
                 ),
                 "pulse_length_bin": (
                     ["pulse_length_bin"],

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -397,10 +397,7 @@ class SetGroupsEK80(SetGroupsBase):
                     np.arange(data_shape[1]),
                     DEFAULT_BEAM_COORD_ATTRS["range_bin"],
                 ),
-                "quadrant": (
-                    ["quadrant"],
-                    np.arange(num_transducer_sectors)
-                ),
+                "quadrant": (["quadrant"], np.arange(num_transducer_sectors)),
             },
         )
 


### PR DESCRIPTION
Unified where the attributes for the core beam coordinate variables (`frequency`, `ping_time`, `range_bin`) are set. I've created a new `DEFAULT_BEAM_COORD_ATTRS` dict in `set_groups_base.py` that declares these common attributes and their values, then import that variable in the various set_groups_x.py modules. This PR implements that change for ek60, ek80, azfp.This abstraction/centralization will reduce the potential for variability across sensors and make it a tiny, tiny bit easier to roll out support for new sensors in a consistent fashion.

Also added a `long_name` attribute to `range_bin`, partly addressing #373