### PR TITLE
Bump miniforge version to 4.11.0-0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
           activate-environment: ${{ env.CONDA_ENV }}
           environment-file: .ci_helpers/py${{ matrix.python-version }}.yaml
           miniforge-variant: Mambaforge
-          miniforge-version: 4.10.0-0
+          miniforge-version: 4.11.0-0
           use-mamba: true
           auto-activate-base: false
           use-only-tar-bz2: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,10 @@ jobs:
           use-mamba: true
           auto-activate-base: false
           use-only-tar-bz2: true
+      - name: Update mamba
+        shell: bash -l {0}
+        run: |
+          conda update -c conda-forge --yes mamba
       - name: Print conda env
         shell: bash -l {0}
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -67,6 +67,10 @@ jobs:
           use-mamba: true
           auto-activate-base: false
           use-only-tar-bz2: true
+      - name: Update mamba
+        shell: bash -l {0}
+        run: |
+          conda update -c conda-forge --yes mamba
       - name: Print conda env
         shell: bash -l {0}
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -63,7 +63,7 @@ jobs:
           activate-environment: ${{ env.CONDA_ENV }}
           environment-file: .ci_helpers/py${{ matrix.python-version }}.yaml
           miniforge-variant: Mambaforge
-          miniforge-version: 4.10.0-0
+          miniforge-version: 4.11.0-0
           use-mamba: true
           auto-activate-base: false
           use-only-tar-bz2: true


### PR DESCRIPTION
## Overview

This PR bumps the miniforge version to 4.11.0-0 since there was a huge refactoring in conda 4.11 that might cause the missing module issue.