### PR TITLE
Remove the extra space before colon in parameters docstring

### DIFF
--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -68,10 +68,10 @@ def compute_Sv(echodata: EchoData, **kwargs) -> xr.Dataset:
 
     Parameters
     ----------
-    echodata : EchoData
+    echodata: EchoData
         An `EchoData` object created by using `open_raw` or `open_converted`
 
-    env_params : dict, optional
+    env_params: dict, optional
         Environmental parameters needed for calibration.
         Users can supply `"sound speed"` and `"absorption"` directly,
         or specify other variables that can be used to compute them,
@@ -84,7 +84,7 @@ def compute_Sv(echodata: EchoData, **kwargs) -> xr.Dataset:
         sensor, and some are equipped with a pressure sensor, but automatically
         using these pressure data is not currently supported.
 
-    cal_params : dict, optional
+    cal_params: dict, optional
         Intrument-dependent calibration parameters.
 
         For EK60, EK80, and AZFP echosounders, by default echopype uses
@@ -99,7 +99,7 @@ def compute_Sv(echodata: EchoData, **kwargs) -> xr.Dataset:
         Passing in calibration parameters for other echosounders
         are not currently supported.
 
-    waveform_mode : {"CW", "BB"}, optional
+    waveform_mode: {"CW", "BB"}, optional
         Type of transmit waveform.
         Required only for data from the EK80 echosounder
         and not used with any other echosounder.
@@ -109,7 +109,7 @@ def compute_Sv(echodata: EchoData, **kwargs) -> xr.Dataset:
         - `"BB"` for broadband transmission,
           returned echoes recorded as complex samples
 
-    encode_mode : {"complex", "power"}, optional
+    encode_mode: {"complex", "power"}, optional
         Type of encoded return echo data.
         Required only for data from the EK80 echosounder
         and not used with any other echosounder.
@@ -153,10 +153,10 @@ def compute_Sp(echodata: EchoData, **kwargs):
 
     Parameters
     ----------
-    echodata : EchoData
+    echodata: EchoData
         An `EchoData` object created by using `open_raw` or `open_converted`
 
-    env_params : dict, optional
+    env_params: dict, optional
         Environmental parameters needed for calibration.
         Users can supply `"sound speed"` and `"absorption"` directly,
         or specify other variables that can be used to compute them,
@@ -169,7 +169,7 @@ def compute_Sp(echodata: EchoData, **kwargs):
         sensor, and some are equipped with a pressure sensor, but automatically
         using these pressure data is not currently supported.
 
-    cal_params : dict, optional
+    cal_params: dict, optional
         Intrument-dependent calibration parameters.
 
         For EK60, EK80, and AZFP echosounders, by default echopype uses
@@ -184,7 +184,7 @@ def compute_Sp(echodata: EchoData, **kwargs):
         Passing in calibration parameters for other echosounders
         are not currently supported.
 
-    waveform_mode : {"CW", "BB"}, optional
+    waveform_mode: {"CW", "BB"}, optional
         Type of transmit waveform.
         Required only for data from the EK80 echosounder
         and not used with any other echosounder.
@@ -194,7 +194,7 @@ def compute_Sp(echodata: EchoData, **kwargs):
         - `"BB"` for broadband transmission,
           returned echoes recorded as complex samples
 
-    encode_mode : {"complex", "power"}, optional
+    encode_mode: {"complex", "power"}, optional
         Type of encoded return echo data.
         Required only for data from the EK80 echosounder
         and not used with any other echosounder.

--- a/echopype/calibrate/calibrate_azfp.py
+++ b/echopype/calibrate/calibrate_azfp.py
@@ -29,7 +29,7 @@ class CalibrateAZFP(CalibrateBase):
 
         Parameters
         ----------
