### PR TITLE
Upgrade typing-extensions to version 4 and use conda-compatible requirements syntax

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ fsspec
 s3fs==2021.11.0
 requests
 aiohttp
-typing-extensions~=3.10
+typing-extensions>=3.10,==3.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ fsspec
 s3fs==2021.11.0
 requests
 aiohttp
-typing-extensions>=3.10,==3.*
+typing-extensions>=4.1,==4.*


### PR DESCRIPTION
`typing-extensions~=3.10` is valid syntax with pip, but conda does not support it yet, so we can use the equivalent `>=3.10,==3.*` syntax instead