### PR TITLE
Fix indentation in Sv dataset `water_level` existence

### DIFF
--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -37,8 +37,8 @@ def test_compute_Sv_returns_water_level(ek60_path):
     # make sure the returned Dataset has water_level and throw an assertion error if the
     # EchoData object does not have water_level (just in case we remove it from the file
     # used in the future)
-   assert 'water_level' in ed.platform.data_vars.keys()
-   assert 'water_level' in ds_Sv.data_vars
+    assert 'water_level' in ed.platform.data_vars.keys()
+    assert 'water_level' in ds_Sv.data_vars
 
 
 def test_compute_Sv_ek60_echoview(ek60_path):


### PR DESCRIPTION
This is leftover from #583 where there's an indentation error. Somehow I didn't notice that the test didn't pass at that time. :/ 