### PR TITLE
Add sonar_serial_number for EK80

### DIFF
--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -63,6 +63,7 @@ class SetGroupsEK80(SetGroupsBase):
             "transducer_name",
             "application_name",
             "application_version",
+            "channel_id_short",
         ]
         var = defaultdict(list)
         for ch_id, data in self.parser_obj.config_datagram["configuration"].items():
@@ -74,6 +75,7 @@ class SetGroupsEK80(SetGroupsBase):
             {
                 "serial_number": (["frequency"], var["serial_number"]),
                 "sonar_model": (["frequency"], var["transducer_name"]),
+                "sonar_serial_number": (["frequency"], var["channel_id_short"]),
                 "sonar_software_name": (
                     ["frequency"],
                     var["application_name"],


### PR DESCRIPTION
Resolves #212 

Adds a sonar_serial_number attribute to the sonar group for EK80 files.

# Examples

(same files from https://github.com/OSOceanAcoustics/echopype/issues/212#issuecomment-1053626927)

**File: test_data/ek80/D20170912-T234910.raw**

![image](https://user-images.githubusercontent.com/49664304/156159588-182246da-146e-475c-a8d3-e2e443d6b349.png)

**File: test_data/ek80/Green2.Survey2.FM.short.slow.-D20191004-T211557.raw**

![image](https://user-images.githubusercontent.com/49664304/156159743-deffb8ee-7966-4301-9f35-4c7ac08cb8bc.png)