-        cal_params : dict
+        cal_params: dict
         """
         # Params from the Beam group
         for p in ["EL", "DS", "TVR", "VTX", "Sv_offset", "equivalent_beam_angle"]:
@@ -43,7 +43,7 @@ class CalibrateAZFP(CalibrateBase):
 
         Parameters
         ----------
-        env_params : dict
+        env_params: dict
         """
         # Temperature comes from either user input or data file
         self.env_params["temperature"] = (
@@ -83,7 +83,7 @@ class CalibrateAZFP(CalibrateBase):
 
         Parameters
         ----------
-        cal_type : str
+        cal_type: str
             'Sv' for calculating volume backscattering strength, or
             'Sp' for calculating point backscattering strength
         """

--- a/echopype/calibrate/calibrate_base.py
+++ b/echopype/calibrate/calibrate_base.py
@@ -33,7 +33,7 @@ class CalibrateBase(abc.ABC):
 
         Returns
         -------
-        range_meter : xr.DataArray
+        range_meter: xr.DataArray
             range in units meter
         """
         pass
@@ -44,7 +44,7 @@ class CalibrateBase(abc.ABC):
 
         Parameters
         ----------
-        cal_type : str
+        cal_type: str
             'Sv' for calculating volume backscattering strength, or
             'Sp' for calculating point backscattering strength
         """

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -19,7 +19,7 @@ class CalibrateEK(CalibrateBase):
         """
         Parameters
         ----------
-        waveform_mode : {"CW", "BB"}
+        waveform_mode: {"CW", "BB"}
             Type of transmit waveform.
             Required only for data from the EK80 echosounder.
 
@@ -28,7 +28,7 @@ class CalibrateEK(CalibrateBase):
             - `"BB"` for broadband transmission,
               returned echoes recorded as complex samples
 
-        encode_mode : {"complex", "power"}
+        encode_mode: {"complex", "power"}
             Type of encoded return echo data.
             Required only for data from the EK80 echosounder.
 
@@ -38,7 +38,7 @@ class CalibrateEK(CalibrateBase):
 
         Returns
         -------
-        range_meter : xr.DataArray
+        range_meter: xr.DataArray
             range in units meter
         """
         self.range_meter = self.echodata.compute_range(
@@ -52,7 +52,7 @@ class CalibrateEK(CalibrateBase):
 
         Parameters
         ----------
-        param : str
+        param: str
             name of parameter to retrieve
         """
         # TODO: need to test with EK80 power/angle data
@@ -113,7 +113,7 @@ class CalibrateEK(CalibrateBase):
 
         Parameters
         ----------
-        cal_params : dict
+        cal_params: dict
         """
 
         if (
@@ -151,10 +151,10 @@ class CalibrateEK(CalibrateBase):
 
         Parameters
         ----------
-        cal_type : str
+        cal_type: str
             'Sv' for calculating volume backscattering strength, or
             'Sp' for calculating point backscattering strength
-        use_beam_power : bool
+        use_beam_power: bool
             whether to use beam_power.
             If ``True`` use ``echodata.beam_power``; if ``False`` use ``echodata.beam``.
             Note ``echodata.beam_power`` could only exist for EK80 data.
@@ -249,7 +249,7 @@ class CalibrateEK60(CalibrateEK):
 
         Parameters
         ----------
-        env_params : dict
+        env_params: dict
         """
         # Re-calculate environment parameters if user supply all env variables
         if (
@@ -330,9 +330,9 @@ class CalibrateEK80(CalibrateEK):
 
         Parameters
         ----------
-        env_params : dict
+        env_params: dict
 
-        waveform_mode : {"CW", "BB"}
+        waveform_mode: {"CW", "BB"}
             Type of transmit waveform.
 
             - `"CW"` for narrowband transmission,
@@ -340,7 +340,7 @@ class CalibrateEK80(CalibrateEK):
             - (default) `"BB"` for broadband transmission,
               returned echoes recorded as complex samples
 
-        encode_mode : {"complex", "power"}
+        encode_mode: {"complex", "power"}
             Type of encoded return echo data.
 
             - (default) `"complex"` for complex samples
@@ -418,11 +418,11 @@ class CalibrateEK80(CalibrateEK):
 
         Parameters
         ----------
-        channel_id : str
+        channel_id: str
             channel id for which the param to be retrieved
-        filter_name : str
+        filter_name: str
             name of filter coefficients to retrieve
-        param_type : str
+        param_type: str
             'coeff' or 'decimation'
         """
         if param_type == "coeff":
@@ -472,9 +472,9 @@ class CalibrateEK80(CalibrateEK):
 
         Parameters
         ----------
-        y : np.array
+        y: np.array
             chirp from _tapered_chirp
-        ch_id : str
+        ch_id: str
             channel_id to select the right coefficients and factors
         """
         # filter coefficients and decimation factor
@@ -506,9 +506,9 @@ class CalibrateEK80(CalibrateEK):
         ----------
         ytx :array
             transmit signal
-        fs_deci : float
+        fs_deci: float
             sampling frequency of the decimated (recorded) signal
-        waveform_mode : str
+        waveform_mode: str
             ``CW`` for CW-mode samples, either recorded as complex or power samples
             ``BB`` for BB-mode samples, recorded as complex samples
         """
@@ -528,7 +528,7 @@ class CalibrateEK80(CalibrateEK):
 
         Parameters
         ----------
-        waveform_mode : str
+        waveform_mode: str
             ``CW`` for CW-mode samples, either recorded as complex or power samples
             ``BB`` for BB-mode samples, recorded as complex samples
         """
@@ -592,9 +592,9 @@ class CalibrateEK80(CalibrateEK):
 
         Parameters
         ----------
-        chirp : dict
+        chirp: dict
             transmit chirp replica indexed by channel_id
-        freq_BB : int or float
+        freq_BB: int or float
             frequency channels that transmit in BB mode
             (since CW mode can be in mixed in complex samples too)
         """
@@ -639,10 +639,10 @@ class CalibrateEK80(CalibrateEK):
 
         Parameters
         ----------
-        waveform_mode : str
+        waveform_mode: str
             ``CW`` for CW-mode samples, either recorded as complex or power samples
             ``BB`` for BB-mode samples, recorded as complex samples
-        freq_center : xr.DataArray
+        freq_center: xr.DataArray
             Nominal channel frequency for CW mode samples
             and an xr.DataArray with coorindate ``frequency`` and ``ping_time`` for BB mode samples
 
@@ -697,10 +697,10 @@ class CalibrateEK80(CalibrateEK):
 
         Parameters
         ----------
-        cal_type : str
+        cal_type: str
             'Sv' for calculating volume backscattering strength, or
             'Sp' for calculating point backscattering strength
-        waveform_mode : {"CW", "BB"}
+        waveform_mode: {"CW", "BB"}
             Type of transmit waveform.
 
             - `"CW"` for narrowband transmission,
@@ -867,11 +867,11 @@ class CalibrateEK80(CalibrateEK):
 
         Parameters
         ----------
-        cal_type : str
+        cal_type: str
             'Sv' for calculating volume backscattering strength, or
             'Sp' for calculating point backscattering strength
 
-        waveform_mode : {"CW", "BB"}
+        waveform_mode: {"CW", "BB"}
             Type of transmit waveform.
 
             - `"CW"` for narrowband transmission,
@@ -879,7 +879,7 @@ class CalibrateEK80(CalibrateEK):
             - `"BB"` for broadband transmission,
               returned echoes recorded as complex samples
 
-        encode_mode : {"complex", "power"}
+        encode_mode: {"complex", "power"}
             Type of encoded return echo data.
 
             - `"complex"` for complex samples
@@ -985,7 +985,7 @@ class CalibrateEK80(CalibrateEK):
 
         Parameters
         ----------
-        waveform_mode : {"CW", "BB"}
+        waveform_mode: {"CW", "BB"}
             Type of transmit waveform.
 
             - `"CW"` for narrowband transmission,
@@ -993,7 +993,7 @@ class CalibrateEK80(CalibrateEK):
             - (default) `"BB"` for broadband transmission,
               returned echoes recorded as complex samples
 
-        encode_mode : {"complex", "power"}
+        encode_mode: {"complex", "power"}
             Type of encoded return echo data.
 
             - (default) `"complex"` for complex samples
@@ -1002,7 +1002,7 @@ class CalibrateEK80(CalibrateEK):
 
         Returns
         -------
-        Sv : xr.DataSet
+        Sv: xr.DataSet
             A DataSet containing volume backscattering strength (``Sv``)
             and the corresponding range (``range``) in units meter.
         """
@@ -1015,7 +1015,7 @@ class CalibrateEK80(CalibrateEK):
 
         Parameters
         ----------
-        waveform_mode : {"CW", "BB"}
+        waveform_mode: {"CW", "BB"}
             Type of transmit waveform.
 
             - `"CW"` for narrowband transmission,
@@ -1023,7 +1023,7 @@ class CalibrateEK80(CalibrateEK):
             - (default) `"BB"` for broadband transmission,
               returned echoes recorded as complex samples
 
-        encode_mode : {"complex", "power"}
+        encode_mode: {"complex", "power"}
             Type of encoded return echo data.
 
             - (default) `"complex"` for complex samples
@@ -1032,7 +1032,7 @@ class CalibrateEK80(CalibrateEK):
 
         Returns
         -------
-        Sp : xr.DataSet
+        Sp: xr.DataSet
             A DataSet containing point backscattering strength (``Sp``)
             and the corresponding range (``range``) in units meter.
         """

--- a/echopype/convert/add_ancillary.py
+++ b/echopype/convert/add_ancillary.py
@@ -2,9 +2,9 @@ def update_platform(self, files=None, extra_platform_data=None):
     """
     Parameters
     ----------
-    files : str / list
+    files: str / list
         path of converted .nc/.zarr files
-    extra_platform_data : xarray dataset
+    extra_platform_data: xarray dataset
         dataset containing platform information along a 'time' dimension
     """
     # self.extra_platform data passed into to_netcdf or from another function

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -40,19 +40,19 @@ def to_file(
 
     Parameters
     ----------
-    engine : str {'netcdf4', 'zarr'}
+    engine: str {'netcdf4', 'zarr'}
         type of converted file
-    save_path : str
+    save_path: str
         path that converted .nc file will be saved
-    compress : bool
+    compress: bool
         whether or not to perform compression on data variables
         Defaults to ``True``
-    overwrite : bool
+    overwrite: bool
         whether or not to overwrite existing files
         Defaults to ``False``
-    parallel : bool
+    parallel: bool
         whether or not to use parallel processing. (Not yet implemented)
-    output_storage_options : dict
+    output_storage_options: dict
         Additional keywords to pass to the filesystem class.
     """
     if parallel:
@@ -273,20 +273,20 @@ def _check_file(
 
     Parameters
     ----------
-    raw_file : str
+    raw_file: str
         path to raw data file
-    sonar_model : str
+    sonar_model: str
         model of the sonar instrument
-    xml_path : str
+    xml_path: str
         path to XML config file used by AZFP
-    storage_options : dict
+    storage_options: dict
         options for cloud storage
 
     Returns
     -------
-    file : str
+    file: str
         path to existing raw data file
-    xml : str
+    xml: str
         path to existing xml file
         empty string if no xml file is required for the specified model
     """
@@ -331,9 +331,9 @@ def open_raw(
 
     Parameters
     ----------
-    raw_file : str
+    raw_file: str
         path to raw data file
-    sonar_model : str
+    sonar_model: str
         model of the sonar instrument
 
         - ``EK60``: Kongsberg Simrad EK60 echosounder
@@ -344,12 +344,12 @@ def open_raw(
         - ``AD2CP``: Nortek Signature series ADCP
           (tested with Signature 500 and Signature 1000)
 
-    xml_path : str
+    xml_path: str
         path to XML config file used by AZFP
-    convert_params : dict
+    convert_params: dict
         parameters (metadata) that may not exist in the raw file
         and need to be added to the converted file
-    storage_options : dict
+    storage_options: dict
         options for cloud storage
 
     Returns

--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -98,7 +98,7 @@ class ParseAZFP(ParseBase):
 
         Parameters
         ----------
-        raw : list
+        raw: list
             raw filename
         """
 

--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -335,13 +335,13 @@ class ParseEK(ParseBase):
 
         Parameters
         ----------
-        data_list : list
+        data_list: list
             Power, angle, or complex samples for each channel from RAW3 datagram.
             Each ping is one entry in the list.
 
         Returns
         -------
-        out_array : np.ndarray
+        out_array: np.ndarray
             Numpy array containing samplings from all pings.
             The array is NaN-padded if some pings are of different lengths.
         """

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -207,9 +207,9 @@ class SetGroupsEK80(SetGroupsBase):
 
         Parameters
         ----------
-        data_type : str
+        data_type: str
             'complex' or 'power'
-        params : dict
+        params: dict
             beam parameters that do not change across ping
         """
         ch_ids = self.parser_obj.ch_ids[data_type]

--- a/echopype/convert/utils/ek_raw_parsers.py
+++ b/echopype/convert/utils/ek_raw_parsers.py
@@ -516,7 +516,7 @@ class SimradMRUParser(_SimradDatagramParser):
         high_date:    long uint representing MSBytes of 64bit NT date
         timestamp:    datetime.datetime object of NT date, assumed to be UTC
         heave:        float
-        roll :        float
+        roll:        float
         pitch:        float
         heading:      float
 

--- a/echopype/echodata/api.py
+++ b/echopype/echodata/api.py
@@ -13,11 +13,11 @@ def open_converted(
 
     Parameters
     ----------
-    converted_raw_path : str
+    converted_raw_path: str
         path to converted data file
-    storage_options : dict
+    storage_options: dict
         options for cloud storage
-    kwargs : dict
+    kwargs: dict
         optional keyword arguments to be passed
         into xr.open_dataset
 

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -149,7 +149,7 @@ class EchoData:
 
         Parameters
         ----------
-        env_params : dict
+        env_params: dict
             Environmental parameters needed for computing sonar range.
             Users can supply `"sound speed"` directly,
             or specify other variables that can be used to compute them,
@@ -162,7 +162,7 @@ class EchoData:
             sensor, and some are equipped with a pressure sensor, but automatically
             using these pressure data is not currently supported.
 
-        azfp_cal_type : {"Sv", "Sp"}, optional
+        azfp_cal_type: {"Sv", "Sp"}, optional
 
             - `"Sv"` for calculating volume backscattering strength
             - `"Sp"` for calculating point backscattering strength.
@@ -170,7 +170,7 @@ class EchoData:
             This parameter needs to be specified for data from the AZFP echosounder,
             due to a difference in computing range for Sv and Sp.
 
-        ek_waveform_mode : {"CW", "BB"}, optional
+        ek_waveform_mode: {"CW", "BB"}, optional
             Type of transmit waveform.
             Required only for data from the EK80 echosounder.
 
@@ -179,7 +179,7 @@ class EchoData:
             - `"BB"` for broadband transmission,
               returned echoes recorded as complex samples
 
-        ek_encode_mode : {"complex", "power"}, optional
+        ek_encode_mode: {"complex", "power"}, optional
             Type of encoded return echo data.
             Required only for data from the EK80 echosounder.
 
@@ -395,7 +395,7 @@ class EchoData:
 
         Parameters
         ----------
-        extra_platform_data : xr.Dataset
+        extra_platform_data: xr.Dataset
             An `xr.Dataset` containing the additional platform data to be added
             to the `EchoData.platform` group.
         time_dim: str, default="time"
@@ -635,17 +635,17 @@ class EchoData:
 
         Parameters
         ----------
-        save_path : str
+        save_path: str
             path that converted .nc file will be saved
-        compress : bool
+        compress: bool
             whether or not to perform compression on data variables
             Defaults to ``True``
-        overwrite : bool
+        overwrite: bool
             whether or not to overwrite existing files
             Defaults to ``False``
-        parallel : bool
+        parallel: bool
             whether or not to use parallel processing. (Not yet implemented)
-        output_storage_options : dict
+        output_storage_options: dict
             Additional keywords to pass to the filesystem class.
         """
         from ..convert.api import to_file
@@ -657,17 +657,17 @@ class EchoData:
 
         Parameters
         ----------
-        save_path : str
+        save_path: str
             path that converted .nc file will be saved
-        compress : bool
+        compress: bool
             whether or not to perform compression on data variables
             Defaults to ``True``
-        overwrite : bool
+        overwrite: bool
             whether or not to overwrite existing files
             Defaults to ``False``
-        parallel : bool
+        parallel: bool
             whether or not to use parallel processing. (Not yet implemented)
-        output_storage_options : dict
+        output_storage_options: dict
             Additional keywords to pass to the filesystem class.
         """
         from ..convert.api import to_file

--- a/echopype/metrics/summary_statistics.py
+++ b/echopype/metrics/summary_statistics.py
@@ -18,8 +18,8 @@ def delta_z(ds: xr.Dataset, range_label="range") -> xr.DataArray:
 
     Parameters
     ----------
-    ds : xr.Dataset
-    range_label : str
+    ds: xr.Dataset
+    range_label: str
         Name of an xarray DataArray in `ds` containing range information.
 
     Returns
@@ -37,8 +37,8 @@ def convert_to_linear(ds: xr.Dataset, Sv_label="Sv") -> xr.DataArray:
 
     Parameters
     ----------
-    ds : xr.Dataset
-    Sv_label : str
+    ds: xr.Dataset
+    Sv_label: str
         Name of an xarray DataArray in `ds` containing volume backscattering strength (Sv).
 
     Returns
@@ -55,8 +55,8 @@ def abundance(ds: xr.Dataset, range_label="range") -> xr.DataArray:
 
     Parameters
     ----------
-    ds : xr.Dataset
-    range_label : str
+    ds: xr.Dataset
+    range_label: str
         Name of an xarray DataArray in `ds` containing range information.
 
     Returns
@@ -75,8 +75,8 @@ def center_of_mass(ds: xr.Dataset, range_label="range") -> xr.DataArray:
 
     Parameters
     ----------
-    ds : xr.Dataset
-    range_label : str
+    ds: xr.Dataset
+    range_label: str
         Name of an xarray DataArray in `ds` containing range information.
 
     Returns
@@ -97,8 +97,8 @@ def dispersion(ds: xr.Dataset, range_label="range") -> xr.DataArray:
 
     Parameters
     ----------
-    ds : xr.Dataset
-    range_label : str
+    ds: xr.Dataset
+    range_label: str
         Name of an xarray DataArray in `ds` containing range information.
 
     Returns
@@ -121,8 +121,8 @@ def evenness(ds: xr.Dataset, range_label="range") -> xr.DataArray:
 
     Parameters
     ----------
-    ds : xr.Dataset
-    range_label : str
+    ds: xr.Dataset
+    range_label: str
         Name of an xarray DataArray in `ds` containing range information.
 
     Returns
@@ -142,8 +142,8 @@ def aggregation(ds: xr.Dataset, range_label="range") -> xr.DataArray:
 
     Parameters
     ----------
-    ds : xr.Dataset
-    range_label : str
+    ds: xr.Dataset
+    range_label: str
         Name of an xarray DataArray in `ds` containing range information.
 
     Returns

--- a/echopype/preprocess/api.py
+++ b/echopype/preprocess/api.py
@@ -21,11 +21,11 @@ def compute_MVBS(ds_Sv, range_meter_bin=20, ping_time_bin="20S"):
 
     Parameters
     ----------
-    ds_Sv : xr.Dataset
+    ds_Sv: xr.Dataset
         dataset containing Sv and range [m]
-    range_meter_bin : Union[int, float]
+    range_meter_bin: Union[int, float]
         bin size along ``range`` in meters, default to ``20``
-    ping_time_bin : str
+    ping_time_bin: str
         bin size along ``ping_time``, default to ``20S``
 
     Returns
@@ -83,11 +83,11 @@ def compute_MVBS_index_binning(ds_Sv, range_bin_num=100, ping_num=100):
 
     Parameters
     ----------
-    ds_Sv : xr.Dataset
+    ds_Sv: xr.Dataset
         dataset containing Sv and range [m]
-    range_bin_num : int
+    range_bin_num: int
         number of samples to average along the ``range_bin`` dimension, default to 100
-    ping_num : int
+    ping_num: int
         number of pings to average, default to 100
 
     Returns
@@ -135,13 +135,13 @@ def estimate_noise(ds_Sv, ping_num, range_bin_num, noise_max=None):
 
     Parameters
     ----------
-    ds_Sv : xr.Dataset
+    ds_Sv: xr.Dataset
         dataset containing Sv and range [m]
-    ping_num : int
+    ping_num: int
         number of pings to obtain noise estimates
-    range_bin_num : int
+    range_bin_num: int
         number of samples along the ``range_bin`` dimension to obtain noise estimates
-    noise_max : float
+    noise_max: float
         the upper limit for background noise expected under the operating conditions
 
     Returns
@@ -167,15 +167,15 @@ def remove_noise(ds_Sv, ping_num, range_bin_num, noise_max=None, SNR_threshold=3
 
     Parameters
     ----------
-    ds_Sv : xr.Dataset
+    ds_Sv: xr.Dataset
         dataset containing Sv and range [m]
-    ping_num : int
+    ping_num: int
         number of pings to obtain noise estimates
-    range_bin_num : int
+    range_bin_num: int
         number of samples along the ``range_bin`` dimension to obtain noise estimates
-    noise_max : float
+    noise_max: float
         the upper limit for background noise expected under the operating conditions
-    SNR_threshold : float
+    SNR_threshold: float
         acceptable signal-to-noise ratio, default to 3 dB
 
     Returns

--- a/echopype/preprocess/noise_est.py
+++ b/echopype/preprocess/noise_est.py
@@ -7,11 +7,11 @@ class NoiseEst:
     """
     Attributes
     ----------
-    ds_Sv : xr.Dataset
+    ds_Sv: xr.Dataset
         dataset containing Sv and range [m]
-    ping_num : int
+    ping_num: int
         number of pings to obtain noise estimates
-    range_bin_num : int
+    range_bin_num: int
         number of samples along range to obtain noise estimates
     """
 
@@ -55,7 +55,7 @@ class NoiseEst:
 
         Parameters
         ----------
-        noise_max : Union[int, float]
+        noise_max: Union[int, float]
             the upper limit for background noise expected under the operating conditions
         """
         power_cal_binned_avg = 10 * np.log10(  # binned averages of calibrated power
@@ -94,9 +94,9 @@ class NoiseEst:
 
         Parameters
         ----------
-        noise_max : float
+        noise_max: float
             the upper limit for background noise expected under the operating conditions
-        SNR_threshold : float
+        SNR_threshold: float
             acceptable signal-to-noise ratio, default to 3 dB
         """
         # Compute Sv_noise

--- a/echopype/process/process_deprecated.py
+++ b/echopype/process/process_deprecated.py
@@ -151,9 +151,9 @@ class Process():
         based on the input file format.
         Parameters
         ----------
-        ds : xr.Dataset
+        ds: xr.Dataset
             xarray dataset object
-        path : str
+        path: str
             output file
         """
         if self._file_format == 'netcdf4':

--- a/echopype/qc/api.py
+++ b/echopype/qc/api.py
@@ -36,11 +36,11 @@ def coerce_increasing_time(ds, time_name="ping_time", local_win_len=100):
 
     Parameters
     ----------
-    ds : xr.Dataset
+    ds: xr.Dataset
         a dataset for which the time coordinate needs to be corrected
-    time_name : str
+    time_name: str
         name of the time coordinate to be corrected
-    local_win_len : int
+    local_win_len: int
         half length of the local window within which the median pinging interval
         is used to infer the correct next ping time
 
@@ -57,9 +57,9 @@ def exist_reversed_time(ds, time_name):
 
     Parameters
     ----------
-    ds : xr.Dataset
+    ds: xr.Dataset
         a dataset for which the time coordinate will be tested
-    time_name : str
+    time_name: str
         name of the time coordinate to be tested
 
     Returns

--- a/echopype/tests/preprocess/test_preprocess.py
+++ b/echopype/tests/preprocess/test_preprocess.py
@@ -112,15 +112,15 @@ def _construct_MVBS_toy_data(nfreq, npings, nrange_bins, ping_size, range_bin_si
 
     Parameters
     ----------
-    nfreq : int
+    nfreq: int
         number of frequencies
-    npings : int
+    npings: int
         number of pings
-    nrange_bins : int
+    nrange_bins: int
         number of range_bins
-    ping_size : int
+    ping_size: int
         number of pings with the same value
-    range_bin_size : int
+    range_bin_size: int
         number of range_bins with the same value
 
     Returns
@@ -148,11 +148,11 @@ def _construct_MVBS_test_data(nfreq, npings, nrange_bins):
 
     Parameters
     ----------
-    nfreq : int
+    nfreq: int
         number of frequencies
-    npings : int
+    npings: int
         number of pings
-    nrange_bins : int
+    nrange_bins: int
         number of range_bins
 
     Returns

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -86,13 +86,13 @@ def sanitize_file_path(
 
     Parameters
     ----------
-    file_path : str | Path | FSMap
+    file_path: str | Path | FSMap
         The source file path
-    engine : str {'netcdf4', 'zarr'}
+    engine: str {'netcdf4', 'zarr'}
         The engine to be used for file output
-    storage_options : dict
+    storage_options: dict
         Storage options for file path
-    is_dir : bool
+    is_dir: bool
         Flag for the function to know
         if file_path is a directory or not.
         If not, suffix will be determined.
@@ -146,13 +146,13 @@ def validate_output_path(
 
     Parameters
     ----------
-    source_file : str
+    source_file: str
         The source file path
-    engine : str {'netcdf4', 'zarr'}
+    engine: str {'netcdf4', 'zarr'}
         The engine to be used for file output
-    output_storage_options : dict
+    output_storage_options: dict
         Storage options for remote output path
-    save_path : str | Path | None
+    save_path: str | Path | None
         Either a directory or a file. If none then the save path is 'temp_echopype_output/'
         in the current working directory.
     """
@@ -225,9 +225,9 @@ def check_file_existence(
 
     Parameters
     ----------
-    file_path : str or pathlib.Path or fsspec.FSMap
+    file_path: str or pathlib.Path or fsspec.FSMap
         path to file
-    storage_options : dict
+    storage_options: dict
         options for cloud storage
     """
     if isinstance(file_path, Path):

--- a/echopype/utils/uwa.py
+++ b/echopype/utils/uwa.py
@@ -13,14 +13,14 @@ def calc_sound_speed(
 
     Parameters
     ----------
-    temperature : num
+    temperature: num
         temperature in deg C
-    salinity : num
+    salinity: num
         salinity in ppt
-    pressure : num
+    pressure: num
         pressure in dbars
 
-    formula_source : str
+    formula_source: str
         Source of formula used for calculating sound speed.
         Default is to use the formula supplied by AZFP (``formula_source='AZFP'``).
         Another option is to use Mackenzie (1981)
@@ -67,19 +67,19 @@ def calc_absorption(
 
     Parameters
     ----------
-    frequency : int or numpy array
+    frequency: int or numpy array
         frequency in Hz
-    distance : num
+    distance: num
         distance in m (FG formula only)
-    temperature : num
+    temperature: num
         temperature in deg C
-    salinity : num
+    salinity: num
         salinity in ppt
-    pressure : num
+    pressure: num
         pressure in dbars
-    pH : num
+    pH: num
         pH of water
-    formula_source : str
+    formula_source: str
         Source of formula used for calculating sound speed.
         Default is to use Ainlie and McColm (1998) (``formula_source='AM'``).
         Another option is to the formula supplied by AZFP (``formula_source='AZFP'``).

--- a/echopype/visualize/api.py
+++ b/echopype/visualize/api.py
@@ -19,21 +19,21 @@ def create_echogram(
 
     Parameters
     ----------
-    data : EchoData or xr.Dataset
+    data: EchoData or xr.Dataset
         Echodata or Xarray Dataset to be plotted
-    frequency : int, float, or list of float or ints, optional
+    frequency: int, float, or list of float or ints, optional
         The frequency to be plotted.
         Otherwise all frequency will be plotted.
-    get_range : bool, optional
+    get_range: bool, optional
         Flag as to whether range should be computed or not,
         by default it will just plot range_bin as the yaxis.
 
         Note that for data that is "Sv" xarray dataset, `get_range` defaults
         to `True`.
-    range_kwargs : dict
+    range_kwargs: dict
         Keyword arguments dictionary for computing range.
         Keys are `env_params`, `waveform_mode`, and `encode_mode`.
-    water_level : int, float, xr.DataArray, or bool, optional
+    water_level: int, float, xr.DataArray, or bool, optional
         Water level data array for platform water level correction.
         Note that auto addition of water level can be performed
         when data is an EchoData object by setting this argument


### PR DESCRIPTION
Currently in the API references, the parameter data types are not rendered correctly due to an extra space immediately after the parameter and before the ":" -- this is somewhat unexpected since that format "parameter : datatype" is what's in the [style guide](https://numpydoc.readthedocs.io/en/latest/format.html), but perhaps `automodapi` has its own mind?