### PR TITLE
Fix packaging gh workflow [skip ci]

### DIFF
--- a/.github/workflows/packit.yaml
+++ b/.github/workflows/packit.yaml
@@ -34,7 +34,7 @@ jobs:
         # Change setuptools-scm local_scheme to "no-local-version" so the
         # local part of the version isn't included, making the version string
         # compatible with PyPI.
-        sed --in-place "s/node-and-date/no-local-version/g" setup.py
+        sed --in-place "s/node-and-date/no-local-version/g" pyproject.toml
 
     - name: Build source and wheel distributions
       run: |


### PR DESCRIPTION
Setting for setuptools_scm is now moved to pyproject.toml. Earlier PR missed this for packaging workflow.