### PR TITLE
docs: git and PR merging workflows, output_storage_options docs [skip ci]

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -17,12 +17,10 @@ source GitHub repository
 `https://github.com/OSOceanAcoustics/echopype/ <https://github.com/OSOceanAcoustics/echopype/>`_ 
 (``upstream``), then clone your fork; your fork will be the ``origin`` remote. See 
 `this excellent tutorial <https://www.dataschool.io/how-to-contribute-on-github/>`_ for 
-guidance on forking and opening pull requests, but replace references to the ``main`` 
+guidance on forking and opening pull requests (PRs), but replace references to the ``main`` 
 branch with the ``dev`` development branch. See 
 `this description of the gitflow workflow <https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow>`_. 
-The complete workflow we use is depicted in the diagram below, which includes
-components involving documentation updates (see `Documentation development`_ below)
-and preparation of releases.
+This diagram depicts the complete workflow we use in the source GitHub repository:
 
 .. mermaid::
 
@@ -35,6 +33,15 @@ and preparation of releases.
         stable --> |docs merge| rel[release/0.x.y]
         dev --> |dev merge| rel
         rel --> main
+
+- ``doc patch``: Updates to the documentation that refer to the current ``echopype`` 
+  release can be pushed out immediately to the `echopype documentation site <https://echopype.readthedocs.io>`_ 
+  by contibuting patches (PRs) to the ``stable`` branch. See `Documentation development`_ 
+  below for more details.
+- ``code patch``: Code development is carried out as patches (PRs) to the ``dev``
+  branch; changes in the documentation corresponding to changes in the code can be 
+  carried out in this branch as well. 
+- New releases are prepared in a new release branch that merges changes in ``dev`` and ``stable``.
 
 
 Installation for echopype development
@@ -184,12 +191,6 @@ These updates will then become available immediately on the default ReadTheDocs 
 Examples of such updates include fixing spelling mistakes, expanding an explanation, 
 and adding a new section that documents a previously undocumented feature.
 
-Function and object doc strings
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For inline strings documenting functions and objects ("doc strings"), we use the
-`numpydoc style (Numpy docstring format) <https://numpydoc.readthedocs.io/en/latest/format.html>`_.
-
 Documentation versions
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -205,3 +206,9 @@ corresponding version.
 
 We also maintain a test version of the documentation at `<https://doc-test-echopype.readthedocs.io/>`_
 for viewing and debugging larger, more experimental changes, typically from a separate fork.
+
+Function and object doc strings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For inline strings documenting functions and objects ("doc strings"), we use the
+`numpydoc style (Numpy docstring format) <https://numpydoc.readthedocs.io/en/latest/format.html>`_.

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -12,8 +12,8 @@ see these tips for submitting issues:
 `"Creating issues on GitHub" <https://medium.com/nyc-planning-digital/writing-a-proper-github-issue-97427d62a20f>`_.
 
 For echopype development we use the **gitflow workflow** with forking. All development
-changes are merged into the ``dev`` development branch. First create your own fork of the 
-source GitHub repository 
+changes (except for documentation) are merged into the ``dev`` development branch. 
+First create your own fork of the source GitHub repository 
 `https://github.com/OSOceanAcoustics/echopype/ <https://github.com/OSOceanAcoustics/echopype/>`_ 
 (``upstream``), then clone your fork; your fork will be the ``origin`` remote. See 
 `this excellent tutorial <https://www.dataschool.io/how-to-contribute-on-github/>`_ for 
@@ -42,6 +42,12 @@ This diagram depicts the complete workflow we use in the source GitHub repositor
   branch; changes in the documentation corresponding to changes in the code can be 
   carried out in this branch as well. 
 - New releases are prepared in a new release branch that merges changes in ``dev`` and ``stable``.
+
+To maintain a clean and readable commit history, use "Merge pull request > Squash and merge" 
+when merging an individual PR to `dev` or a documentation-only PR to `stable`. This will 
+highlight the specific feature(s) contributed by the PR. When merging an ``echopype`` 
+release PR to `main`, use "Merge pull request > Create a merge commit" in order to 
+retain all the squashed PR commits in the commit history.
 
 
 Installation for echopype development
@@ -125,7 +131,7 @@ and `S3 object-storage <https://en.wikipedia.org/wiki/Amazon_S3>`_ sources,
 the latter via `minio <https://minio.io>`_.
 
 `.ci_helpers/run-test.py <https://github.com/OSOceanAcoustics/echopype/blob/main/.ci_helpers/run-test.py>`_
-will execute all tests. Passing a comma separated list of modules at the end will limit
+will execute all tests by default. Passing a comma separated list of modules at the end will limit
 the execution to only tests in the corresponding subpackages. For usage information, 
 run it with the ``-h`` argument: ``python .ci_helpers/run-test.py -h``
 
@@ -138,7 +144,7 @@ and useful pre-commit "hooks" have been configured in the
 Current hooks include file formatting (linting) checks (trailing spaces, trailing lines,
 JSON and YAML format checks, etc) and Python style autoformatters (PEP8 / flake8, ``black`` and ``isort``).
 
-To run pre-commit hooks locally, run `pre-commit install` before running the 
+To run pre-commit hooks locally, run ``pre-commit install`` before running the 
 docker setup-service deploy statement described above. The hooks will run automatically 
 during ``git commit`` and will give you options as needed before committing your changes.
 You can also run ``pre-commit`` before actually doing ``git commit``, as you edit the code, 
