### PR TITLE
Update s3fs to 2021.11.0 and add link to issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,8 @@ scipy
 xarray
 zarr
 fsspec
-s3fs==2021.10.1
+# https://github.com/fsspec/s3fs/pull/554
+s3fs==2021.11.0
 requests
 aiohttp
 typing-extensions~=3.10


### PR DESCRIPTION
This PR updates s3fs pinning to 2021.11.0 for now until we asses if the latest works.