### PR TITLE
Change water_level name to range_offset and include it in the returned Dataset from compute_SV

### DIFF
--- a/docs/source/convert.rst
+++ b/docs/source/convert.rst
@@ -202,7 +202,7 @@ data attributes that are not recorded in the raw data files but need to be
 specified according to the SONAR-netCDF4 convention.
 These attributes are metadata and include
 ``platform_name``, ``platform_type``, ``platform_code_ICES``,
-and sometimes ``water_level``, depending on the sonar model.
+and sometimes ``range_offset``, depending on the sonar model.
 These attributes can be set using the following:
 
 .. code-block:: python

--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -16,7 +16,6 @@ def _compute_cal(
     cal_params=None,
     waveform_mode=None,
     encode_mode=None,
-    include_range_offset=False
 ):
     # Check on waveform_mode and encode_mode inputs
     if echodata.sonar_model == "EK80":
@@ -55,7 +54,7 @@ def _compute_cal(
     # Perform calibration
     if cal_type == "Sv":
 
-        if include_range_offset and ('range_offset' in echodata.platform.data_vars.keys()):
+        if 'range_offset' in echodata.platform.data_vars.keys():
 
             # add range_offset to the created xr.Dataset
             sv_dataset = cal_obj.compute_Sv(waveform_mode=waveform_mode, encode_mode=encode_mode)
@@ -129,12 +128,6 @@ def compute_Sv(echodata: EchoData, **kwargs) -> xr.Dataset:
         - `"power"` for power/angle samples, only allowed when
           the echosounder is configured for narrowband transmission
 
-    include_range_offset : bool, optional
-        If True, the returned xr.Dataset (describing the calibrated
-        Sv dataset) will contain the variable range_offset from the
-        EchoData object provided (if it exists). By default, this
-        value is set to False.
-
     Returns
     -------
     xr.Dataset
@@ -156,6 +149,10 @@ def compute_Sv(echodata: EchoData, **kwargs) -> xr.Dataset:
     The current calibration implemented for EK80 broadband complex data
     uses band-integrated Sv with the gain computed at the center frequency
     of the transmit signal.
+
+    The returned xr.Dataset will contain the variable range_offset from the
+    EchoData object provided, if it exists. If range_offset is not returned,
+    it must be set using EchoData.update_platform().
     """
     return _compute_cal(cal_type="Sv", echodata=echodata, **kwargs)
 

--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -54,15 +54,19 @@ def _compute_cal(
     # Perform calibration
     if cal_type == "Sv":
 
-        if 'range_offset' in echodata.platform.data_vars.keys():
+        if "range_offset" in echodata.platform.data_vars.keys():
 
             # add range_offset to the created xr.Dataset
-            sv_dataset = cal_obj.compute_Sv(waveform_mode=waveform_mode, encode_mode=encode_mode)
-            sv_dataset['range_offset'] = echodata.platform.range_offset
+            sv_dataset = cal_obj.compute_Sv(
+                waveform_mode=waveform_mode, encode_mode=encode_mode
+            )
+            sv_dataset["range_offset"] = echodata.platform.range_offset
             return sv_dataset
 
         else:
-            return cal_obj.compute_Sv(waveform_mode=waveform_mode, encode_mode=encode_mode)
+            return cal_obj.compute_Sv(
+                waveform_mode=waveform_mode, encode_mode=encode_mode
+            )
 
     else:
         return cal_obj.compute_Sp(waveform_mode=waveform_mode, encode_mode=encode_mode)

--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -16,6 +16,7 @@ def _compute_cal(
     cal_params=None,
     waveform_mode=None,
     encode_mode=None,
+    include_range_offset=False
 ):
     # Check on waveform_mode and encode_mode inputs
     if echodata.sonar_model == "EK80":
@@ -53,7 +54,17 @@ def _compute_cal(
     )
     # Perform calibration
     if cal_type == "Sv":
-        return cal_obj.compute_Sv(waveform_mode=waveform_mode, encode_mode=encode_mode)
+
+        if include_range_offset and ('range_offset' in echodata.platform.data_vars.keys()):
+
+            # add range_offset to the created xr.Dataset
+            sv_dataset = cal_obj.compute_Sv(waveform_mode=waveform_mode, encode_mode=encode_mode)
+            sv_dataset['range_offset'] = echodata.platform.range_offset
+            return sv_dataset
+
+        else:
+            return cal_obj.compute_Sv(waveform_mode=waveform_mode, encode_mode=encode_mode)
+
     else:
         return cal_obj.compute_Sp(waveform_mode=waveform_mode, encode_mode=encode_mode)
 
@@ -117,6 +128,12 @@ def compute_Sv(echodata: EchoData, **kwargs) -> xr.Dataset:
         - `"complex"` for complex samples
         - `"power"` for power/angle samples, only allowed when
           the echosounder is configured for narrowband transmission
+
+    include_range_offset : bool, optional
+        If True, the returned xr.Dataset (describing the calibrated
+        Sv dataset) will contain the variable range_offset from the
+        EchoData object provided (if it exists). By default, this
+        value is set to False.
 
     Returns
     -------

--- a/echopype/convert/add_ancillary.py
+++ b/echopype/convert/add_ancillary.py
@@ -99,11 +99,11 @@ def update_platform(self, files=None, extra_platform_data=None):
                             default=np.full(num_obs, np.nan),
                         ),
                     ),
-                    "water_level": (
+                    "range_offset": (
                         "location_time",
                         mapping_get_multiple(
                             extra_platform_data,
-                            ["water_level", "WATER_LEVEL"],
+                            ["range_offset", "RANGE_OFFSET"],
                             np.ones(num_obs),
                         ),
                     ),
@@ -160,11 +160,11 @@ def update_platform(self, files=None, extra_platform_data=None):
                             default=np.full(num_obs, np.nan),
                         ),
                     ),
-                    "water_level": (
+                    "range_offset": (
                         "location_time",
                         mapping_get_multiple(
                             extra_platform_data,
-                            ["water_level", "WATER_LEVEL"],
+                            ["range_offset", "RANGE_OFFSET"],
                             np.ones(num_obs),
                         ),
                     ),

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -223,7 +223,7 @@ def _set_convert_params(param_dict: Dict[str, str]) -> Dict[str, str]:
     """Set parameters (metadata) that may not exist in the raw files.
 
     The default set of parameters include:
-    - Platform group: ``platform_name``, ``platform_type``, ``platform_code_ICES``, ``water_level``
+    - Platform group: ``platform_name``, ``platform_type``, ``platform_code_ICES``, ``range_offset``
     - Platform/NMEA: ``nmea_gps_sentence``,
                      for selecting specific NMEA sentences,
                      with default values ['GGA', 'GLL', 'RMC'].
@@ -248,7 +248,7 @@ def _set_convert_params(param_dict: Dict[str, str]) -> Dict[str, str]:
     out_params["platform_name"] = param_dict.get("platform_name", "")
     out_params["platform_code_ICES"] = param_dict.get("platform_code_ICES", "")
     out_params["platform_type"] = param_dict.get("platform_type", "")
-    out_params["water_level"] = param_dict.get("water_level", None)
+    out_params["range_offset"] = param_dict.get("range_offset", None)
     out_params["nmea_gps_sentence"] = param_dict.get(
         "nmea_gps_sentence", NMEA_SENTENCE_DEFAULT
     )

--- a/echopype/convert/convert.py
+++ b/echopype/convert/convert.py
@@ -15,7 +15,7 @@ CONVERT_PARAMS = [
     "platform_name",
     "platform_code_ICES",
     "platform_type",
-    "water_level",
+    "range_offset",
     "nmea_gps_sentence",
 ]
 

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -206,8 +206,8 @@ class SetGroupsEK60(SetGroupsBase):
             ch_ids = list(self.parser_obj.config_datagram["transceivers"].keys())
 
             # TODO: consider allow users to set range_offset like in EK80?
-            # if self.ui_param['water_level'] is not None:
-            #     range_offset = self.ui_param['water_level']
+            # if self.ui_param['range_offset'] is not None:
+            #     range_offset = self.ui_param['range_offset']
             # else:
             #     range_offset = np.nan
             #     print('WARNING: The water_level_draft was not in the file. Value '

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -205,11 +205,11 @@ class SetGroupsEK60(SetGroupsBase):
         if not NMEA_only:
             ch_ids = list(self.parser_obj.config_datagram["transceivers"].keys())
 
-            # TODO: consider allow users to set water_level like in EK80?
+            # TODO: consider allow users to set range_offset like in EK80?
             # if self.ui_param['water_level'] is not None:
-            #     water_level = self.ui_param['water_level']
+            #     range_offset = self.ui_param['water_level']
             # else:
-            #     water_level = np.nan
+            #     range_offset = np.nan
             #     print('WARNING: The water_level_draft was not in the file. Value '
             #           'set to None.')
 
@@ -233,10 +233,10 @@ class SetGroupsEK60(SetGroupsBase):
                             self.parser_obj.ping_data_dict["heave"][ch],
                             self._varattrs["platform_var_default"]["heave"],
                         ),
