### PR TITLE
Add setuptools_scm ahead of time for versioning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,8 @@ py_modules =
     _echopype_version
 include_package_data = True
 python_requires = >=3.8
+setup_requires=
+    setuptools_scm
 
 [options.extras_require]
 plot =


### PR DESCRIPTION
This PR adds `setuptools_scm` ahead of time to determine versioning, seems like without this, the packaging doesn't work properly.