### PR TITLE
docs: Add 0.5.5 release notes and description of combine_echodata

### DIFF
--- a/docs/source/open-converted.rst
+++ b/docs/source/open-converted.rst
@@ -34,7 +34,7 @@ the data into a single ``EchoData`` object in memory:
 .. code-block:: python
 
    ed_list = []
-   for converted_file in ["convertedfile1.nc", "convertedfile2.nc"]
+   for converted_file in ["convertedfile1.nc", "convertedfile2.nc"]:
       ed_list.append(ep.open_converted(converted_file))
 
    combined_ed = ep.combine_echodata(ed_list)

--- a/docs/source/open-converted.rst
+++ b/docs/source/open-converted.rst
@@ -5,23 +5,40 @@ Open converted files
 Open a converted netCDF or Zarr dataset
 ---------------------------------------
 
-Converted netCDF and Zarr files can be opened with the ``open_converted`` function
+Converted netCDF files can be opened with the ``open_converted`` function
 that returns a lazy loaded ``EchoData`` object (only metadata are read during opening):
 
 .. code-block:: python
 
    import echopype as ep
-   nc_path = './converted_files/file.nc'        # path to a converted nc file
-   ed = ep.open_converted(nc_path)              # create an EchoData object
+   file_path = "./converted_files/file.nc"      # path to a converted nc file
+   ed = ep.open_converted(file_path)            # create an EchoData object
 
+Likewise, specify the path to open a Zarr dataset. To open such a dataset from 
+cloud storage, use the same ``storage_options`` parameter as with 
+`open_raw <convert.html#aws-s3-access>`_. For example:
 
-.. TODO: Demo opening from Zarr on S3
+.. code-block:: python
 
-.. TODO: Add section on combine_echodata, including the sample code from echopype_tour nb
+   s3_path = "s3://s3bucketname/directory_path/dataset.zarr"     # S3 dataset path
+   ed = ep.open_converted(s3_path, storage_options={"anon": True})
+
+Combine EchoData objects
+------------------------
+
+Converted data found in multiple files corresponding to the same instrument deployment can be 
+combined into a single ``EchoData`` object. First assemble a list of ``EchoData`` objects from the 
+converted files (netCDF or Zarr). Then apply ``combine_echodata`` on this list to combine all
+the data into a single ``EchoData`` object in memory:
+
+.. code-block:: python
+
    ed_list = []
-   for converted_file in sorted(glob.glob(str(converted_dpath / "*.nc"))):
+   for converted_file in ["convertedfile1.nc", "convertedfile2.nc"]
       ed_list.append(ep.open_converted(converted_file))
+
    combined_ed = ep.combine_echodata(ed_list)
+
 
 .. TODO: Mention ep.qc.exist_reversed_time and coerce rev time ..
 

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -4,6 +4,51 @@ What's new
 See `GitHub releases page <https://github.com/OSOceanAcoustics/echopype/releases>`_ for the complete history.
 
 
+v0.5.5 (2021 Dec 10)
+--------------------
+
+Overview
+~~~~~~~~
+
+This is a minor release that includes new features, enhancements, bug fixes, and linking to an echopype preprint.
+
+New features
+~~~~~~~~~~~~
+
+- Allow converting ES60/70/80 files and handle  various datagram anomaly (#409)
+- Add simple echogram plotting functionality (beta) (#436)
+
+Enhancements
+~~~~~~~~~~~~
+
+- ``update_platform`` method for ``EchoData`` now include proper variable attributes and correctly selects time range of platform data variables corresponding to those of the acoustic data (#476, #492, #493, #488)
+- Improve testing for ``preprocess.compute_MVBS`` by running through real data for all supported sonar models (#454)
+- Generalize handling of Beam group coordinate attributes and a subset of variable attributes (#480, #493)
+- Allow optional kwargs when loading ``EchoData`` groups to enable delaying operations (#456)
+
+Bug fixes
+~~~~~~~~~
+
+- The gain factor for band-integrated Sv is now computed from broadband calibration data stored in the Vendor group (when available) or use nominal narrowband values (#446, #477)
+- Fix time variable encoding for ``combine_echodata`` (#486)
+- Fix missing ``ping_time`` dimension in AZFP Sv dataset to enable MVBS computation (#453)
+- Fix bugs re path when writing to cloud (#462)
+
+Documentation
+~~~~~~~~~~~~~
+
+- Improvements to the "Contributing to echopype" page: Elaborate on the git branch workflow. Add description of PR squash and merge vs merge commit. Add instructions for running only a subset of tests locally (#482)
+- Add documentation about ``output_storage_options`` for writing to cloud storage (#482)
+- Add documentation and docstring for ``sonar_model`` in ``open_raw`` (#475)
+- Improve documentation of EchoData object by adding a sample of the xarray Dataset HTML browser (#503)
+
+Others
+~~~~~~
+
+- Zenodo badge update (#469)
+- Add github citation file (#496), linking to `echopype preprint on arXiv <https://arxiv.org/abs/2111.00187>`_
+
+
 v0.5.4 (2021 Sep 27)
 --------------------
 
@@ -67,8 +112,8 @@ Improvements
 - Improve test coverage accuracy (#411)
 - Improve testing structure to match with subpackage structure (#401, #416, #429 )
 
-Documentaion
-~~~~~~~~~~~~
+Documentation
+~~~~~~~~~~~~~
 
 - Expand ``Contributing to echopype`` page, including development workflow and testing strategy (#417, #420, #423)
 


### PR DESCRIPTION
Add 0.5.5 release notes, example of using `open_converted` to open a zarr dataset from S3, and description of `combine_echodata`.