### PR TITLE
Update test_convert_source_target_locs to enable parallel testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Running All Tests
         shell: bash -l {0}
         run: |
-          pytest -vv -rx --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings |& tee ci_${{ matrix.python-version }}_test_log.log
+          pytest -vv -rx --numprocesses=4 --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings |& tee ci_${{ matrix.python-version }}_test_log.log
       - name: Upload ci test log
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -96,12 +96,12 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'Needs Complete Testing')
         shell: bash -l {0}
         run: |
-          pytest -vv -rx --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings |& tee ci_${{ matrix.python-version }}_test_log.log
+          pytest -vvv -rx --numprocesses=4 --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings |& tee ci_${{ matrix.python-version }}_test_log.log
       - name: Running Tests
         if: "!contains(github.event.pull_request.labels.*.name, 'Needs Complete Testing')"
         shell: bash -l {0}
         run: |
-          python .ci_helpers/run-test.py --pytest-args="--log-cli-level=WARNING,-vv,-rx,--disable-warnings" --include-cov ${{ steps.files.outputs.added_modified_renamed }} |& tee ci_test_log.log
+          python .ci_helpers/run-test.py --pytest-args="--log-cli-level=WARNING,-vvv,-rx,--numprocesses=4,--disable-warnings" --include-cov ${{ steps.files.outputs.added_modified_renamed }} |& tee ci_test_log.log
       - name: Upload ci test log
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v2

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -180,7 +180,8 @@ def validate_output_path(
     else:
         if isinstance(save_path, str):
             # Clean folder path by stripping '/' at the end
-            save_path = save_path.strip("/")
+            if save_path.endswith("/"):
+                save_path = save_path[:-1]
 
             # Determine whether this is a directory or not
             is_dir = True if Path(save_path).suffix == "" else False


### PR DESCRIPTION
## Overview

This PR updates the creation of temporary folders within `test_convert_source_target_locs` so that the tests can run in parallel without any issues.

## Current dev local test

Testing our current `dev` branch locally resulted in all tests being run within ~5 minutes rather than the current time of ~26 min.

![Screenshot from 2022-02-08 10-14-44](https://user-images.githubusercontent.com/17802172/153050248-8da71ed4-b807-418a-9770-743a561d9956.png)
