### PR TITLE
Change `range_bin` to `range_sample`

### DIFF
--- a/docs/source/convert.rst
+++ b/docs/source/convert.rst
@@ -285,7 +285,7 @@ currently not supported.
 .. note::
 
    Zarr datasets will be automatically chunked with default chunk sizes of
-   25000 for ``range_bin`` and 2500 for ``ping_time`` dimensions.
+   25000 for ``range_sample`` and 2500 for ``ping_time`` dimensions.
 
 
 Non-uniform data
@@ -301,7 +301,7 @@ change in the middle of the file. For example:
 - Data from different frequency channels can also be collected with
   different sampling intervals.
 
-These changes produce different number of samples along range (the ``range_bin``
+These changes produce different number of samples along range (the ``range_sample``
 dimension in the converted ``.nc`` file), which are incompatible with the goal
 to save the data as a multi-dimensional array that can be easily indexed using xarray.
 

--- a/docs/source/process.rst
+++ b/docs/source/process.rst
@@ -22,7 +22,7 @@ Functionality
     from the calibrated data.
   - Compute mean volume backscattering strength (MVBS) based
     on either the number of pings and sample intervals
-    (the ``range_bin`` dimension in the dataset) or a
+    (the ``range_sample`` dimension in the dataset) or a
     specified ping time interval and range interval in
     physics units (seconds and meters, respectively).
 
@@ -70,7 +70,7 @@ The steps for performing these analyses are summarized below:
       # Reduce data based on sample number
       ds_MVBS = ep.preprocess.compute_MVBS_index_binning(
            ds_Sv,             # calibrated Sv dataset
-           range_bin_num=30,  # number of sample bins to average along the range_bin dimensionm
+           range_sample_num=30,  # number of sample bins to average along the range_sample dimensionm
            ping_num=5         # number of pings to average
        )
 
@@ -81,7 +81,7 @@ The steps for performing these analyses are summarized below:
       # Remove noise
       ds_Sv_clean = ep.preprocess.remove_noise(    # obtain a denoised Sv dataset
          ds_Sv,             # calibrated Sv dataset
-         range_bin_num=30,  # number of samples along the range_bin dimension for estimating noise
+         range_sample_num=30,  # number of samples along the range_sample dimension for estimating noise
          ping_num=5,        # number of pings for estimating noise
       )
 

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -317,4 +317,4 @@ New features
 Bug fixes
 ~~~~~~~~~
 
-Fix bugs in slicing NMEA group data based on the same time base when `range_sample` is changed
+Fix bugs in slicing NMEA group data based on the same time base when `range_bin` is changed

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -317,4 +317,4 @@ New features
 Bug fixes
 ~~~~~~~~~
 
-Fix bugs in slicing NMEA group data based on the same time base when `range_bin` is changed
+Fix bugs in slicing NMEA group data based on the same time base when `range_sample` is changed

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -594,7 +594,7 @@ class CalibrateEK80(CalibrateEK):
         for freq in freq_BB:
             backscatter_freq = (
                 backscatter.sel(frequency=freq)
-                .dropna(dim="range_bin", how="all")
+                .dropna(dim="range_sample", how="all")
                 .dropna(dim="quadrant", how="all")
                 .dropna(dim="ping_time")
             )
@@ -604,7 +604,7 @@ class CalibrateEK80(CalibrateEK):
             replica = xr.DataArray(np.conj(chirp[channel_id]), dims="window")
             # Pulse compression via rolling
             pc = (
-                backscatter_freq.rolling(range_bin=replica.size)
+                backscatter_freq.rolling(range_sample=replica.size)
                 .construct("window")
                 .dot(replica)
                 / np.linalg.norm(chirp[channel_id]) ** 2

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -21,7 +21,7 @@ COMPRESSION_SETTINGS = {
     "zarr": {"compressor": zarr.Blosc(cname="zstd", clevel=3, shuffle=2)},
 }
 
-DEFAULT_CHUNK_SIZE = {"range_bin": 25000, "ping_time": 2500}
+DEFAULT_CHUNK_SIZE = {"range_sample": 25000, "ping_time": 2500}
 
 NMEA_SENTENCE_DEFAULT = ["GGA", "GLL", "RMC"]
 
@@ -152,7 +152,7 @@ def _save_groups_to_file(echodata, output_path, engine, compress=True):
         io.save_file(
             echodata.beam.chunk(
                 {
-                    "range_bin": DEFAULT_CHUNK_SIZE["range_bin"],
+                    "range_sample": DEFAULT_CHUNK_SIZE["range_sample"],
                     "ping_time": DEFAULT_CHUNK_SIZE["ping_time"],
                 }
             ),
@@ -166,7 +166,7 @@ def _save_groups_to_file(echodata, output_path, engine, compress=True):
         io.save_file(
             echodata.beam_power.chunk(
                 {
-                    "range_bin": DEFAULT_CHUNK_SIZE["range_bin"],
+                    "range_sample": DEFAULT_CHUNK_SIZE["range_sample"],
                     "ping_time": DEFAULT_CHUNK_SIZE["ping_time"],
                 }
             ),

--- a/echopype/convert/convert_combine.py
+++ b/echopype/convert/convert_combine.py
@@ -103,7 +103,7 @@ def perform_combination(sonar_model, input_paths, output_path, engine):
         io.save_file(
             ds_beam.chunk(
                 {
-                    "range_bin": DEFAULT_CHUNK_SIZE["range_bin"],
+                    "range_sample": DEFAULT_CHUNK_SIZE["range_sample"],
                     "ping_time": DEFAULT_CHUNK_SIZE["ping_time"],
                 }
             ),  # these chunk sizes are ad-hoc

--- a/echopype/convert/parse_ad2cp.py
+++ b/echopype/convert/parse_ad2cp.py
@@ -117,9 +117,9 @@ class Dimension(Enum):
     TIME_ECHOSOUNDER_RAW = "ping_time_echosounder_raw"
     TIME_ECHOSOUNDER_RAW_TRANSMIT = "ping_time_echosounder_raw_transmit"
     BEAM = "beam"
-    RANGE_BIN_BURST = "range_bin_burst"
-    RANGE_BIN_AVERAGE = "range_bin_average"
-    RANGE_BIN_ECHOSOUNDER = "range_bin_echosounder"
+    RANGE_SAMPLE_BURST = "range_sample_burst"
+    RANGE_SAMPLE_AVERAGE = "range_sample_average"
+    RANGE_SAMPLE_ECHOSOUNDER = "range_sample_echosounder"
     NUM_ALTIMETER_SAMPLES = "num_altimeter_samples"
     SAMPLE = "sample"
     SAMPLE_TRANSMIT = "sample_transmit"
@@ -890,21 +890,21 @@ class Ad2cpDataPacket:
         return checksum
 
 
-RANGE_BINS = {
-    DataRecordType.AVERAGE_VERSION2: Dimension.RANGE_BIN_AVERAGE,
-    DataRecordType.AVERAGE_VERSION3: Dimension.RANGE_BIN_AVERAGE,
-    DataRecordType.BURST_VERSION2: Dimension.RANGE_BIN_BURST,
-    DataRecordType.BURST_VERSION3: Dimension.RANGE_BIN_BURST,
-    DataRecordType.ECHOSOUNDER: Dimension.RANGE_BIN_ECHOSOUNDER,
+RANGE_SAMPLES = {
+    DataRecordType.AVERAGE_VERSION2: Dimension.RANGE_SAMPLE_AVERAGE,
+    DataRecordType.AVERAGE_VERSION3: Dimension.RANGE_SAMPLE_AVERAGE,
+    DataRecordType.BURST_VERSION2: Dimension.RANGE_SAMPLE_BURST,
+    DataRecordType.BURST_VERSION3: Dimension.RANGE_SAMPLE_BURST,
+    DataRecordType.ECHOSOUNDER: Dimension.RANGE_SAMPLE_ECHOSOUNDER,
 }
 
 
-def range_bin(data_record_type: DataRecordType) -> Dimension:
+def range_sample(data_record_type: DataRecordType) -> Dimension:
     """
-    Gets the correct range bin dimension for the given data record type
+    Gets the correct range sample dimension for the given data record type
     """
 
-    return RANGE_BINS[data_record_type]
+    return RANGE_SAMPLES[data_record_type]
 
 
 class HeaderOrDataRecordFormat:
@@ -1104,7 +1104,7 @@ class HeaderOrDataRecordFormats:
                     field_dimensions=lambda data_record_type: [
                         Dimension.TIME_BURST,
                         Dimension.BEAM,
-                        range_bin(data_record_type),
+                        range_sample(data_record_type),
                     ],
                     field_units="m/s",
                     field_unit_conversion=lambda packet, x: x
@@ -1123,7 +1123,7 @@ class HeaderOrDataRecordFormats:
                     field_dimensions=lambda data_record_type: [
                         Dimension.TIME_AVERAGE,
                         Dimension.BEAM,
-                        range_bin(data_record_type),
+                        range_sample(data_record_type),
                     ],
                     field_units="m/s",
                     field_unit_conversion=lambda packet, x: x
@@ -1142,7 +1142,7 @@ class HeaderOrDataRecordFormats:
                     field_dimensions=lambda data_record_type: [
                         Dimension.TIME_ECHOSOUNDER,
                         Dimension.BEAM,
-                        range_bin(data_record_type),
+                        range_sample(data_record_type),
                     ],
                     field_units="m/s",
                     field_unit_conversion=lambda packet, x: x
@@ -1161,7 +1161,7 @@ class HeaderOrDataRecordFormats:
                     field_dimensions=lambda data_record_type: [
                         Dimension.TIME_BURST,
                         Dimension.BEAM,
-                        range_bin(data_record_type),
+                        range_sample(data_record_type),
                     ],
                     field_units="dB/count",
                     field_unit_conversion=lambda packet, x: x / 2,
@@ -1179,7 +1179,7 @@ class HeaderOrDataRecordFormats:
                     field_dimensions=lambda data_record_type: [
                         Dimension.TIME_AVERAGE,
                         Dimension.BEAM,
-                        range_bin(data_record_type),
+                        range_sample(data_record_type),
                     ],
                     field_units="dB/count",
                     field_unit_conversion=lambda packet, x: x / 2,
@@ -1197,7 +1197,7 @@ class HeaderOrDataRecordFormats:
                     field_dimensions=lambda data_record_type: [
                         Dimension.TIME_ECHOSOUNDER,
                         Dimension.BEAM,
-                        range_bin(data_record_type),
+                        range_sample(data_record_type),
                     ],
                     field_units="dB/count",
                     field_unit_conversion=lambda packet, x: x / 2,
@@ -1215,7 +1215,7 @@ class HeaderOrDataRecordFormats:
                     field_dimensions=lambda data_record_type: [
                         Dimension.TIME_BURST,
                         Dimension.BEAM,
-                        range_bin(data_record_type),
+                        range_sample(data_record_type),
                     ],
                     field_units="0-100",
                     field_exists_predicate=lambda packet: packet.is_burst()
@@ -1232,7 +1232,7 @@ class HeaderOrDataRecordFormats:
                     field_dimensions=lambda data_record_type: [
                         Dimension.TIME_AVERAGE,
                         Dimension.BEAM,
-                        range_bin(data_record_type),
+                        range_sample(data_record_type),
                     ],
                     field_units="0-100",
                     field_exists_predicate=lambda packet: packet.is_average()
@@ -1249,7 +1249,7 @@ class HeaderOrDataRecordFormats:
                     field_dimensions=lambda data_record_type: [
                         Dimension.TIME_ECHOSOUNDER,
                         Dimension.BEAM,
-                        range_bin(data_record_type),
+                        range_sample(data_record_type),
                     ],
                     field_units="0-100",
                     field_exists_predicate=lambda packet: packet.is_echosounder()
@@ -1397,7 +1397,7 @@ class HeaderOrDataRecordFormats:
                 field_dimensions=lambda data_record_type: [
                     Dimension.TIME_BURST,
                     Dimension.BEAM,
-                    range_bin(data_record_type),
+                    range_sample(data_record_type),
                 ],
                 field_units="m/s",
                 field_unit_conversion=lambda packet, x: x
@@ -1416,7 +1416,7 @@ class HeaderOrDataRecordFormats:
                 field_dimensions=lambda data_record_type: [
                     Dimension.TIME_AVERAGE,
                     Dimension.BEAM,
-                    range_bin(data_record_type),
+                    range_sample(data_record_type),
                 ],
                 field_units="m/s",
                 field_unit_conversion=lambda packet, x: x
@@ -1435,7 +1435,7 @@ class HeaderOrDataRecordFormats:
                 field_dimensions=lambda data_record_type: [
                     Dimension.TIME_ECHOSOUNDER,
                     Dimension.BEAM,
-                    range_bin(data_record_type),
+                    range_sample(data_record_type),
                 ],
                 field_units="m/s",
                 field_unit_conversion=lambda packet, x: x
@@ -1454,7 +1454,7 @@ class HeaderOrDataRecordFormats:
                 field_dimensions=lambda data_record_type: [
                     Dimension.TIME_BURST,
                     Dimension.BEAM,
-                    range_bin(data_record_type),
+                    range_sample(data_record_type),
                 ],
                 field_units="dB/count",
                 field_unit_conversion=lambda packet, x: x / 2,
@@ -1472,7 +1472,7 @@ class HeaderOrDataRecordFormats:
                 field_dimensions=lambda data_record_type: [
                     Dimension.TIME_AVERAGE,
                     Dimension.BEAM,
-                    range_bin(data_record_type),
+                    range_sample(data_record_type),
                 ],
                 field_units="dB/count",
                 field_unit_conversion=lambda packet, x: x / 2,
@@ -1490,7 +1490,7 @@ class HeaderOrDataRecordFormats:
                 field_dimensions=lambda data_record_type: [
                     Dimension.TIME_ECHOSOUNDER,
                     Dimension.BEAM,
-                    range_bin(data_record_type),
+                    range_sample(data_record_type),
                 ],
                 field_units="dB/count",
                 field_unit_conversion=lambda packet, x: x / 2,
@@ -1508,7 +1508,7 @@ class HeaderOrDataRecordFormats:
                 field_dimensions=lambda data_record_type: [
                     Dimension.TIME_BURST,
                     Dimension.BEAM,
-                    range_bin(data_record_type),
+                    range_sample(data_record_type),
                 ],
                 field_units="0-100",
                 field_exists_predicate=lambda packet: packet.is_burst()
@@ -1525,7 +1525,7 @@ class HeaderOrDataRecordFormats:
                 field_dimensions=lambda data_record_type: [
                     Dimension.TIME_AVERAGE,
                     Dimension.BEAM,
-                    range_bin(data_record_type),
+                    range_sample(data_record_type),
                 ],
                 field_units="0-100",
                 field_exists_predicate=lambda packet: packet.is_average()
@@ -1542,7 +1542,7 @@ class HeaderOrDataRecordFormats:
                 field_dimensions=lambda data_record_type: [
                     Dimension.TIME_ECHOSOUNDER,
                     Dimension.BEAM,
-                    range_bin(data_record_type),
+                    range_sample(data_record_type),
                 ],
                 field_units="0-100",
                 field_exists_predicate=lambda packet: packet.is_echosounder()
@@ -1644,7 +1644,7 @@ class HeaderOrDataRecordFormats:
                 ],
                 field_dimensions=[
                     Dimension.TIME_ECHOSOUNDER,
-                    Dimension.RANGE_BIN_ECHOSOUNDER,
+                    Dimension.RANGE_SAMPLE_ECHOSOUNDER,
                 ],
                 field_units="dB/count",
                 field_unit_conversion=lambda packet, x: x / 100,
@@ -1759,7 +1759,7 @@ class HeaderOrDataRecordFormats:
                 field_shape=lambda packet: [packet.data.get("num_cells", 0)],
                 field_dimensions=lambda data_record_type: [
                     Dimension.TIME,
-                    range_bin(data_record_type),
+                    range_sample(data_record_type),
                 ],
                 field_units="%",
                 field_exists_predicate=lambda packet: packet.data[

--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -40,7 +40,7 @@ class ParseEK(ParseBase):
         self.config_datagram = None
         self.ping_data_dict = defaultdict(lambda: defaultdict(list))
         self.ping_time = defaultdict(list)  # store ping time according to channel
-        self.num_range_bin_groups = None  # number of range_bin groups
+        self.num_range_sample_groups = None  # number of range_sample groups
         self.ch_ids = defaultdict(
             list
         )  # Stores the channel ids for each data type (power, angle, complex)

--- a/echopype/convert/set_groups_ad2cp.py
+++ b/echopype/convert/set_groups_ad2cp.py
@@ -177,9 +177,9 @@ class SetGroupsAd2cp(SetGroupsBase):
                 "ping_time_average": self.ds.get("ping_time_average"),
                 "ping_time_echosounder": self.ds.get("ping_time_echosounder"),
                 "beam": self.ds.get("beam"),
-                "range_bin_burst": self.ds.get("range_bin_burst"),
-                "range_bin_average": self.ds.get("range_bin_average"),
-                "range_bin_echosounder": self.ds.get("range_bin_echosounder"),
+                "range_sample_burst": self.ds.get("range_sample_burst"),
+                "range_sample_average": self.ds.get("range_sample_average"),
+                "range_sample_echosounder": self.ds.get("range_sample_echosounder"),
             },
             attrs={
                 "platform_name": self.ui_param["platform_name"],
@@ -191,8 +191,8 @@ class SetGroupsAd2cp(SetGroupsBase):
 
     def set_beam(self) -> xr.Dataset:
         # TODO: should we divide beam into burst/average (e.g., beam_burst, beam_average)
-        # like was done for range_bin (we have range_bin_burst, range_bin_average,
-        # and range_bin_echosounder)?
+        # like was done for range_sample (we have range_sample_burst, range_sample_average,
+        # and range_sample_echosounder)?
         data_vars = {
             "number_of_beams": self.ds.get("num_beams"),
             "coordinate_system": self.ds.get("coordinate_system"),
@@ -241,9 +241,9 @@ class SetGroupsAd2cp(SetGroupsBase):
                 "ping_time_average": self.ds.get("ping_time_average"),
                 "ping_time_echosounder": self.ds.get("ping_time_echosounder"),
                 "beam": self.ds.get("beam"),
-                "range_bin_burst": self.ds.get("range_bin_burst"),
-                "range_bin_average": self.ds.get("range_bin_average"),
-                "range_bin_echosounder": self.ds.get("range_bin_echosounder"),
+                "range_sample_burst": self.ds.get("range_sample_burst"),
+                "range_sample_average": self.ds.get("range_sample_average"),
+                "range_sample_echosounder": self.ds.get("range_sample_echosounder"),
                 "altimeter_sample_bin": self.ds.get("altimeter_sample_bin"),
             },
             attrs={"pulse_compressed": self.pulse_compressed},
@@ -350,9 +350,9 @@ class SetGroupsAd2cp(SetGroupsBase):
                 "sample": self.ds.get("sample"),
                 "sample_transmit": self.ds.get("sample_transmit"),
                 "beam": self.ds.get("beam"),
-                "range_bin_average": self.ds.get("range_bin_average"),
-                "range_bin_burst": self.ds.get("range_bin_burst"),
-                "range_bin_echosounder": self.ds.get("range_bin_echosounder"),
+                "range_sample_average": self.ds.get("range_sample_average"),
+                "range_sample_burst": self.ds.get("range_sample_burst"),
+                "range_sample_echosounder": self.ds.get("range_sample_echosounder"),
             },
             attrs={**attrs, "pulse_compressed": self.pulse_compressed},
         )

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -110,12 +110,12 @@ class SetGroupsAZFP(SetGroupsBase):
             )
 
         # Largest number of counts along the range dimension among the different channels
-        longest_range_bin = np.max(unpacked_data["num_bins"])
-        range_bin = np.arange(longest_range_bin)
+        longest_range_sample = np.max(unpacked_data["num_bins"])
+        range_sample = np.arange(longest_range_sample)
 
         # Pad power data
-        if any(unpacked_data["num_bins"] != longest_range_bin):
-            N_tmp = np.full((len(N), len(ping_time), longest_range_bin), np.nan)
+        if any(unpacked_data["num_bins"] != longest_range_sample):
+            N_tmp = np.full((len(N), len(ping_time), longest_range_sample), np.nan)
             for i, n in enumerate(N):
                 N_tmp[i, :, : n.shape[1]] = n
             N = N_tmp
@@ -138,7 +138,7 @@ class SetGroupsAZFP(SetGroupsBase):
 
         ds = xr.Dataset(
             {
-                "backscatter_r": (["frequency", "ping_time", "range_bin"], N),
+                "backscatter_r": (["frequency", "ping_time", "range_sample"], N),
                 "equivalent_beam_angle": (["frequency"], parameters["BP"]),
                 "gain_correction": (["frequency"], unpacked_data["gain"]),
                 "sample_interval": (["frequency"], sample_int, {"units": "s"}),
@@ -182,10 +182,10 @@ class SetGroupsAZFP(SetGroupsBase):
                     ping_time,
                     self._varattrs["beam_coord_default"]["ping_time"],
                 ),
-                "range_bin": (
-                    ["range_bin"],
-                    range_bin,
-                    self._varattrs["beam_coord_default"]["range_bin"],
+                "range_sample": (
+                    ["range_sample"],
+                    range_sample,
+                    self._varattrs["beam_coord_default"]["range_sample"],
                 ),
             },
             attrs={

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -9,7 +9,7 @@ from _echopype_version import version as ECHOPYPE_VERSION
 from ..echodata.convention import sonarnetcdf_1
 from ..utils.coding import COMPRESSION_SETTINGS, set_encodings
 
-DEFAULT_CHUNK_SIZE = {"range_bin": 25000, "ping_time": 2500}
+DEFAULT_CHUNK_SIZE = {"range_sample": 25000, "ping_time": 2500}
 
 
 class SetGroupsBase(abc.ABC):

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -514,7 +514,7 @@ class SetGroupsEK60(SetGroupsBase):
             ds_tmp = xr.Dataset(
                 {
                     "backscatter_r": (
-                        ["ping_time", "range_bin"],
+                        ["ping_time", "range_sample"],
                         self.parser_obj.ping_data_dict["power"][ch],
                         {"long_name": "Backscatter power", "units": "dB"},
                     ),
@@ -585,10 +585,10 @@ class SetGroupsEK60(SetGroupsBase):
                         self.parser_obj.ping_time[ch],
                         self._varattrs["beam_coord_default"]["ping_time"],
                     ),
-                    "range_bin": (
-                        ["range_bin"],
+                    "range_sample": (
+                        ["range_sample"],
                         np.arange(data_shape[1]),
-                        self._varattrs["beam_coord_default"]["range_bin"],
+                        self._varattrs["beam_coord_default"]["range_sample"],
                     ),
                 },
             )
@@ -602,12 +602,12 @@ class SetGroupsEK60(SetGroupsBase):
                 ds_tmp = ds_tmp.assign(
                     {
                         "angle_athwartship": (
-                            ["ping_time", "range_bin"],
+                            ["ping_time", "range_sample"],
                             self.parser_obj.ping_data_dict["angle"][ch][:, :, 0],
                             {"long_name": "electrical athwartship angle"},
                         ),
                         "angle_alongship": (
-                            ["ping_time", "range_bin"],
+                            ["ping_time", "range_sample"],
                             self.parser_obj.ping_data_dict["angle"][ch][:, :, 1],
                             {"long_name": "electrical alongship angle"},
                         ),

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -404,12 +404,12 @@ class SetGroupsEK80(SetGroupsBase):
         ds_tmp = xr.Dataset(
             {
                 "backscatter_r": (
-                    ["ping_time", "range_bin", "quadrant"],
+                    ["ping_time", "range_sample", "quadrant"],
                     np.real(data),
                     {"long_name": "Real part of backscatter power", "units": "V"},
                 ),
                 "backscatter_i": (
-                    ["ping_time", "range_bin", "quadrant"],
+                    ["ping_time", "range_sample", "quadrant"],
                     np.imag(data),
                     {"long_name": "Imaginary part of backscatter power", "units": "V"},
                 ),
@@ -420,10 +420,10 @@ class SetGroupsEK80(SetGroupsBase):
                     self.parser_obj.ping_time[ch],
                     self._varattrs["beam_coord_default"]["ping_time"],
                 ),
-                "range_bin": (
-                    ["range_bin"],
+                "range_sample": (
+                    ["range_sample"],
                     np.arange(data_shape[1]),
-                    self._varattrs["beam_coord_default"]["range_bin"],
+                    self._varattrs["beam_coord_default"]["range_sample"],
                 ),
                 "quadrant": (["quadrant"], np.arange(num_transducer_sectors)),
             },
@@ -484,7 +484,7 @@ class SetGroupsEK80(SetGroupsBase):
         ds_tmp = xr.Dataset(
             {
                 "backscatter_r": (
-                    ["ping_time", "range_bin"],
+                    ["ping_time", "range_sample"],
                     self.parser_obj.ping_data_dict["power"][ch],
                     {"long_name": "Backscattering power", "units": "dB"},
                 ),
@@ -495,10 +495,10 @@ class SetGroupsEK80(SetGroupsBase):
                     self.parser_obj.ping_time[ch],
                     self._varattrs["beam_coord_default"]["ping_time"],
                 ),
-                "range_bin": (
-                    ["range_bin"],
+                "range_sample": (
+                    ["range_sample"],
                     np.arange(data_shape[1]),
-                    self._varattrs["beam_coord_default"]["range_bin"],
+                    self._varattrs["beam_coord_default"]["range_sample"],
                 ),
             },
         )
@@ -508,12 +508,12 @@ class SetGroupsEK80(SetGroupsBase):
             ds_tmp = ds_tmp.assign(
                 {
                     "angle_athwartship": (
-                        ["ping_time", "range_bin"],
+                        ["ping_time", "range_sample"],
                         self.parser_obj.ping_data_dict["angle"][ch][:, :, 0],
                         {"long_name": "electrical athwartship angle"},
                     ),
                     "angle_alongship": (
-                        ["ping_time", "range_bin"],
+                        ["ping_time", "range_sample"],
                         self.parser_obj.ping_data_dict["angle"][ch][:, :, 1],
                         {"long_name": "electrical alongship angle"},
                     ),
@@ -522,7 +522,7 @@ class SetGroupsEK80(SetGroupsBase):
 
         return set_encodings(ds_tmp)
 
-    def _assemble_ds_common(self, ch, range_bin_size):
+    def _assemble_ds_common(self, ch, range_sample_size):
         """Variables common to complex and power/angle data."""
         # pulse duration may have different names
         if "pulse_length" in self.parser_obj.ping_data_dict:
@@ -574,10 +574,10 @@ class SetGroupsEK80(SetGroupsBase):
                     self.parser_obj.ping_time[ch],
                     self._varattrs["beam_coord_default"]["ping_time"],
                 ),
-                "range_bin": (
-                    ["range_bin"],
-                    np.arange(range_bin_size),
-                    self._varattrs["beam_coord_default"]["range_bin"],
+                "range_sample": (
+                    ["range_sample"],
+                    np.arange(range_sample_size),
+                    self._varattrs["beam_coord_default"]["range_sample"],
                 ),
             },
         )
@@ -599,7 +599,7 @@ class SetGroupsEK80(SetGroupsBase):
                 )  # override keeps the Dataset attributes
             return set_encodings(ds_combine)
             # # Save to file
-            # io.save_file(ds_combine.chunk({'range_bin': DEFAULT_CHUNK_SIZE['range_bin'],
+            # io.save_file(ds_combine.chunk({'range_sample': DEFAULT_CHUNK_SIZE['range_sample'],
             #                                'ping_time': DEFAULT_CHUNK_SIZE['ping_time']}),
             #              path=self.output_path, mode='a', engine=self.engine,
             #              group=group_name, compression_settings=self.compression_settings)
@@ -639,7 +639,7 @@ class SetGroupsEK80(SetGroupsBase):
                 ds_data = self._assemble_ds_power(ch)
             else:  # skip for channels containing no data
                 continue
-            ds_common = self._assemble_ds_common(ch, ds_data.range_bin.size)
+            ds_common = self._assemble_ds_common(ch, ds_data.range_sample.size)
             ds_data = xr.merge(
                 [ds_data, ds_common], combine_attrs="override"
             )  # override keeps the Dataset attributes

--- a/echopype/echodata/convention/1.0.yml
+++ b/echopype/echodata/convention/1.0.yml
@@ -61,8 +61,8 @@ variable_and_varattributes:
       long_name: Timestamp of each ping
       standard_name: time
       axis: T
-    range_bin:
-      long_name: Along-range bin (sample) number, base 0
+    range_sample:
+      long_name: Along-range sample number, base 0
   platform_coord_default:
     location_time:
       axis: T

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -352,7 +352,9 @@ class EchoData:
                 # TODO: once we allow putting in arbitrary sound_speed,
                 # change below to use linearly-interpolated values
                 range_meter = (
-                    (beam.range_sample * beam["sample_interval"] - shift) * sound_speed / 2
+                    (beam.range_sample * beam["sample_interval"] - shift)
+                    * sound_speed
+                    / 2
                 )
                 # TODO: Lar Anderson's code include a slicing by minRange with a default of 0.02 m,
                 #  need to ask why and see if necessary here
@@ -360,7 +362,9 @@ class EchoData:
                 raise ValueError("Input waveform_mode not recognized!")
 
             # make order of dims conform with the order of backscatter data
-            range_meter = range_meter.transpose("frequency", "ping_time", "range_sample")
+            range_meter = range_meter.transpose(
+                "frequency", "ping_time", "range_sample"
+            )
             range_meter = range_meter.where(
                 range_meter > 0, 0
             )  # set negative ranges to 0

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -285,7 +285,7 @@ class EchoData:
                 sound_speed * L / (2 * f)
                 + (sound_speed / 4)
                 * (
-                    ((2 * (self.beam.range_bin + 1) - 1) * N * bins_to_avg - 1) / f
+                    ((2 * (self.beam.range_sample + 1) - 1) * N * bins_to_avg - 1) / f
                     + self.beam["transmit_duration_nominal"]
                 )
                 - range_offset
@@ -340,8 +340,8 @@ class EchoData:
                 sample_thickness = beam["sample_interval"] * sound_speed / 2
                 # TODO: Check with the AFSC about the half sample difference
                 range_meter = (
-                    beam.range_bin - tvg_correction_factor
-                ) * sample_thickness  # [frequency x range_bin]
+                    beam.range_sample - tvg_correction_factor
+                ) * sample_thickness  # [frequency x range_sample]
             elif waveform_mode == "BB":
                 beam = self.beam  # always use the Beam group
                 # TODO: bug: right now only first ping_time has non-nan range
@@ -351,7 +351,7 @@ class EchoData:
                 # TODO: once we allow putting in arbitrary sound_speed,
                 # change below to use linearly-interpolated values
                 range_meter = (
-                    (beam.range_bin * beam["sample_interval"] - shift) * sound_speed / 2
+                    (beam.range_sample * beam["sample_interval"] - shift) * sound_speed / 2
                 )
                 # TODO: Lar Anderson's code include a slicing by minRange with a default of 0.02 m,
                 #  need to ask why and see if necessary here
@@ -359,7 +359,7 @@ class EchoData:
                 raise ValueError("Input waveform_mode not recognized!")
 
             # make order of dims conform with the order of backscatter data
-            range_meter = range_meter.transpose("frequency", "ping_time", "range_bin")
+            range_meter = range_meter.transpose("frequency", "ping_time", "range_sample")
             range_meter = range_meter.where(
                 range_meter > 0, 0
             )  # set negative ranges to 0

--- a/echopype/metrics/summary_statistics.py
+++ b/echopype/metrics/summary_statistics.py
@@ -14,7 +14,7 @@ import xarray as xr
 
 
 def delta_z(ds: xr.Dataset, range_label="range") -> xr.DataArray:
-    """Helper function to calculate widths between range bins (dz) for discretized integral.
+    """Helper function to calculate widths between range samples (dz) for discretized integral.
 
     Parameters
     ----------
@@ -28,7 +28,7 @@ def delta_z(ds: xr.Dataset, range_label="range") -> xr.DataArray:
     """
     if range_label not in ds:
         raise ValueError(f"{range_label} not in the input Dataset!")
-    dz = ds[range_label].diff(dim="range_bin")
+    dz = ds[range_label].diff(dim="range_sample")
     return dz.where(dz != 0, other=np.nan)
 
 
@@ -65,7 +65,7 @@ def abundance(ds: xr.Dataset, range_label="range") -> xr.DataArray:
     """
     dz = delta_z(ds, range_label=range_label)
     sv = convert_to_linear(ds, "Sv")
-    return 10 * np.log10((sv * dz).sum(dim="range_bin"))
+    return 10 * np.log10((sv * dz).sum(dim="range_sample"))
 
 
 def center_of_mass(ds: xr.Dataset, range_label="range") -> xr.DataArray:
@@ -85,8 +85,8 @@ def center_of_mass(ds: xr.Dataset, range_label="range") -> xr.DataArray:
     """
     dz = delta_z(ds, range_label=range_label)
     sv = convert_to_linear(ds, "Sv")
-    return (ds[range_label] * sv * dz).sum(dim="range_bin") / (sv * dz).sum(
-        dim="range_bin"
+    return (ds[range_label] * sv * dz).sum(dim="range_sample") / (sv * dz).sum(
+        dim="range_sample"
     )
 
 
@@ -108,8 +108,8 @@ def dispersion(ds: xr.Dataset, range_label="range") -> xr.DataArray:
     dz = delta_z(ds, range_label=range_label)
     sv = convert_to_linear(ds, "Sv")
     cm = center_of_mass(ds)
-    return ((ds[range_label] - cm) ** 2 * sv * dz).sum(dim="range_bin") / (sv * dz).sum(
-        dim="range_bin"
+    return ((ds[range_label] - cm) ** 2 * sv * dz).sum(dim="range_sample") / (sv * dz).sum(
+        dim="range_sample"
     )
 
 
@@ -131,7 +131,7 @@ def evenness(ds: xr.Dataset, range_label="range") -> xr.DataArray:
     """
     dz = delta_z(ds, range_label=range_label)
     sv = convert_to_linear(ds, "Sv")
-    return ((sv * dz).sum(dim="range_bin")) ** 2 / (sv ** 2 * dz).sum(dim="range_bin")
+    return ((sv * dz).sum(dim="range_sample")) ** 2 / (sv ** 2 * dz).sum(dim="range_sample")
 
 
 def aggregation(ds: xr.Dataset, range_label="range") -> xr.DataArray:

--- a/echopype/metrics/summary_statistics.py
+++ b/echopype/metrics/summary_statistics.py
@@ -108,9 +108,9 @@ def dispersion(ds: xr.Dataset, range_label="echo_range") -> xr.DataArray:
     dz = delta_z(ds, range_label=range_label)
     sv = convert_to_linear(ds, "Sv")
     cm = center_of_mass(ds)
-    return ((ds[range_label] - cm) ** 2 * sv * dz).sum(dim="range_sample") / (sv * dz).sum(
-        dim="range_sample"
-    )
+    return ((ds[range_label] - cm) ** 2 * sv * dz).sum(dim="range_sample") / (
+        sv * dz
+    ).sum(dim="range_sample")
 
 
 def evenness(ds: xr.Dataset, range_label="echo_range") -> xr.DataArray:
@@ -131,7 +131,9 @@ def evenness(ds: xr.Dataset, range_label="echo_range") -> xr.DataArray:
     """
     dz = delta_z(ds, range_label=range_label)
     sv = convert_to_linear(ds, "Sv")
-    return ((sv * dz).sum(dim="range_sample")) ** 2 / (sv ** 2 * dz).sum(dim="range_sample")
+    return ((sv * dz).sum(dim="range_sample")) ** 2 / (sv ** 2 * dz).sum(
+        dim="range_sample"
+    )
 
 
 def aggregation(ds: xr.Dataset, range_label="echo_range") -> xr.DataArray:

--- a/echopype/preprocess/api.py
+++ b/echopype/preprocess/api.py
@@ -111,7 +111,7 @@ def compute_MVBS_index_binning(ds_Sv, range_sample_num=100, ping_num=100):
     ds_out = da.to_dataset()
     ds_out["echo_range"] = (
         ds_Sv["echo_range"]
-        .coarsen(  # binned echo_range (use first value in each sample)
+        .coarsen(  # binned echo_range (use first value in each average bin)
             ping_time=ping_num, range_sample=range_sample_num, boundary="pad"
         )
         .min(skipna=True)

--- a/echopype/preprocess/api.py
+++ b/echopype/preprocess/api.py
@@ -80,7 +80,7 @@ def compute_MVBS(ds_Sv, range_meter_bin=20, ping_time_bin="20S"):
 
 def compute_MVBS_index_binning(ds_Sv, range_sample_num=100, ping_num=100):
     """Compute Mean Volume Backscattering Strength (MVBS)
-    based on intervals of ``range_sample`` and ping number specified in index number.
+    based on intervals of ``range_sample`` and ping number (`ping_num`) specified in index number.
 
     Output of this function differs from that of ``compute_MVBS``, which computes
     bin-averaged Sv according to intervals of range (``echo_range``) and ``ping_time`` specified

--- a/echopype/preprocess/api.py
+++ b/echopype/preprocess/api.py
@@ -79,7 +79,7 @@ def compute_MVBS(ds_Sv, range_meter_bin=20, ping_time_bin="20S"):
 
 def compute_MVBS_index_binning(ds_Sv, range_sample_num=100, ping_num=100):
     """Compute Mean Volume Backscattering Strength (MVBS)
-    based on intervals of `range_sample` and ping number specified in index number.
+    based on intervals of ``range_sample`` and ping number specified in index number.
 
     Output of this function differs from that of ``compute_MVBS``, which computes
     bin-averaged Sv according to intervals of range and ping_time specified in physical units.

--- a/echopype/preprocess/noise_est.py
+++ b/echopype/preprocess/noise_est.py
@@ -11,14 +11,14 @@ class NoiseEst:
         dataset containing Sv and range [m]
     ping_num : int
         number of pings to obtain noise estimates
-    range_bin_num : int
+    range_sample_num : int
         number of samples along range to obtain noise estimates
     """
 
-    def __init__(self, ds_Sv, ping_num, range_bin_num):
+    def __init__(self, ds_Sv, ping_num, range_sample_num):
         self.ds_Sv = ds_Sv
         self.ping_num = ping_num
-        self.range_bin_num = range_bin_num
+        self.range_sample_num = range_sample_num
         self.spreading_loss = None
         self.absorption_loss = None
         self.Sv_noise = None
@@ -60,10 +60,10 @@ class NoiseEst:
         """
         power_cal_binned_avg = 10 * np.log10(  # binned averages of calibrated power
             self.power_cal.coarsen(
-                ping_time=self.ping_num, range_bin=self.range_bin_num, boundary="pad"
+                ping_time=self.ping_num, range_sample=self.range_sample_num, boundary="pad"
             ).mean()
         )
-        noise = power_cal_binned_avg.min(dim="range_bin", skipna=True)
+        noise = power_cal_binned_avg.min(dim="range_sample", skipna=True)
 
         # align ping_time to first of each ping collection
         noise["ping_time"] = self.power_cal["ping_time"][:: self.ping_num]
@@ -116,7 +116,7 @@ class NoiseEst:
         self.ds_Sv = self.ds_Sv.assign_attrs(
             {
                 "noise_ping_num": self.ping_num,
-                "noise_range_bin_num": self.range_bin_num,
+                "noise_range_sample_num": self.range_sample_num,
                 "SNR_threshold": SNR_threshold,
                 "noise_max": noise_max,
             }

--- a/echopype/preprocess/noise_est.py
+++ b/echopype/preprocess/noise_est.py
@@ -60,7 +60,9 @@ class NoiseEst:
         """
         power_cal_binned_avg = 10 * np.log10(  # binned averages of calibrated power
             self.power_cal.coarsen(
-                ping_time=self.ping_num, range_sample=self.range_sample_num, boundary="pad"
+                ping_time=self.ping_num,
+                range_sample=self.range_sample_num,
+                boundary="pad",
             ).mean()
         )
         noise = power_cal_binned_avg.min(dim="range_sample", skipna=True)

--- a/echopype/process/process_deprecated.py
+++ b/echopype/process/process_deprecated.py
@@ -60,9 +60,9 @@ class Process():
         self.TS_path = None
 
         # Deprecated proc attributes
-        self.noise_est_range_bin_size = 5  # meters per tile for noise estimation
+        self.noise_est_range_sample_size = 5  # meters per tile for noise estimation
         self.noise_est_ping_size = 30  # number of pings per tile for noise estimation
-        self.MVBS_range_bin_size = 5  # meters per tile for MVBS
+        self.MVBS_range_sample_size = 5  # meters per tile for MVBS
         self.MVBS_ping_size = 30  # number of pings per tile for MVBS
 
         if self.file_path .upper().endswith('.NC'):
@@ -234,7 +234,7 @@ class Process():
         return self.Sv
 
     def noise_estimates(self, source_postfix='_Sv', source_path=None,
-                        noise_est_range_bin_size=None, noise_est_ping_size=None):
+                        noise_est_range_sample_size=None, noise_est_ping_size=None):
 
         if source_path is None:
             if self.Sv is None:
@@ -247,14 +247,14 @@ class Process():
             source = source_path
         print('%s  Sv source used to estimate noise: %s' % (dt.datetime.now().strftime('%H:%M:%S'), source))
 
-        range_bin_size = noise_est_range_bin_size if \
-            noise_est_range_bin_size is not None else self.noise_est_range_bin_size
+        range_sample_size = noise_est_range_sample_size if \
+            noise_est_range_sample_size is not None else self.noise_est_range_sample_size
         ping_size = noise_est_ping_size if noise_est_ping_size is not None else self.noise_est_ping_size
 
-        return preprocess.estimate_noise(proc_data, ping_size, range_bin_size)
+        return preprocess.estimate_noise(proc_data, ping_size, range_sample_size)
 
     def remove_noise(self, source_postfix='_Sv', source_path=None,
-                     noise_est_range_bin_size=None, noise_est_ping_size=None,
+                     noise_est_range_sample_size=None, noise_est_ping_size=None,
                      SNR=0, Sv_threshold=None,
                      save=False, save_postfix='_Sv_clean', save_path=None):
 
@@ -269,14 +269,14 @@ class Process():
             source = source_path
         print('%s  Sv source used to remove noise: %s' % (dt.datetime.now().strftime('%H:%M:%S'), source))
 
-        range_bin_size = noise_est_range_bin_size if \
-            noise_est_range_bin_size is not None else self.noise_est_range_bin_size
+        range_sample_size = noise_est_range_sample_size if \
+            noise_est_range_sample_size is not None else self.noise_est_range_sample_size
         ping_size = noise_est_ping_size if noise_est_ping_size is not None else self.noise_est_ping_size
 
         self.Sv_clean = preprocess.remove_noise(
             proc_data,
             ping_num=ping_size,
-            range_bin_num=range_bin_size,
+            range_sample_num=range_sample_size,
             noise_max=Sv_threshold,
             SNR_threshold=SNR
         )
@@ -288,7 +288,7 @@ class Process():
             self._save_dataset(self.Sv_clean, self.Sv_clean_path)
 
     def get_MVBS(self, source_postfix='_Sv', source_path=None,
-                 MVBS_range_bin_size=None, MVBS_ping_size=None,
+                 MVBS_range_sample_size=None, MVBS_ping_size=None,
                  save=False, save_postfix='_MVBS', save_path=None):
 
         if source_path is not None:
@@ -306,7 +306,7 @@ class Process():
             source = "memory"
         print('%s  Sv source used to calculate MVBS: %s' % (dt.datetime.now().strftime('%H:%M:%S'), source))
 
-        range_bin_size = MVBS_range_bin_size if MVBS_range_bin_size is not None else self.MVBS_range_bin_size
+        range_sample_size = MVBS_range_sample_size if MVBS_range_sample_size is not None else self.MVBS_range_sample_size
         ping_size = MVBS_ping_size if MVBS_ping_size is not None else self.MVBS_ping_size
 
         # Range must have ping_time or it will error. Range does not have ping time for AZFP when temps are averaged
@@ -315,7 +315,7 @@ class Process():
 
         self.MVBS = preprocess.compute_MVBS_index_binning(
             proc_data,
-            range_bin_num=range_bin_size,
+            range_sample_num=range_sample_size,
             ping_num=ping_size
         ).rename({'Sv': 'MVBS'})
         # Save results in object and as a netCDF file

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -42,7 +42,7 @@ def test_compute_Sv_returns_water_level(ek60_path):
 
 
 def test_compute_Sv_ek60_echoview(ek60_path):
-    # constant range_bin
+    # constant range_sample
     ek60_raw_path = str(
         ek60_path.joinpath('DY1801_EK60-D20180211-T164025.raw')
     )
@@ -70,7 +70,7 @@ def test_compute_Sv_ek60_echoview(ek60_path):
     # Echoview data is shifted by 1 sample along range (missing the first sample)
     assert np.allclose(
         test_Sv[:, :, 7:],
-        ds_Sv.Sv.isel(ping_time=slice(None, 10), range_bin=slice(8, None)),
+        ds_Sv.Sv.isel(ping_time=slice(None, 10), range_sample=slice(8, None)),
         atol=1e-8,
     )
 
@@ -190,7 +190,7 @@ def test_compute_Sv_ek80_matlab(ek80_path):
 
     # TODO: resolve discrepancy in range between echopype and Matlab code
     ds_matlab = loadmat(ek80_matlab_path)
-    Sv_70k = ds_Sv.Sv.isel(frequency=0, ping_time=0).dropna('range_bin').values
+    Sv_70k = ds_Sv.Sv.isel(frequency=0, ping_time=0).dropna('range_sample').values
 
 
 def test_compute_Sv_ek80_pc_echoview(ek80_path):
@@ -228,7 +228,7 @@ def test_compute_Sv_ek80_pc_echoview(ek80_path):
     pc_mean = (
         pc.pulse_compressed_output.isel(frequency=0)
         .mean(dim='quadrant')
-        .dropna('range_bin')
+        .dropna('range_sample')
     )
 
     # Read EchoView pc raw power output

--- a/echopype/tests/convert/test_convert_azfp.py
+++ b/echopype/tests/convert/test_convert_azfp.py
@@ -122,10 +122,10 @@ def test_convert_azfp_01a_different_ranges(azfp_path):
         raw_file=azfp_01a_path, sonar_model='AZFP', xml_path=azfp_xml_path
     )
     assert echodata.beam.backscatter_r.isel(frequency=0).dropna(
-        'range_bin'
+        'range_sample'
     ).shape == (360, 438)
     assert echodata.beam.backscatter_r.isel(frequency=3).dropna(
-        'range_bin'
+        'range_sample'
     ).shape == (360, 135)
 
 

--- a/echopype/tests/convert/test_convert_ek60.py
+++ b/echopype/tests/convert/test_convert_ek60.py
@@ -44,7 +44,7 @@ def test_convert_ek60_matlab_raw(ek60_path):
             for fidx in range(5)
         ],
         echodata.beam.backscatter_r.transpose(
-            'frequency', 'range_bin', 'ping_time'
+            'frequency', 'range_sample', 'ping_time'
         ),
         rtol=0,
         atol=1.6e-5,
@@ -57,7 +57,7 @@ def test_convert_ek60_matlab_raw(ek60_path):
                 for fidx in range(5)
             ],
             echodata.beam['angle_' + angle].transpose(
-                'frequency', 'range_bin', 'ping_time'
+                'frequency', 'range_sample', 'ping_time'
             ),
         )
 
@@ -90,7 +90,7 @@ def test_convert_ek60_echoview_raw(ek60_path):
             echodata.beam.backscatter_r.isel(
                 frequency=fidx,
                 ping_time=slice(None, 10),
-                range_bin=slice(1, None),
+                range_sample=slice(1, None),
             ),
             atol=9e-6,
             rtol=atol,

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -58,7 +58,7 @@ def test_convert_ek80_complex_matlab(ek80_path):
     ds_matlab = loadmat(ek80_matlab_path_bb)
     assert np.array_equal(
         echodata.beam.backscatter_r.isel(frequency=0, ping_time=0)
-        .dropna('range_bin')
+        .dropna('range_sample')
         .values[1:, :],
         np.real(
             ds_matlab['data']['echodata'][0][0][0, 0]['complexsamples']
@@ -66,7 +66,7 @@ def test_convert_ek80_complex_matlab(ek80_path):
     )
     assert np.array_equal(
         echodata.beam.backscatter_i.isel(frequency=0, ping_time=0)
-        .dropna('range_bin')
+        .dropna('range_sample')
         .values[1:, :],
         np.imag(
             ds_matlab['data']['echodata'][0][0][0, 0]['complexsamples']
@@ -104,7 +104,7 @@ def test_convert_ek80_cw_power_angle_echoview(ek80_path):
         assert np.allclose(
             test_power,
             echodata.beam.backscatter_r.sel(frequency=freq * 1e3).dropna(
-                'range_bin'
+                'range_sample'
             ),
             rtol=0,
             atol=1.1e-5,
@@ -133,7 +133,7 @@ def test_convert_ek80_cw_power_angle_echoview(ek80_path):
                 df_angle.loc[df_angle['Ping_index'] == ping_idx, ' Major'],
                 major.sel(frequency=freq * 1e3)
                 .isel(ping_time=ping_idx)
-                .dropna('range_bin'),
+                .dropna('range_sample'),
                 rtol=0,
                 atol=5e-5,
             )
@@ -141,7 +141,7 @@ def test_convert_ek80_cw_power_angle_echoview(ek80_path):
                 df_angle.loc[df_angle['Ping_index'] == ping_idx, ' Minor'],
                 minor.sel(frequency=freq * 1e3)
                 .isel(ping_time=ping_idx)
-                .dropna('range_bin'),
+                .dropna('range_sample'),
                 rtol=0,
                 atol=5e-5,
             )
@@ -163,7 +163,7 @@ def test_convert_ek80_complex_echoview(ek80_path):
     )  # averaged across quadrants
     assert np.allclose(
         echodata.beam.backscatter_r.sel(frequency=70e3)
-        .dropna('range_bin')
+        .dropna('range_sample')
         .mean(dim='quadrant'),
         df_bb.iloc[::2, 14:],  # real rows
         rtol=0,
@@ -171,7 +171,7 @@ def test_convert_ek80_complex_echoview(ek80_path):
     )
     assert np.allclose(
         echodata.beam.backscatter_i.sel(frequency=70e3)
-        .dropna('range_bin')
+        .dropna('range_sample')
         .mean(dim='quadrant'),
         df_bb.iloc[1::2, 14:],  # imag rows
         rtol=0,

--- a/echopype/tests/metrics/test_metrics_summary_statistics.py
+++ b/echopype/tests/metrics/test_metrics_summary_statistics.py
@@ -23,8 +23,8 @@ def create_test_ds(Sv, range):
 
     testDS = xr.Dataset(
         data_vars=dict(
-            Sv=(["frequency", "ping_time", "range_bin"], Sv),
-            range=(["frequency", "ping_time", "range_bin"], range),
+            Sv=(["frequency", "ping_time", "range_sample"], Sv),
+            range=(["frequency", "ping_time", "range_sample"], range),
         ),
         coords={
             'frequency': xr.DataArray(
@@ -38,10 +38,10 @@ def create_test_ds(Sv, range):
                 name='ping_time',
                 dims=['ping_time'],
             ),
-            'range_bin': xr.DataArray(
+            'range_sample': xr.DataArray(
                 r_b,
-                name='range_bin',
-                dims=['range_bin'],
+                name='range_sample',
+                dims=['range_sample'],
             ),
         },
     )

--- a/echopype/tests/old/test_old.py
+++ b/echopype/tests/old/test_old.py
@@ -26,8 +26,8 @@ def test_calibrate_ek80_bb():
     bb_test_df_i = bb_test_df.iloc[1::2, 14:]
     with xr.open_dataset(tmp.nc_path, group='Sonar/Beam_group1') as ds_beam:
         # Select 70 kHz channel and averaged across the quadrants
-        backscatter_r = ds_beam.backscatter_r[0].dropna('range_bin').mean('quadrant')
-        backscatter_i = ds_beam.backscatter_i[0].dropna('range_bin').mean('quadrant')
+        backscatter_r = ds_beam.backscatter_r[0].dropna('range_sample').mean('quadrant')
+        backscatter_i = ds_beam.backscatter_i[0].dropna('range_sample').mean('quadrant')
         assert np.allclose(backscatter_r, bb_test_df_r)
         assert np.allclose(backscatter_i, bb_test_df_i)
 
@@ -54,7 +54,7 @@ def test_calibrate_ek80_cw():
 
 
 def test_calibration_ek60_echoview():
-    ek60_raw_path = str(ek60_path.joinpath('DY1801_EK60-D20180211-T164025.raw'))  # constant range_bin
+    ek60_raw_path = str(ek60_path.joinpath('DY1801_EK60-D20180211-T164025.raw'))  # constant range_sample
     ek60_echoview_path = ek60_path.joinpath('from_echoview')
 
     tmp = Convert(ek60_raw_path)

--- a/echopype/tests/preprocess/test_preprocess.py
+++ b/echopype/tests/preprocess/test_preprocess.py
@@ -161,9 +161,9 @@ def test_remove_noise():
 def _construct_MVBS_toy_data(
     nfreq, npings, nrange_samples, ping_size, range_sample_size
 ):
-    """Construct data with values that increase every ping_num and `range_sample_num`
+    """Construct data with values that increase every ping_num and ``range_sample_num``
     so that the result of computing MVBS is a smaller array
-    that increases regularly for each resampled ping_time and `range_sample`
+    that increases regularly for each resampled ``ping_time`` and ``range_sample``
 
     Parameters
     ----------
@@ -172,16 +172,16 @@ def _construct_MVBS_toy_data(
     npings : int
         number of pings
     nrange_samples : int
-        number of range_samples
+        number of range samples
     ping_size : int
         number of pings with the same value
     range_sample_size : int
-        number of range_samples with the same value
+        number of range samples with the same value
 
     Returns
     -------
     np.ndarray
-        Array with blocks of ping_times and range_samples with the same value,
+        Array with blocks of ``ping_times`` and range samples with the same value,
         so that computing the MVBS will result in regularly increasing values
         every row and column
     """
@@ -210,13 +210,13 @@ def _construct_MVBS_test_data(nfreq, npings, nrange_samples):
     npings : int
         number of pings
     nrange_samples : int
-        number of range_samples
+        number of range samples
 
     Returns
     -------
     np.ndarray
         Array with values that increases regularly
-        every ping and range_sample
+        every ping and range sample
     """
 
     # Construct test array

--- a/echopype/tests/preprocess/test_preprocess.py
+++ b/echopype/tests/preprocess/test_preprocess.py
@@ -79,11 +79,11 @@ def test_remove_noise():
     """Test remove_noise on toy data"""
 
     # Parameters for fake data
-    nfreq, npings, nrange_bins = 1, 10, 100
+    nfreq, npings, nrange_samples = 1, 10, 100
     freq = np.arange(nfreq)
     ping_index = np.arange(npings)
-    range_bin = np.arange(nrange_bins)
-    data = np.ones(nrange_bins)
+    range_sample = np.arange(nrange_samples)
+    data = np.ones(nrange_samples)
 
     # Insert noise points
     np.put(data, 30, -30)
@@ -96,7 +96,7 @@ def test_remove_noise():
         coords=[
             ('frequency', freq),
             ('ping_time', ping_index),
-            ('range_bin', range_bin),
+            ('range_sample', range_sample),
         ],
     )
     Sv.name = "Sv"
@@ -104,28 +104,28 @@ def test_remove_noise():
 
     ds_Sv = ds_Sv.assign(
         range=xr.DataArray(
-            np.array([[np.linspace(0, 10, nrange_bins)] * npings]),
+            np.array([[np.linspace(0, 10, nrange_samples)] * npings]),
             coords=Sv.coords,
         )
     )
     ds_Sv = ds_Sv.assign(sound_absorption=0.001)
     # Run noise removal
     ds_Sv = ep.preprocess.remove_noise(
-        ds_Sv, ping_num=2, range_bin_num=5, SNR_threshold=0
+        ds_Sv, ping_num=2, range_sample_num=5, SNR_threshold=0
     )
 
     # Test if noise points are are nan
     assert np.isnan(
-        ds_Sv.Sv_corrected.isel(frequency=0, ping_time=0, range_bin=30)
+        ds_Sv.Sv_corrected.isel(frequency=0, ping_time=0, range_sample=30)
     )
     assert np.isnan(
-        ds_Sv.Sv_corrected.isel(frequency=0, ping_time=0, range_bin=60)
+        ds_Sv.Sv_corrected.isel(frequency=0, ping_time=0, range_sample=60)
     )
 
     # Test remove noise on a normal distribution
     np.random.seed(1)
     data = np.random.normal(
-        loc=-100, scale=2, size=(nfreq, npings, nrange_bins)
+        loc=-100, scale=2, size=(nfreq, npings, nrange_samples)
     )
     # Make Dataset to pass into remove_noise
     Sv = xr.DataArray(
@@ -133,7 +133,7 @@ def test_remove_noise():
         coords=[
             ('frequency', freq),
             ('ping_time', ping_index),
-            ('range_bin', range_bin),
+            ('range_sample', range_sample),
         ],
     )
     Sv.name = "Sv"
@@ -141,29 +141,29 @@ def test_remove_noise():
     # Attach required range and sound_absorption values
     ds_Sv = ds_Sv.assign(
         range=xr.DataArray(
-            np.array([[np.linspace(0, 3, nrange_bins)] * npings]),
+            np.array([[np.linspace(0, 3, nrange_samples)] * npings]),
             coords=Sv.coords,
         )
     )
     ds_Sv = ds_Sv.assign(sound_absorption=0.001)
     # Run noise removal
     ds_Sv = ep.preprocess.remove_noise(
-        ds_Sv, ping_num=2, range_bin_num=5, SNR_threshold=0
+        ds_Sv, ping_num=2, range_sample_num=5, SNR_threshold=0
     )
     null = ds_Sv.Sv_corrected.isnull()
     # Test to see if the right number of points are removed before the range gets too large
     assert (
-        np.count_nonzero(null.isel(frequency=0, range_bin=slice(None, 50)))
+        np.count_nonzero(null.isel(frequency=0, range_sample=slice(None, 50)))
         == 6
     )
 
 
 def _construct_MVBS_toy_data(
-    nfreq, npings, nrange_bins, ping_size, range_bin_size
+    nfreq, npings, nrange_samples, ping_size, range_sample_size
 ):
-    """Construct data with values that increase every ping_num and range_bin_num
+    """Construct data with values that increase every ping_num and `range_sample_num`
     so that the result of computing MVBS is a smaller array
-    that increases regularly for each resampled ping_time and range_bin
+    that increases regularly for each resampled ping_time and `range_sample`
 
     Parameters
     ----------
@@ -171,24 +171,24 @@ def _construct_MVBS_toy_data(
         number of frequencies
     npings : int
         number of pings
-    nrange_bins : int
-        number of range_bins
+    nrange_samples : int
+        number of range_samples
     ping_size : int
         number of pings with the same value
-    range_bin_size : int
-        number of range_bins with the same value
+    range_sample_size : int
+        number of range_samples with the same value
 
     Returns
     -------
     np.ndarray
-        Array with blocks of ping_times and range_bins with the same value,
+        Array with blocks of ping_times and range_samples with the same value,
         so that computing the MVBS will result in regularly increasing values
         every row and column
     """
-    data = np.ones((nfreq, npings, nrange_bins))
+    data = np.ones((nfreq, npings, nrange_samples))
     for p_i, ping in enumerate(range(0, npings, ping_size)):
-        for r_i, rb in enumerate(range(0, nrange_bins, range_bin_size)):
-            data[0, ping : ping + ping_size, rb : rb + range_bin_size] += (
+        for r_i, rb in enumerate(range(0, nrange_samples, range_sample_size)):
+            data[0, ping : ping + ping_size, rb : rb + range_sample_size] += (
                 r_i + p_i
             )
     # First frequency increases by 1 each row and column, second increases by 2, third by 3, etc.
@@ -198,7 +198,7 @@ def _construct_MVBS_toy_data(
     return data
 
 
-def _construct_MVBS_test_data(nfreq, npings, nrange_bins):
+def _construct_MVBS_test_data(nfreq, npings, nrange_samples):
     """Construct data for testing the toy data from
     `_construct_MVBS_toy_data` after it has gone through the
     MVBS calculation.
@@ -209,18 +209,18 @@ def _construct_MVBS_test_data(nfreq, npings, nrange_bins):
         number of frequencies
     npings : int
         number of pings
-    nrange_bins : int
-        number of range_bins
+    nrange_samples : int
+        number of range_samples
 
     Returns
     -------
     np.ndarray
         Array with values that increases regularly
-        every ping and range_bin
+        every ping and range_sample
     """
 
     # Construct test array
-    test_array = np.add(*np.indices((npings, nrange_bins)))
+    test_array = np.add(*np.indices((npings, nrange_samples)))
     return np.array([(test_array + 1) * (f + 1) for f in range(nfreq)])
 
 
@@ -228,53 +228,53 @@ def test_compute_MVBS_index_binning():
     """Test compute_MVBS_index_binning on toy data"""
 
     # Parameters for toy data
-    nfreq, npings, nrange_bins = 4, 40, 400
+    nfreq, npings, nrange_samples = 4, 40, 400
     ping_num = 3  # number of pings to average over
-    range_bin_num = 7  # number of range_bins to average over
+    range_sample_num = 7  # number of range_samples to average over
 
-    # Construct toy data that increases regularly every ping_num and range_bin_num
+    # Construct toy data that increases regularly every ping_num and range_sample_num
     data = _construct_MVBS_toy_data(
         nfreq=nfreq,
         npings=npings,
-        nrange_bins=nrange_bins,
+        nrange_samples=nrange_samples,
         ping_size=ping_num,
-        range_bin_size=range_bin_num,
+        range_sample_size=range_sample_num,
     )
 
     data_log = 10 * np.log10(data)  # Convert to log domain
     freq_index = np.arange(nfreq)
     ping_index = np.arange(npings)
-    range_bin = np.arange(nrange_bins)
+    range_sample = np.arange(nrange_samples)
     Sv = xr.DataArray(
         data_log,
         coords=[
             ('frequency', freq_index),
             ('ping_time', ping_index),
-            ('range_bin', range_bin),
+            ('range_sample', range_sample),
         ],
     )
     Sv.name = "Sv"
     ds_Sv = Sv.to_dataset()
     ds_Sv = ds_Sv.assign(
         range=xr.DataArray(
-            np.array([[np.linspace(0, 10, nrange_bins)] * npings] * nfreq),
+            np.array([[np.linspace(0, 10, nrange_samples)] * npings] * nfreq),
             coords=Sv.coords,
         )
     )
 
     # Binned MVBS test
     ds_MVBS = ep.preprocess.compute_MVBS_index_binning(
-        ds_Sv, range_bin_num=range_bin_num, ping_num=ping_num
+        ds_Sv, range_sample_num=range_sample_num, ping_num=ping_num
     )
     data_test = 10 ** (ds_MVBS.Sv / 10)  # Convert to linear domain
 
     # Shape test
     data_binned_shape = np.ceil(
-        (nfreq, npings / ping_num, nrange_bins / range_bin_num)
+        (nfreq, npings / ping_num, nrange_samples / range_sample_num)
     ).astype(int)
     assert np.all(data_test.shape == data_binned_shape)
 
-    # Construct test array that increases by 1 for each range_bin and ping_time
+    # Construct test array that increases by 1 for each range_sample and ping_time
     test_array = _construct_MVBS_test_data(
         nfreq, data_binned_shape[1], data_binned_shape[2]
     )
@@ -287,20 +287,20 @@ def test_compute_MVBS():
     """Test compute_MVBS on toy data"""
 
     # Parameters for fake data
-    nfreq, npings, nrange_bins = 4, 100, 4000
+    nfreq, npings, nrange_samples = 4, 100, 4000
     range_meter_bin = 7  # range in meters to average over
     ping_time_bin = 3  # number of seconds to average over
     ping_rate = 2  # Number of pings per second
-    range_bin_per_meter = 30  # Number of range_bins per meter
+    range_sample_per_meter = 30  # Number of range_samples per meter
 
     # Useful conversions
     ping_num = (
         npings / ping_rate / ping_time_bin
     )  # number of pings to average over
-    range_bin_num = (
-        nrange_bins / range_bin_per_meter / range_meter_bin
-    )  # number of range_bins to average over
-    total_range = nrange_bins / range_bin_per_meter  # total range in meters
+    range_sample_num = (
+        nrange_samples / range_sample_per_meter / range_meter_bin
+    )  # number of range_samples to average over
+    total_range = nrange_samples / range_sample_per_meter  # total range in meters
 
     # Construct data with values that increase with range and time
     # so that when compute_MVBS is performed, the result is a smaller array
@@ -308,9 +308,9 @@ def test_compute_MVBS():
     data = _construct_MVBS_toy_data(
         nfreq=nfreq,
         npings=npings,
-        nrange_bins=nrange_bins,
+        nrange_samples=nrange_samples,
         ping_size=ping_rate * ping_time_bin,
-        range_bin_size=range_bin_per_meter * range_meter_bin,
+        range_sample_size=range_sample_per_meter * range_meter_bin,
     )
 
     data_log = 10 * np.log10(data)  # Convert to log domain
@@ -319,13 +319,13 @@ def test_compute_MVBS():
     ping_time = pd.date_range(
         '1/1/2020', periods=npings, freq=f'{1/ping_rate}S'
     )
-    range_bin = np.arange(nrange_bins)
+    range_sample = np.arange(nrange_samples)
     Sv = xr.DataArray(
         data_log,
         coords=[
             ('frequency', freq_index),
             ('ping_time', ping_time),
-            ('range_bin', range_bin),
+            ('range_sample', range_sample),
         ],
     )
     Sv.name = "Sv"
@@ -333,7 +333,7 @@ def test_compute_MVBS():
     ds_Sv = ds_Sv.assign(
         range=xr.DataArray(
             np.array(
-                [[np.linspace(0, total_range, nrange_bins)] * npings] * nfreq
+                [[np.linspace(0, total_range, nrange_samples)] * npings] * nfreq
             ),
             coords=Sv.coords,
         )
@@ -346,10 +346,10 @@ def test_compute_MVBS():
     data_test = 10 ** (ds_MVBS.Sv / 10)  # Convert to linear domain
 
     # Shape test
-    data_binned_shape = np.ceil((nfreq, ping_num, range_bin_num)).astype(int)
+    data_binned_shape = np.ceil((nfreq, ping_num, range_sample_num)).astype(int)
     assert np.all(data_test.shape == data_binned_shape)
 
-    # Construct test array that increases by 1 for each range_bin and ping_time
+    # Construct test array that increases by 1 for each range_sample and ping_time
     test_array = _construct_MVBS_test_data(
         nfreq, data_binned_shape[1], data_binned_shape[2]
     )

--- a/echopype/tests/preprocess/test_preprocess.py
+++ b/echopype/tests/preprocess/test_preprocess.py
@@ -181,7 +181,7 @@ def _construct_MVBS_toy_data(
     Returns
     -------
     np.ndarray
-        Array with blocks of ``ping_times`` and range samples with the same value,
+        Array with blocks of ``ping_time`` and ``range_sample`` with the same value,
         so that computing the MVBS will result in regularly increasing values
         every row and column
     """

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -266,7 +266,7 @@ def test_water_level_echodata(water_level, expect_warning):
             )
     except Exception as e:
         assert isinstance(e, ValueError)
-        assert str(e) == 'Water level must have any of these dimensions: frequency, ping_time, range_bin'  # noqa
+        assert str(e) == 'Water level must have any of these dimensions: frequency, ping_time, range_sample'  # noqa
 
     if isinstance(results, xr.DataArray):
         final_array = results.isel(frequency=0, ping_time=0).values
@@ -325,7 +325,7 @@ def test_water_level_Sv_dataset(water_level, expect_warning):
             )
     except Exception as e:
         assert isinstance(e, ValueError)
-        assert str(e) == 'Water level must have any of these dimensions: frequency, ping_time, range_bin'  # noqa
+        assert str(e) == 'Water level must have any of these dimensions: frequency, ping_time, range_sample'  # noqa
 
     if isinstance(results, xr.DataArray):
         final_array = results.isel(frequency=0, ping_time=0).values

--- a/echopype/visualize/api.py
+++ b/echopype/visualize/api.py
@@ -26,7 +26,7 @@ def create_echogram(
         Otherwise all frequency will be plotted.
     get_range : bool, optional
         Flag as to whether range should be computed or not,
-        by default it will just plot range_bin as the yaxis.
+        by default it will just plot `range_sample` as the yaxis.
 
         Note that for data that is "Sv" xarray dataset, `get_range` defaults
         to `True`.
@@ -71,7 +71,7 @@ def create_echogram(
             raise ValueError(
                 "Visualization for AD2CP sonar model is currently unsupported."
             )
-        yaxis = 'range_bin'
+        yaxis = 'range_sample'
         variable = 'backscatter_r'
         ds = data.beam
         if get_range is True:
@@ -147,7 +147,7 @@ def create_echogram(
         yaxis = 'range'
         if 'range' not in data.dims and get_range is False:
             # Range in dims indicates that data is MVBS.
-            yaxis = 'range_bin'
+            yaxis = 'range_sample'
 
         # If depth is available in ds, use it.
         ds = ds.set_coords('range')

--- a/echopype/visualize/api.py
+++ b/echopype/visualize/api.py
@@ -26,7 +26,7 @@ def create_echogram(
         Otherwise all frequency will be plotted.
     get_range : bool, optional
         Flag as to whether range should be computed or not,
-        by default it will just plot `range_sample` as the yaxis.
+        by default it will just plot ``range_sample`` as the yaxis.
 
         Note that for data that is "Sv" xarray dataset, `get_range` defaults
         to `True`.

--- a/echopype/visualize/plot.py
+++ b/echopype/visualize/plot.py
@@ -174,15 +174,15 @@ def _plot_echogram(
         if (
             np.any(filtered_ds.isnull()).values == np.array(True)
             and 'range' in filtered_ds.coords
-            and 'range_bin' in filtered_ds.dims
+            and 'range_sample' in filtered_ds.dims
             and variable in ['backscatter_r', 'Sv']
         ):
             # Handle the nans for echodata and Sv
             filtered_ds = filtered_ds.sel(
-                range_bin=filtered_ds.range_bin.where(
+                range_sample=filtered_ds.range_sample.where(
                     ~filtered_ds.range.isel(ping_time=0).isnull()
                 )
-                .dropna(dim='range_bin')
+                .dropna(dim='range_sample')
                 .data
             )
         plot = filtered_ds.plot.pcolormesh(
@@ -214,17 +214,17 @@ def _plot_echogram(
             if (
                 np.any(d.isnull()).values == np.array(True)
                 and 'range' in d.coords
-                and 'range_bin' in d.dims
+                and 'range_sample' in d.dims
                 and variable in ['backscatter_r', 'Sv']
             ):
                 # Handle the nans for echodata and Sv
                 d = d.sel(
-                    range_bin=d.range_bin.where(
+                    range_sample=d.range_sample.where(
                         ~d.range.sel(frequency=f.values)
                         .isel(ping_time=0)
                         .isnull()
                     )
-                    .dropna(dim='range_bin')
+                    .dropna(dim='range_sample')
                     .data
                 )
             plot = d.plot.pcolormesh(


### PR DESCRIPTION
This PR is in reference to issue #570 . It should be noted that the change from `range` to `echo_range` took place in PR #590.

In this PR, we address the change from `range_bin` --> `range_sample`. 

In this PR we do not modify `open_converted` (to account for the change from `range_bin` --> `range_sample`). This will be done in a future PR.
