### PR TITLE
Enable the handling of nans for visualize of echodata and Sv

### DIFF
--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -183,7 +183,6 @@ def test_plot_mvbs(
     mvbs = echopype.preprocess.compute_MVBS(Sv, ping_time_bin='10S')
 
     plots = []
-    plots = echopype.visualize.create_echogram(mvbs)
     try:
         plots = echopype.visualize.create_echogram(mvbs)
     except Exception as e:

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -1,4 +1,5 @@
 import echopype
+import echopype.visualize
 from echopype.testing import TEST_DATA_FOLDER
 
 import pytest

--- a/echopype/visualize/api.py
+++ b/echopype/visualize/api.py
@@ -14,7 +14,7 @@ def create_echogram(
     range_kwargs: dict = {},
     water_level: Union[int, float, xr.DataArray, bool, None] = None,
     **kwargs,
-) -> Union[FacetGrid, QuadMesh]:
+) -> List[Union[FacetGrid, QuadMesh]]:
     """Create an Echogram from an EchoData object or Sv and MVBS Dataset.
 
     Parameters


### PR DESCRIPTION
## Overview

This PR handles the `nan` values when trying to plot `backscatter_r` or `Sv` with `get_range=True`. It basically drops the nans and plot each frequency individually. The `create_echogram` API now returns a list rather than just a facet grid or quadmesh.