-                        "water_level": (
+                        "range_offset": (
                             ["ping_time"],
                             self.parser_obj.ping_data_dict["transducer_depth"][ch],
-                            self._varattrs["platform_var_default"]["water_level"],
+                            self._varattrs["platform_var_default"]["range_offset"],
                         ),
                     },
                     coords={

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -96,8 +96,8 @@ class SetGroupsEK80(SetGroupsBase):
         """Set the Platform group."""
 
         # Collect variables
-        if self.ui_param["water_level"] is not None:
-            range_offset = self.ui_param["water_level"]
+        if self.ui_param["range_offset"] is not None:
+            range_offset = self.ui_param["range_offset"]
         elif "water_level_draft" in self.parser_obj.environment:
             range_offset = self.parser_obj.environment["water_level_draft"]
         else:

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -97,11 +97,11 @@ class SetGroupsEK80(SetGroupsBase):
 
         # Collect variables
         if self.ui_param["water_level"] is not None:
-            water_level = self.ui_param["water_level"]
+            range_offset = self.ui_param["water_level"]
         elif "water_level_draft" in self.parser_obj.environment:
-            water_level = self.parser_obj.environment["water_level_draft"]
+            range_offset = self.parser_obj.environment["water_level_draft"]
         else:
-            water_level = np.nan
+            range_offset = np.nan
             print(
                 "WARNING: The water_level_draft was not in the file. "
                 "Value set to NaN."
@@ -165,9 +165,9 @@ class SetGroupsEK80(SetGroupsBase):
                     },
                 ),
                 "sentence_type": (["location_time"], msg_type),
