### PR TITLE
Fix echodata combined encodings

### DIFF
--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -8,6 +8,7 @@ from _echopype_version import version as ECHOPYPE_VERSION
 
 from ..core import SONAR_MODELS
 from ..qc import coerce_increasing_time, exist_reversed_time
+from ..utils.coding import set_encodings
 from .echodata import EchoData
 
 
@@ -247,6 +248,8 @@ def combine_echodata(echodatas: List[EchoData], combine_attrs="override") -> Ech
         if combined_group is not None:
             # xarray inserts this dimension when concating along multiple dimensions
             combined_group = combined_group.drop_dims("concat_dim", errors="ignore")
+
+        combined_group = set_encodings(combined_group)
         setattr(result, group, combined_group)
 
     # save ping time before reversal correction


### PR DESCRIPTION
## Overview

This PR fixes #479 where the merged echodata object does not have any encoding, which in turn, when written to netcdf file, xarray determines those encodings, esp for `*time` variables. By utilizing the new `coding` module and `set_encodings` now the combined echodata object has encoding for variables in `DEFAULT_ENCODINGS`.