### PR TITLE
Allow flexible environment variables in EA640/EK80 files

### DIFF
--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -24,20 +24,14 @@ class SetGroupsEK80(SetGroupsBase):
         ping_time = np.array([ping_time.astype("datetime64[ns]")])
 
         # Collect variables
+        tmp_env = self.parser_obj.environment.copy()
+        tmp_env.pop("timestamp")
+        tmp_env.pop("xml")
+        dict_env = dict()
+        for k, v in tmp_env.items():
+            dict_env[k] = (["ping_time"], [v])
         ds = xr.Dataset(
-            {
-                "temperature": (
-                    ["ping_time"],
-                    [self.parser_obj.environment["temperature"]],
-                ),
-                "depth": (["ping_time"], [self.parser_obj.environment["depth"]]),
-                "acidity": (["ping_time"], [self.parser_obj.environment["acidity"]]),
-                "salinity": (["ping_time"], [self.parser_obj.environment["salinity"]]),
-                "sound_speed_indicative": (
-                    ["ping_time"],
-                    [self.parser_obj.environment["sound_speed"]],
-                ),
-            },
+            dict_env,
             coords={
                 "ping_time": (
                     ["ping_time"],

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -25,11 +25,10 @@ class SetGroupsEK80(SetGroupsBase):
 
         # Collect variables
         tmp_env = self.parser_obj.environment.copy()
-        tmp_env.pop("timestamp")
-        tmp_env.pop("xml")
         dict_env = dict()
         for k, v in tmp_env.items():
-            dict_env[k] = (["ping_time"], [v])
+            if k in ["temperature", "depth", "acidity", "salinity", "sound_speed"]:
+                dict_env[k] = (["ping_time"], [v])
         ds = xr.Dataset(
             dict_env,
             coords={

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -24,11 +24,18 @@ class SetGroupsEK80(SetGroupsBase):
         ping_time = np.array([ping_time.astype("datetime64[ns]")])
 
         # Collect variables
-        tmp_env = self.parser_obj.environment.copy()
         dict_env = dict()
-        for k, v in tmp_env.items():
+        for k, v in self.parser_obj.environment.items():
             if k in ["temperature", "depth", "acidity", "salinity", "sound_speed"]:
                 dict_env[k] = (["ping_time"], [v])
+
+        # Rename to conform with those defined in convention
+        if "sound_speed" in dict_env:
+            dict_env["sound_speed_indicative"] = dict_env.pop("sound_speed")
+        for k in ["sound_absorption", "absorption"]:  # add possible variation until having example
+            if k in dict_env:
+                dict_env["absorption_indicative"] = dict_env.pop(k)
+
         ds = xr.Dataset(
             dict_env,
             coords={

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -32,7 +32,10 @@ class SetGroupsEK80(SetGroupsBase):
         # Rename to conform with those defined in convention
         if "sound_speed" in dict_env:
             dict_env["sound_speed_indicative"] = dict_env.pop("sound_speed")
-        for k in ["sound_absorption", "absorption"]:  # add possible variation until having example
+        for k in [
+            "sound_absorption",
+            "absorption",
+        ]:  # add possible variation until having example
             if k in dict_env:
                 dict_env["absorption_indicative"] = dict_env.pop(k)
 


### PR DESCRIPTION
This PR changes `SetGroupsEK80.set_env` to dynamically generates the dataset content. This addresses #531.

Still need to add a corresponding test to the convert tests.
@cywhale: If you have access to the recording software, could you try to see if you could further reduce the test file size?