-                "water_level": (
+                "range_offset": (
                     [],
-                    water_level,
+                    range_offset,
                     {
                         "long_name": "z-axis distance from the platform coordinate system "
                         "origin to the sonar transducer",

--- a/echopype/echodata/convention/1.0.yml
+++ b/echopype/echodata/convention/1.0.yml
@@ -89,6 +89,6 @@ variable_and_varattributes:
       standard_name: platform_heave_angle
       units: arc_degree
       valid_range: (-90.0, 90.0)
-    water_level:
+    range_offset:
       long_name: z-axis distance from the platform coordinate system origin to the sonar transducer
       units: m

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -403,7 +403,7 @@ class EchoData:
             - `"heave"`
             - `"latitude"`
             - `"longitude"`
-            - `"water_level"`
+            - `"range_offset"`
         The data inserted into the Platform group will be indexed by a dimension named
         `"location_time"`.
 
@@ -504,7 +504,7 @@ class EchoData:
             "heave",
             "latitude",
             "longitude",
-            "water_level",
+            "range_offset",
         ]
         dropped_vars = []
         for var in dropped_vars_target:
@@ -569,12 +569,12 @@ class EchoData:
                         default=platform.get("longitude", np.full(num_obs, np.nan)),
                     ),
                 ),
-                "water_level": (
+                "range_offset": (
                     "location_time",
                     mapping_search_variable(
                         extra_platform_data,
-                        ["water_level", "WATER_LEVEL"],
-                        default=platform.get("water_level", np.zeros(num_obs)),
+                        ["range_offset", "RANGE_OFFSET"],
+                        default=platform.get("range_offset", np.zeros(num_obs)),
                     ),
                 ),
             }

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -405,7 +405,7 @@ def test_update_platform(update_platform_samples):
 
     ed = echopype.open_raw(raw_file, "EK80")
 
