### PR TITLE
Make "EA640" an allowable `sonar_model` input to `open_raw`

### DIFF
--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -432,7 +432,7 @@ def open_raw(
     # Set up echodata object
     echodata = EchoData(source_file=file_chk, xml_path=xml_chk, sonar_model=sonar_model)
     # Top-level date_created varies depending on sonar model
-    if sonar_model in ["EK60", "ES70", "EK80", "ES80"]:
+    if sonar_model in ["EK60", "ES70", "EK80", "ES80", "EA640"]:
         echodata.top = setgrouper.set_toplevel(
             sonar_model=sonar_model, date_created=parser.config_datagram["timestamp"]
         )
@@ -442,7 +442,7 @@ def open_raw(
         )
     echodata.environment = setgrouper.set_env()
     echodata.platform = setgrouper.set_platform()
-    if sonar_model in ["EK60", "ES70", "EK80", "ES80"]:
+    if sonar_model in ["EK60", "ES70", "EK80", "ES80", "EA640"]:
         echodata.nmea = setgrouper.set_nmea()
     echodata.provenance = setgrouper.set_provenance()
     echodata.sonar = setgrouper.set_sonar()

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -338,8 +338,8 @@ def open_raw(
 
         - ``EK60``: Kongsberg Simrad EK60 echosounder
         - ``ES70``: Kongsberg Simrad ES70 echosounder
-        - ``EK80``: Kongsberg Simrad EK80 echsoounder
-        - ``EA640``: Kongsberg EA640 echsoounder
+        - ``EK80``: Kongsberg Simrad EK80 echosounder
+        - ``EA640``: Kongsberg EA640 echosounder
         - ``AZFP``: ASL Environmental Sciences AZFP echosounder
         - ``AD2CP``: Nortek Signature series ADCP
           (tested with Signature 500 and Signature 1000)

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -338,8 +338,8 @@ def open_raw(
 
         - ``EK60``: Kongsberg Simrad EK60 echosounder
         - ``ES70``: Kongsberg Simrad ES70 echosounder
-        - ``EK80``: Kongsberg Simrad EK80 and Kongsberg EA640 echsoounders
-        - ``EK80``: Kongsberg Simrad EK80 and Kongsberg EA640 echsoounders
+        - ``EK80``: Kongsberg Simrad EK80 echsoounder
+        - ``EA640``: Kongsberg EA640 echsoounder
         - ``AZFP``: ASL Environmental Sciences AZFP echosounder
         - ``AD2CP``: Nortek Signature series ADCP
           (tested with Signature 500 and Signature 1000)

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -24,20 +24,14 @@ class SetGroupsEK80(SetGroupsBase):
         ping_time = np.array([ping_time.astype("datetime64[ns]")])
 
         # Collect variables
+        tmp_env = self.parser_obj.environment.copy()
+        tmp_env.pop("timestamp")
+        tmp_env.pop("xml")
+        dict_env = dict()
+        for k, v in tmp_env.items():
+            dict_env[k] = (["ping_time"], [v])
         ds = xr.Dataset(
-            {
-                "temperature": (
-                    ["ping_time"],
-                    [self.parser_obj.environment["temperature"]],
-                ),
-                "depth": (["ping_time"], [self.parser_obj.environment["depth"]]),
-                "acidity": (["ping_time"], [self.parser_obj.environment["acidity"]]),
-                "salinity": (["ping_time"], [self.parser_obj.environment["salinity"]]),
-                "sound_speed_indicative": (
-                    ["ping_time"],
-                    [self.parser_obj.environment["sound_speed"]],
-                ),
-            },
+            dict_env,
             coords={
                 "ping_time": (
                     ["ping_time"],

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -25,11 +25,10 @@ class SetGroupsEK80(SetGroupsBase):
 
         # Collect variables
         tmp_env = self.parser_obj.environment.copy()
-        tmp_env.pop("timestamp")
-        tmp_env.pop("xml")
         dict_env = dict()
         for k, v in tmp_env.items():
-            dict_env[k] = (["ping_time"], [v])
+            if k in ["temperature", "depth", "acidity", "salinity", "sound_speed"]:
+                dict_env[k] = (["ping_time"], [v])
         ds = xr.Dataset(
             dict_env,
             coords={


### PR DESCRIPTION
This PR makes it possible to use `sonar_model="EA640"` in `open_raw`. The docstring is also updated.

This PR addresses #538.