### PR TITLE
Add link to Notebook examples in Docs 

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-.. echopype documentation master file, created by
+OA.. echopype documentation master file, created by
    sphinx-quickstart on Wed Feb 13 15:33:27 2019.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
@@ -17,7 +17,7 @@ However, most of the new data remain under-utilized.
 echopype aims to address the root cause of this problem - the lack of
 interoperable data format and scalable analysis workflows that adapt well
 with increasing data volume - by providing open-source tools as entry points for
-scientists to make discovery using these new data.
+scientists to make discovery using these new data. .
 
 
 Documentation

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-OA.. echopype documentation master file, created by
+.. echopype documentation master file, created by
    sphinx-quickstart on Wed Feb 13 15:33:27 2019.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
@@ -17,7 +17,7 @@ However, most of the new data remain under-utilized.
 echopype aims to address the root cause of this problem - the lack of
 interoperable data format and scalable analysis workflows that adapt well
 with increasing data volume - by providing open-source tools as entry points for
-scientists to make discovery using these new data. .
+scientists to make discovery using these new data.
 
 
 Documentation

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -28,7 +28,7 @@ Examples
 --------
 
 Additional `Jupyter notebooks <https://osoceanacoustics.github.io/echopype-examples/>`_
-illustrating the workflow of Echopype are also made available to the public. These
+illustrating the workflow of Echopype are also made available. These
 examples include a quick tour of Echopype, a demonstration of how Echopype can be used
 to explore ship echosounder data from a Pacific Hake survey, and using Echopype to
 visualize the response of zooplankton to a solar eclipse.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,5 +1,9 @@
+Installation and Examples
+=========================
+
+
 Installation
-============
+------------
 
 Echopype is available and tested for Python>=3.7. The latest release 
 can be installed from `PyPI <https://pypi.org/project/echopype/>`_:
@@ -18,3 +22,13 @@ Previous releases are also available on PyPI and conda.
 
 For instructions on installing a development version of echopype,
 see the :doc:`contributing` page.
+
+
+Examples
+--------
+
+Additional `Jupyter notebooks <https://osoceanacoustics.github.io/echopype-examples/>`_
+illustrating the workflow of Echopype are also made available to the public. These
+examples include a quick tour of Echopype, a demonstration of how Echopype can be used
+to explore ship echosounder data from a Pacific Hake survey, and using Echopype to
+visualize the response of zooplankton to a solar eclipse.

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -1,6 +1,7 @@
 Other resources
 ================
 
+
 Software
 --------
 


### PR DESCRIPTION
This PR addresses the missing link to the Notebook examples in the Docs. 