### PR TITLE
Add coordinate values to SONAR-netCDF4 convention file

### DIFF
--- a/echopype/echodata/convention/1.0.yml
+++ b/echopype/echodata/convention/1.0.yml
@@ -12,10 +12,6 @@ groups:
     name: Top-level
     description: contains metadata about the SONAR-netCDF4 file format.
     ep_group:
-    coords_ek60: []
-    coords_ek80: []
-    coords_azfp: []
-    coords_ad2cp: []
   environment:
     name: Environment
     description: contains information relevant to acoustic propagation through water.

--- a/echopype/echodata/convention/1.0.yml
+++ b/echopype/echodata/convention/1.0.yml
@@ -12,32 +12,62 @@ groups:
     name: Top-level
     description: contains metadata about the SONAR-netCDF4 file format.
     ep_group:
+    coords_ek60: []
+    coords_ek80: []
+    coords_azfp: []
+    coords_ad2cp: []
   environment:
     name: Environment
     description: contains information relevant to acoustic propagation through water.
     ep_group: Environment
+    coords_ek60: ['frequency', 'ping_time']
+    coords_ek80: ['ping_time']
+    coords_azfp: ['ping_time']
+    coords_ad2cp: ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder']
   platform:
     name: Platform
     description: contains information about the platform on which the sonar is installed.
     ep_group: Platform
+    coords_ek60: ['location_time', 'ping_time', 'frequency']
+    coords_ek80: ['mru_time', 'location_time']
+    coords_azfp: []
+    coords_ad2cp: ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder', 'beam',
+                   'range_sample_burst', 'range_sample_average', 'range_sample_echosounder']
   nmea:
     name: Platform/NMEA
     description: contains information specific to the NMEA protocol.
     ep_group: Platform/NMEA
+    coords_ek60: ['location_time']
+    coords_ek80: ['location_time']
+    coords_azfp: ['location_time']
+    coords_ad2cp: ['location_time']
   provenance:
     name: Provenance
     description: contains metadata about how the SONAR-netCDF4 version of the data were obtained.
     ep_group: Provenance
+    coords_ek60: []
+    coords_ek80: []
+    coords_azfp: []
+    coords_ad2cp: []
   sonar:
     name: Sonar
     description: contains specific metadata for the sonar system.
     ep_group: Sonar
+    coords_ek60: ['beam']
+    coords_ek80: ['beam', 'frequency']
+    coords_azfp: ['beam']
+    coords_ad2cp: []
   beam:
     name: Sonar/Beam_group1
     description: >-
       contains backscatter data (either complex samples or uncalibrated power samples)
       and other beam or channel-specific data, including split-beam angle data when they exist.
     ep_group: Sonar/Beam_group1
+    coords_ek60: ['frequency', 'ping_time', 'range_sample']
+    coords_ek80: ['frequency', 'ping_time', 'range_sample', 'quadrant']  # will contain quadrant only if it is complex
+    coords_azfp: ['frequency', 'ping_time', 'range_sample']
+    coords_ad2cp: ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder', 'beam',
+                   'range_sample_burst', 'range_sample_average', 'range_sample_echosounder', 'altimeter_sample_bin']
   beam_power:
     name: Sonar/Beam_group2
     description: >-
@@ -45,10 +75,21 @@ groups:
       including split-beam angle data when they exist.
       Only exists if complex backscatter data they already in Sonar/Beam_group1
     ep_group: Sonar/Beam_group2
+    coords_ek60: []
+    coords_ek80: ['frequency', 'ping_time', 'range_sample']
+    coords_azfp: []
+    coords_ad2cp: []
   vendor:
     name: Vendor specific
     description: contains vendor-specific information about the sonar and the data.
     ep_group: Vendor
+    coords_ek60: ['frequency', 'pulse_length_bin']
+    coords_ek80: ['frequency', 'pulse_length_bin', 'cal_frequency', 'cal_channel_id']
+    coords_azfp: ['frequency', 'ping_time', 'ancillary_len', 'ad_len']
+    coords_ad2cp: ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder',
+                   'ping_time_echosounder_raw', 'ping_time_echosounder_raw_transmit',
+                   'ping_time_echosounder_raw_transmit', 'sample', 'sample_transmit', 'beam', 'range_sample_average',
+                   'range_sample_burst', 'range_sample_echosounder']
 variable_and_varattributes:
   # Convention-based global, coordinate and variable attributes
   beam_coord_default:


### PR DESCRIPTION
This PR is in reference to issue #596. 

In this PR I have added `coords_ek60`, `coords_ek80`, `coords_azfp`, and `coords_ad2cp` to each group of `1.0.yml`. These added values are lists of all the **POSSIBLE** coordinates for each group and echosounder. For example, in the beam group, `coords_ek80` is set to `['frequency', 'ping_time', 'range_sample', 'quadrant']`. However, depending on certain choices, it is possible that the coordinate `quadrant` is not produced by the class `SetGroupsEK80`. 

@leewujung  and @emiliom could you please review these lists to make sure I haven’t missed any coordinates? 
