### PR TITLE
Expand extracted time range in EchoData.update_platform by 1 in both directions; add test for extracted time range

### DIFF
--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -404,19 +404,20 @@ class EchoData:
 
         # clip incoming time to 1 less than min of EchoData.beam["ping_time"] and
         #   1 greater than max of EchoData.beam["ping_time"]
-        # account for unsorted time
+        # account for unsorted external time by checking whether each time value is between
+        #   min and max ping_time instead of finding the 2 external times corresponding to the
+        #   min and max ping_time and taking all the times between those indices
         sorted_external_time = extra_platform_data[time_dim].data
         sorted_external_time.sort()
         min_index = max(
             np.searchsorted(
-                sorted_external_time, self.beam["ping_time"].min(), side="right"
-            )
-            - 1,
+                sorted_external_time, self.beam["ping_time"].min(), side="left"
+            ) - 1, # noqa
             0,
         )
         max_index = min(
             np.searchsorted(
-                sorted_external_time, self.beam["ping_time"].max(), side="left"
+                sorted_external_time, self.beam["ping_time"].max(), side="right"
             ),
             len(sorted_external_time) - 1,
         )

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -409,12 +409,14 @@ class EchoData:
         #   min and max ping_time and taking all the times between those indices
         sorted_external_time = extra_platform_data[time_dim].data
         sorted_external_time.sort()
+        # fmt: off
         min_index = max(
             np.searchsorted(
                 sorted_external_time, self.beam["ping_time"].min(), side="left"
-            ) - 1, # noqa
+            ) - 1,
             0,
         )
+        # fmt: on
         max_index = min(
             np.searchsorted(
                 sorted_external_time, self.beam["ping_time"].max(), side="right"

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -403,6 +403,8 @@ class EchoData:
             extra_platform_data = extra_platform_data.drop_vars(trajectory_var)
             extra_platform_data = extra_platform_data.swap_dims({"obs": time_dim})
 
+        # clip incoming time to 1 less than min of EchoData.beam["ping_time"] and
+        #   1 greater than max of EchoData.beam["ping_time"]
         # account for unsorted time
         sorted_external_time = extra_platform_data[time_dim].data
         sorted_external_time.sort()
@@ -416,8 +418,7 @@ class EchoData:
         max_index = min(
             np.searchsorted(
                 sorted_external_time, self.beam["ping_time"].max(), side="left"
-            )
-            + 1,
+            ),
             len(sorted_external_time) - 1,
         )
         extra_platform_data = extra_platform_data.sel(

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -169,7 +169,11 @@ def test_update_platform():
     for variable in updated:
         assert not np.isnan(ed.platform[variable].values).all()
 
+    # check times are > min(ed.beam["ping_time"]) - 2s
     assert (ed.platform["location_time"] > ed.beam["ping_time"].min() - np.timedelta64(2, "s")).all()
+    # check there is only 1 time < min(ed.beam["ping_time"])
     assert np.count_nonzero(ed.platform["location_time"] < ed.beam["ping_time"].min()) == 1
+    # check times are < max(ed.beam["ping_time"]) + 2s
     assert (ed.platform["location_time"] < ed.beam["ping_time"].max() + np.timedelta64(2, "s")).all()
+    # check there is only 1 time > max(ed.beam["ping_time"])
     assert np.count_nonzero(ed.platform["location_time"] > ed.beam["ping_time"].max()) == 1

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -168,3 +168,8 @@ def test_update_platform():
 
     for variable in updated:
         assert not np.isnan(ed.platform[variable].values).all()
+
+    assert (ed.platform["location_time"] > ed.beam["ping_time"].min() - np.timedelta64(2, "s")).all()
+    assert np.count_nonzero(ed.platform["location_time"] < ed.beam["ping_time"].min()) == 1
+    assert (ed.platform["location_time"] < ed.beam["ping_time"].max() + np.timedelta64(2, "s")).all()
+    assert np.count_nonzero(ed.platform["location_time"] > ed.beam["ping_time"].max()) == 1

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -169,6 +169,7 @@ def test_update_platform():
     for variable in updated:
         assert not np.isnan(ed.platform[variable].values).all()
 
+    # times have max interval of 2s
     # check times are > min(ed.beam["ping_time"]) - 2s
     assert (ed.platform["location_time"] > ed.beam["ping_time"].min() - np.timedelta64(2, "s")).all()
     # check there is only 1 time < min(ed.beam["ping_time"])


### PR DESCRIPTION
* Expands the extracted time range from external platform data to 1 less than min of `EchoData.beam["ping_time"]` and 1 more than max of `EchoData.beam["ping_time"]`
    * Was originally between min of `EchoData.beam["ping_time"]` and max of `EchoData.beam["ping_time"]`
* Adds test for extracted time range of updated platform data

Fixes #485 