-    updated = ["pitch", "roll", "latitude", "longitude", "water_level"]
+    updated = ["pitch", "roll", "latitude", "longitude", "range_offset"]
     for variable in updated:
         assert np.isnan(ed.platform[variable].values).all()
 

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -195,7 +195,7 @@ def test_plot_mvbs(
 
 
 @pytest.mark.parametrize(
-    ("water_level", "expect_warning"),
+    ("range_offset", "expect_warning"),
     [
         (True, False),
         ([True], True),
@@ -206,9 +206,9 @@ def test_plot_mvbs(
         (30.5, False),
     ],
 )
-def test_water_level_echodata(water_level, expect_warning):
+def test_range_offset_echodata(range_offset, expect_warning):
     from echopype.echodata import EchoData
-    from echopype.visualize.api import _add_water_level
+    from echopype.visualize.api import _add_range_offset
 
     filepath = ek60_path / "ncei-wcsd" / "Summer2017-D20170719-T211347.raw"
     sonar_model = "EK60"
@@ -225,25 +225,25 @@ def test_water_level_echodata(water_level, expect_warning):
         ek_encode_mode=range_kwargs.get('encode_mode', 'power'),
     )
     single_array = range_in_meter.isel(frequency=0, ping_time=0).values
-    no_input_water_level = False
-    if isinstance(water_level, list):
-        water_level = water_level[0]
-        echodata.platform = echodata.platform.drop_vars('water_level')
-        no_input_water_level = True
+    no_input_range_offset = False
+    if isinstance(range_offset, list):
+        range_offset = range_offset[0]
+        echodata.platform = echodata.platform.drop_vars('range_offset')
+        no_input_range_offset = True
 
-    if isinstance(water_level, xr.DataArray):
-        if 'frequency' in water_level.dims:
-            original_array = single_array + water_level.isel(frequency=0).values
-    elif isinstance(water_level, bool) and water_level is True:
-        if no_input_water_level is False:
+    if isinstance(range_offset, xr.DataArray):
+        if 'frequency' in range_offset.dims:
+            original_array = single_array + range_offset.isel(frequency=0).values
+    elif isinstance(range_offset, bool) and range_offset is True:
+        if no_input_range_offset is False:
             original_array = (
                 single_array
-                + echodata.platform.water_level.isel(frequency=0, ping_time=0).values
+                + echodata.platform.range_offset.isel(frequency=0, ping_time=0).values
             )
         else:
             original_array = single_array
-    elif water_level is not False and isinstance(water_level, (int, float)):
-        original_array = single_array + water_level
+    elif range_offset is not False and isinstance(range_offset, (int, float)):
+        original_array = single_array + range_offset
     else:
         original_array = single_array
 
@@ -251,22 +251,22 @@ def test_water_level_echodata(water_level, expect_warning):
     try:
         if expect_warning:
             with pytest.warns(UserWarning):
-                results = _add_water_level(
+                results = _add_range_offset(
                     range_in_meter=range_in_meter,
-                    water_level=water_level,
+                    range_offset=range_offset,
                     data_type=EchoData,
                     platform_data=echodata.platform,
                 )
         else:
-            results = _add_water_level(
+            results = _add_range_offset(
                 range_in_meter=range_in_meter,
-                water_level=water_level,
+                range_offset=range_offset,
                 data_type=EchoData,
                 platform_data=echodata.platform,
             )
     except Exception as e:
         assert isinstance(e, ValueError)
-        assert str(e) == 'Water level must have any of these dimensions: frequency, ping_time, range_bin'  # noqa
+        assert str(e) == 'Range offset must have any of these dimensions: frequency, ping_time, range_bin'  # noqa
 
     if isinstance(results, xr.DataArray):
         final_array = results.isel(frequency=0, ping_time=0).values
@@ -275,7 +275,7 @@ def test_water_level_echodata(water_level, expect_warning):
 
 
 @pytest.mark.parametrize(
-    ("water_level", "expect_warning"),
+    ("range_offset", "expect_warning"),
     [
         (True, True),
         (False, True),
@@ -285,8 +285,8 @@ def test_water_level_echodata(water_level, expect_warning):
         (30.5, False),
     ],
 )
-def test_water_level_Sv_dataset(water_level, expect_warning):
-    from echopype.visualize.api import _add_water_level
+def test_range_offset_Sv_dataset(range_offset, expect_warning):
+    from echopype.visualize.api import _add_range_offset
 
     filepath = ek60_path / "ncei-wcsd" / "Summer2017-D20170719-T211347.raw"
     sonar_model = "EK60"
@@ -300,11 +300,11 @@ def test_water_level_Sv_dataset(water_level, expect_warning):
     range_in_meter = ds.range
     single_array = range_in_meter.isel(frequency=0, ping_time=0).values
 
-    if isinstance(water_level, xr.DataArray):
-        if 'frequency' in water_level.dims:
-            original_array = single_array + water_level.isel(frequency=0).values
-    elif not isinstance(water_level, bool) and isinstance(water_level, (int, float)):
-        original_array = single_array + water_level
+    if isinstance(range_offset, xr.DataArray):
+        if 'frequency' in range_offset.dims:
+            original_array = single_array + range_offset.isel(frequency=0).values
+    elif not isinstance(range_offset, bool) and isinstance(range_offset, (int, float)):
+        original_array = single_array + range_offset
     else:
         original_array = single_array
 
@@ -312,20 +312,20 @@ def test_water_level_Sv_dataset(water_level, expect_warning):
     try:
         if expect_warning:
             with pytest.warns(UserWarning):
-                results = _add_water_level(
+                results = _add_range_offset(
                     range_in_meter=range_in_meter,
-                    water_level=water_level,
+                    range_offset=range_offset,
                     data_type=xr.Dataset,
                 )
         else:
-            results = _add_water_level(
+            results = _add_range_offset(
                 range_in_meter=range_in_meter,
-                water_level=water_level,
+                range_offset=range_offset,
                 data_type=xr.Dataset,
             )
     except Exception as e:
         assert isinstance(e, ValueError)
-        assert str(e) == 'Water level must have any of these dimensions: frequency, ping_time, range_bin'  # noqa
+        assert str(e) == 'Range offset must have any of these dimensions: frequency, ping_time, range_bin'  # noqa
 
     if isinstance(results, xr.DataArray):
         final_array = results.isel(frequency=0, ping_time=0).values


### PR DESCRIPTION
This PR is directly related to #516 and partially related to #259.

It changes the current `EchoData.platform.water_level` name to `EchoData.platform.range_offset`.

Additionally, it allows for the inclusion of the `range_offset` variable in the Sv dataset.  The inclusion of `range_offset` is achieved in the calibrate function [compute_Sv](https://echopype.readthedocs.io/en/stable/api/echopype.calibrate.compute_Sv.html) by setting `include_range_offset` as an optional input argument (with a default value of False). The following code snippet is an example of its usage:

```
import echopype as ep
ed = ep.open_raw(raw_file="...", sonar_model='EK60')
ds_Sv = ep.calibrate.compute_Sv(ed, include_range_offset=True)
```