@@ -168,6 +174,15 @@ This is done by including the string "[skip ci]" in your last commit's message.
 
 Documentation development
 -------------------------
+
+Function and object doc strings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For inline strings documenting functions and objects ("doc strings"), we use the
+`numpydoc style (Numpy docstring format) <https://numpydoc.readthedocs.io/en/latest/format.html>`_.
+
+Sphinx ReadTheDocs documentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Echopype documentation (`<https://echopype.readthedocs.io>`_) is based on 
 `Sphinx <https://www.sphinx-doc.org>`_ and is hosted at 
@@ -207,9 +222,3 @@ corresponding version.
 
 We also maintain a test version of the documentation at `<https://doc-test-echopype.readthedocs.io/>`_
 for viewing and debugging larger, more experimental changes, typically from a separate fork.
-
-Function and object doc strings
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For inline strings documenting functions and objects ("doc strings"), we use the
-`numpydoc style (Numpy docstring format) <https://numpydoc.readthedocs.io/en/latest/format.html>`_.

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -125,8 +125,9 @@ and `S3 object-storage <https://en.wikipedia.org/wiki/Amazon_S3>`_ sources,
 the latter via `minio <https://minio.io>`_.
 
 `.ci_helpers/run-test.py <https://github.com/OSOceanAcoustics/echopype/blob/main/.ci_helpers/run-test.py>`_
-will execute all tests. For usage information, run it with the ``-h`` argument:
-``python .ci_helpers/run-test.py -h``
+will execute all tests. Passing a comma separated list of modules at the end will limit
+the execution to only tests in the corresponding subpackages. For usage information, 
+run it with the ``-h`` argument: ``python .ci_helpers/run-test.py -h``
 
 pre-commit hooks
 ~~~~~~~~~~~~~~~~

--- a/docs/source/convert.rst
+++ b/docs/source/convert.rst
@@ -155,7 +155,7 @@ through ``storage_options`` keywords:
 
    ed = open_raw(
       raw_file_s3path, sonar_model='EK60',
-      storage_options={key: 'ACCESSKEY', secret: 'SECRETKEY'}
+      storage_options={'key': 'ACCESSKEY', 'secret': 'SECRETKEY'}
    )
 
 or via a credentials file stored in the default AWS credentials file 
@@ -261,10 +261,14 @@ Save to AWS S3
 .. attention::
    Saving to S3 was introduced in version 0.5.0.
 
-Converted files can be saved directly into an AWS S3 bucket by specifying ``storage_options``
-as done with input files (see above, "AWS S3 access"). The example below illustrates a 
-fully remote processing pipeline, reading a raw file from a web server and saving the
-converted Zarr dataset to S3. Writing netCDF4 to S3 is currently not supported.
+Converted files can be saved directly into an AWS S3 bucket by specifying 
+``output_storage_options``, similar to ``storage_options`` with input files 
+(see above, "AWS S3 access"). The example below illustrates a fully remote 
+processing pipeline, reading a raw file from a web server and saving the
+converted Zarr dataset to S3. (As with ``storage_options`` when accessing 
+raw data from S3, a ``profile``-based ``session`` can also be used, passing the 
+``session`` to ``output_storage_options``). Writing netCDF4 to S3 is 
+currently not supported.
 
 .. code-block:: python
 
@@ -273,7 +277,7 @@ converted Zarr dataset to S3. Writing netCDF4 to S3 is currently not supported.
       ed.to_zarr(
          overwrite=True,
          save_path='s3://mybucket/converted_file.zarr',
-         storage_options={key: 'ACCESSKEY', secret: 'SECRETKEY'}
+         output_storage_options={'key': 'ACCESSKEY', 'secret': 'SECRETKEY'}
       )
 
 .. note::

--- a/docs/source/open-converted.rst
+++ b/docs/source/open-converted.rst
@@ -15,13 +15,14 @@ that returns a lazy loaded ``EchoData`` object (only metadata are read during op
    ed = ep.open_converted(nc_path)              # create an EchoData object
 
 
-.. TODO: Demo opening from Zarr on S3, and opening multiple files.
+.. TODO: Demo opening from Zarr on S3
 
 
 EchoData object
 ---------------
 
-.. TODO: Examine EchoData objects
+.. TODO: Examine EchoData objects. Include the echopype echodata HTML repr, 
+   and a sample of the xarray HTML repr for one of the groups
 
 ``EchoData`` is an object for conveniently handling raw converted data from either 
 raw instrument files (via ``open_raw``) or previously converted and standardized raw files
@@ -29,3 +30,12 @@ raw instrument files (via ``open_raw``) or previously converted and standardized
 where each such object corresponds to one of the netCDF4 groups specified in the SONAR-netCDF4
 convention followed by echopype. It is used for conveniently accessing and exploring the 
 echosounder data and for calibration and other processing.
+
+
+.. TODO: Add section on combine_echodata, including the sample code from echopype_tour nb
+   ed_list = []
+   for converted_file in sorted(glob.glob(str(converted_dpath / "*.nc"))):
+      ed_list.append(ep.open_converted(converted_file))
+   combined_ed = ep.combine_echodata(ed_list)
+
+.. TODO: Mention ep.qc.exist_reversed_time and coerce rev time ..


### PR DESCRIPTION
- Convert raw files: Describe use of `output_storage_options`
- Contributing to echopype: Elaborate on the git branch workflow. Add description of PR squash and merge vs merge commit. Add instructions for running only a subset of tests locally. Closes #387