### PR TITLE
Make visualize module fully optional

### DIFF
--- a/echopype/__init__.py
+++ b/echopype/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from _echopype_version import version as __version__  # noqa
 
-from . import calibrate, preprocess, visualize
+from . import calibrate, preprocess
 from .convert.api import open_raw
 from .echodata.api import open_converted
 from .echodata.combine import combine_echodata
@@ -13,6 +13,5 @@ __all__ = [
     "open_converted",
     "combine_echodata",
     "calibrate",
-    "visualize",
     "preprocess",
 ]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,10 @@ with open("requirements.txt") as f:
 with open("requirements-dev.txt") as f:
     dev_reqs = f.readlines()
 
-EXTRA_REQUIRES = {"dev": dev_reqs, "plot": ["cmocean", "matplotlib"]}
+plot_reqs = ["cmocean", "matplotlib"]
+all_reqs = requirements + dev_reqs + plot_reqs
+
+EXTRA_REQUIRES = {"dev": dev_reqs, "plot": plot_reqs, "all": all_reqs}
 
 INSTALL_REQUIRES = [t.strip() for t in requirements]
 


### PR DESCRIPTION
## Overview

This PR fixes #558 by removing direct import of visualize module within the root echopype `__init__.py` file. This means that user now has to specifically import this module by doing: `from echopype import visualize` or `import echopype.visualize`. In that case if the `plot` dependency extra reqs isn't installed, it will throw the `No module named 'matplotlib'` error.