### PR TITLE
docs: update RTD versions discussion (latest > dev) [skip ci]

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -35,7 +35,8 @@ This diagram depicts the complete workflow we use in the source GitHub repositor
         rel --> main
 
 - ``doc patch``: Updates to the documentation that refer to the current ``echopype`` 
-  release can be pushed out immediately to the `echopype documentation site <https://echopype.readthedocs.io>`_ 
+  release can be pushed out immediately to the 
+  `echopype documentation site <https://echopype.readthedocs.io>`_ 
   by contibuting patches (PRs) to the ``stable`` branch. See `Documentation development`_ 
   below for more details.
 - ``code patch``: Code development is carried out as patches (PRs) to the ``dev``
@@ -131,7 +132,6 @@ and `S3 object-storage <https://en.wikipedia.org/wiki/Amazon_S3>`_ sources,
 the latter via `minio <https://minio.io>`_.
 
 `.ci_helpers/run-test.py <https://github.com/OSOceanAcoustics/echopype/blob/main/.ci_helpers/run-test.py>`_
-
 will execute all tests. The entire test suite can be a bit slow, taking up to 40 minutes
 or more. If your changes impact only some of the subpackages (``convert``, ``calibrate``, 
 ``preprocess``, etc), you can run ``run-test.py`` with only a subset of tests by passing
@@ -142,7 +142,6 @@ as an argument a comma-separated list of the modules that have changed. For exam
     python .ci_helpers/run-test.py --local --pytest-args="-vv" echopype/calibrate/calibrate_ek.py,echopype/preprocess/noise_est.py
 
 will run only tests associated with the ``calibrate`` and ``preprocess`` subpackages.
-
 For ``run-test.py`` usage information, use the ``-h`` argument:
 ``python .ci_helpers/run-test.py -h``
 
@@ -224,12 +223,13 @@ Documentation versions
 `<https://echopype.readthedocs.io>`_ redirects to the documentation ``stable`` version, 
 `<https://echopype.readthedocs.io/en/stable/>`_, which is built from the ``stable`` branch 
 on the ``echopype`` GitHub repository. In addition, the ``latest`` version 
-(`<https://echopype.readthedocs.io/en/latest/>`_) is built from the ``main`` branch, 
-while the hidden `dev` version (`<https://echopype.readthedocs.io/en/dev/>`_) is built 
-from the ``dev`` branch. Finally, each new echopype release is built as a new release version 
-on ReadTheDocs. Merging pull requests into any of these three branches or issuing a 
-new tagged release will automatically result in a new ReadTheDocs build for the 
+(`<https://echopype.readthedocs.io/en/latest/>`_) is built from the ``dev`` branch and 
+therefore it reflects the bleeding edge development code (which may occasionally break
+the documenation build). Finally, each new echopype release is built as a new release version 
+on ReadTheDocs. Merging pull requests into ``stable`` or ``dev`` or issuing a new 
+tagged release will automatically result in a new ReadTheDocs build for the 
 corresponding version.
 
 We also maintain a test version of the documentation at `<https://doc-test-echopype.readthedocs.io/>`_
 for viewing and debugging larger, more experimental changes, typically from a separate fork.
+This version is used to test one-off, major breaking changes.


### PR DESCRIPTION
Also included minor improvements in the same Contributing page.

Completes #467, after the change (RTD `latest` version now points to `dev` branch) was implemented in RTD