### PR TITLE
Add test_data to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ azfp/
 temp_echopype_output/
 notebooks/*_dev/
 _echopype_version.py
+!echopype/test_data
+echopype/test_data/*
+!echopype/test_data/README.md


### PR DESCRIPTION
Currently the `.gitignore` does not ignore some files in the `echopype/test_data` file. In this PR I add lines that explicitly ignore everything in the `test_data` folder except the `README.md`. 