### PR TITLE
Reduce EK80 test data files

### DIFF
--- a/echopype/test_data/README.md
+++ b/echopype/test_data/README.md
@@ -6,10 +6,11 @@ Most of these files are stored on Git LFS but the ones that aren't (due to file 
 
 - D20190822-T161221.raw: Contains channels that only record real power data
 - D20170912-T234910.raw: Contains channels that only record complex power data
+- Summer2018--D20180905-T033113.raw: Contains BB channels encoded in complex and CW channels encoded in power samples (reduced from 300 MB to 3.8 MB in test data updates).
 - Summer2018 (3 files): Contains channels with complex power data as well as channels with real power data. They can be combined.
 - 2019118 group2survey-D20191214-T081342.raw: Contains 6 channels but only 2 of those channels collect ping data
 - D20200528-T125932.raw: Data collected from WBT mini (instead of WBT), from @emlynjdavies
-- Green2.Survey2.FM.short.slow.-D20191004-T211557.raw: Contains 2-in-1 transducer, from @FletcherFT
+- Green2.Survey2.FM.short.slow.-D20191004-T211557.raw: Contains 2-in-1 transducer, from @FletcherFT (reduced from 104.9 MB to 765 KB in test data updates)
 
 
 ### EA640


### PR DESCRIPTION
The real changes in this PR will not be reflected in the repo because it involves reducing the size of the EK80 test files in the CI_test_data folder.

The changes are described in test_data/README.