### PR TITLE
Create `dict` that contains sensor-specific structure across Echopype versions

### DIFF
--- a/echopype/convert/set_groups_ad2cp.py
+++ b/echopype/convert/set_groups_ad2cp.py
@@ -28,6 +28,16 @@ class SetGroupsAd2cp(SetGroupsBase):
         self.pulse_compressed = self.parser_obj.get_pulse_compressed()
         self.combine_packets()
 
+        self._beamgroups = [
+            {
+                "name": "Beam_group1",
+                "descr": (
+                    "contains velocity, correlation, and backscatter power (uncalibrated)"
+                    " data and other data derived from acoustic data."
+                ),
+            }
+        ]
+
     def combine_packets(self):
         self.ds = None
 

--- a/echopype/echodata/convention/echodata_structures.py
+++ b/echopype/echodata/convention/echodata_structures.py
@@ -1,4 +1,3 @@
-
 """
 The purpose of this dictionary is to define the structure of each sensor
 across echopype versions. The dictionary was originally intended to ease
@@ -23,314 +22,381 @@ None to any coords that do not have that coordinate (in that sensor). For exampp
 """
 
 SONAR_STRUCTURES = {
-    'AD2CP': {
-        'v0.5.x': {
-            'top': {
-                'ep_group': None,
-                'coords': [],
+    "AD2CP": {
+        "v0.5.x": {
+            "top": {
+                "ep_group": None,
+                "coords": [],
             },
-            'environment': {
-                'ep_group': 'Environment',
-                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder'],
+            "environment": {
+                "ep_group": "Environment",
+                "coords": [
+                    "ping_time",
+                    "ping_time_burst",
+                    "ping_time_average",
+                    "ping_time_echosounder",
+                ],
             },
-            'platform': {
-                'ep_group': 'Platform',
-                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder', 'beam',
-                           'range_bin_burst', 'range_bin_average', 'range_bin_echosounder'],
+            "platform": {
+                "ep_group": "Platform",
+                "coords": [
+                    "ping_time",
+                    "ping_time_burst",
+                    "ping_time_average",
+                    "ping_time_echosounder",
+                    "beam",
+                    "range_bin_burst",
+                    "range_bin_average",
+                    "range_bin_echosounder",
+                ],
             },
-            'provenance': {
-                'ep_group': 'Provenance',
-                'coords': [],
+            "provenance": {
+                "ep_group": "Provenance",
+                "coords": [],
             },
-            'sonar': {
-                'ep_group': 'Sonar',
-                'coords': [],
+            "sonar": {
+                "ep_group": "Sonar",
+                "coords": [],
             },
-            'vendor': {
-                'ep_group': 'Vendor',
-                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder',
-                           'ping_time_echosounder_raw', 'ping_time_echosounder_raw_transmit', 'sample',
-                           'sample_transmit', 'beam', 'range_bin_average', 'range_bin_burst', 'range_bin_echosounder'],
+            "vendor": {
+                "ep_group": "Vendor",
+                "coords": [
+                    "ping_time",
+                    "ping_time_burst",
+                    "ping_time_average",
+                    "ping_time_echosounder",
+                    "ping_time_echosounder_raw",
+                    "ping_time_echosounder_raw_transmit",
+                    "sample",
+                    "sample_transmit",
+                    "beam",
+                    "range_bin_average",
+                    "range_bin_burst",
+                    "range_bin_echosounder",
+                ],
             },
-            'beam': {
-                'ep_group': 'Beam',
-                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder', 'beam',
-                           'range_bin_burst', 'range_bin_average', 'range_bin_echosounder', 'altimeter_sample_bin'],
+            "beam": {
+                "ep_group": "Beam",
+                "coords": [
+                    "ping_time",
+                    "ping_time_burst",
+                    "ping_time_average",
+                    "ping_time_echosounder",
+                    "beam",
+                    "range_bin_burst",
+                    "range_bin_average",
+                    "range_bin_echosounder",
+                    "altimeter_sample_bin",
+                ],
             },
-            'beam_power': None,
-            'nmea': {
-                'ep_group': 'Platform/NMEA',
-                'coords': ['location_time'],
+            "beam_power": None,
+            "nmea": {
+                "ep_group": "Platform/NMEA",
+                "coords": ["location_time"],
             },
         },
-        'v0.6.x': {
-            'top': {
-                'ep_group': None,
-                'coords': [],
+        "v0.6.x": {
+            "top": {
+                "ep_group": None,
+                "coords": [],
             },
-            'environment': {
-                'ep_group': 'Environment',
-                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder'],
+            "environment": {
+                "ep_group": "Environment",
+                "coords": [
+                    "ping_time",
+                    "ping_time_burst",
+                    "ping_time_average",
+                    "ping_time_echosounder",
+                ],
             },
-            'platform': {
-                'ep_group': 'Platform',
-                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder', 'beam',
-                           'range_sample_burst', 'range_sample_average', 'range_sample_echosounder'],
+            "platform": {
+                "ep_group": "Platform",
+                "coords": [
+                    "ping_time",
+                    "ping_time_burst",
+                    "ping_time_average",
+                    "ping_time_echosounder",
+                    "beam",
+                    "range_sample_burst",
+                    "range_sample_average",
+                    "range_sample_echosounder",
+                ],
             },
-            'provenance': {
-                'ep_group': 'Provenance',
-                'coords': [],
+            "provenance": {
+                "ep_group": "Provenance",
+                "coords": [],
             },
-            'sonar': {
-                'ep_group': 'Sonar',
-                'coords': [],
+            "sonar": {
+                "ep_group": "Sonar",
+                "coords": [],
             },
-            'vendor': {
-                'ep_group': 'Vendor',
-                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder',
-                           'ping_time_echosounder_raw', 'ping_time_echosounder_raw_transmit', 'sample',
-                           'sample_transmit', 'beam', 'range_sample_average', 'range_sample_burst',
-                           'range_sample_echosounder'],
+            "vendor": {
+                "ep_group": "Vendor",
+                "coords": [
+                    "ping_time",
+                    "ping_time_burst",
+                    "ping_time_average",
+                    "ping_time_echosounder",
+                    "ping_time_echosounder_raw",
+                    "ping_time_echosounder_raw_transmit",
+                    "sample",
+                    "sample_transmit",
+                    "beam",
+                    "range_sample_average",
+                    "range_sample_burst",
+                    "range_sample_echosounder",
+                ],
             },
-            'beam': {
-                'ep_group': 'Sonar/Beam_group1',
-                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder', 'beam',
-                           'range_sample_burst', 'range_sample_average', 'range_sample_echosounder',
-                           'altimeter_sample_bin'],
+            "beam": {
+                "ep_group": "Sonar/Beam_group1",
+                "coords": [
+                    "ping_time",
+                    "ping_time_burst",
+                    "ping_time_average",
+                    "ping_time_echosounder",
+                    "beam",
+                    "range_sample_burst",
+                    "range_sample_average",
+                    "range_sample_echosounder",
+                    "altimeter_sample_bin",
+                ],
             },
-            'beam_power': None,
-            'nmea': {
-                'ep_group': 'Platform/NMEA',
-                'coords': ['location_time'],
+            "beam_power": None,
+            "nmea": {
+                "ep_group": "Platform/NMEA",
+                "coords": ["location_time"],
             },
-        }
+        },
     },
-    'AZFP': {
-        'v0.5.x': {
-            'top': {
-                'ep_group': None,
-                'coords': [],
+    "AZFP": {
+        "v0.5.x": {
+            "top": {
+                "ep_group": None,
+                "coords": [],
             },
-            'environment': {
-                'ep_group': 'Environment',
-                'coords': ['ping_time'],
+            "environment": {
+                "ep_group": "Environment",
+                "coords": ["ping_time"],
             },
-            'platform': {
-                'ep_group': 'Platform',
-                'coords': [],
+            "platform": {
+                "ep_group": "Platform",
+                "coords": [],
             },
-            'provenance': {
-                'ep_group': 'Provenance',
-                'coords': [],
+            "provenance": {
+                "ep_group": "Provenance",
+                "coords": [],
             },
-            'sonar': {
-                'ep_group': 'Sonar',
-                'coords': [None],
+            "sonar": {
+                "ep_group": "Sonar",
+                "coords": [None],
             },
-            'vendor': {
-                'ep_group': 'Vendor',
-                'coords': ['frequency', 'ping_time', 'ancillary_len', 'ad_len'],
+            "vendor": {
+                "ep_group": "Vendor",
+                "coords": ["frequency", "ping_time", "ancillary_len", "ad_len"],
             },
-            'beam': {
-                'ep_group': 'Beam',
-                'coords': ['frequency', 'ping_time', 'range_bin'],
+            "beam": {
+                "ep_group": "Beam",
+                "coords": ["frequency", "ping_time", "range_bin"],
             },
-            'beam_power': None,
-            'nmea': {
-                'ep_group': 'Platform/NMEA',
-                'coords': ['location_time'],
+            "beam_power": None,
+            "nmea": {
+                "ep_group": "Platform/NMEA",
+                "coords": ["location_time"],
             },
         },
-        'v0.6.x': {
-            'top': {
-                'ep_group': None,
-                'coords': [],
+        "v0.6.x": {
+            "top": {
+                "ep_group": None,
+                "coords": [],
             },
-            'environment': {
-                'ep_group': 'Environment',
-                'coords': ['ping_time'],
+            "environment": {
+                "ep_group": "Environment",
+                "coords": ["ping_time"],
             },
-            'platform': {
-                'ep_group': 'Platform',
-                'coords': [],
+            "platform": {
+                "ep_group": "Platform",
+                "coords": [],
             },
-            'provenance': {
-                'ep_group': 'Provenance',
-                'coords': [],
+            "provenance": {
+                "ep_group": "Provenance",
+                "coords": [],
             },
-            'sonar': {
-                'ep_group': 'Sonar',
-                'coords': ['beam'],
+            "sonar": {
+                "ep_group": "Sonar",
+                "coords": ["beam"],
             },
-            'vendor': {
-                'ep_group': 'Vendor',
-                'coords': ['channel', 'ping_time', 'ancillary_len', 'ad_len'],
+            "vendor": {
+                "ep_group": "Vendor",
+                "coords": ["channel", "ping_time", "ancillary_len", "ad_len"],
             },
-            'beam': {
-                'ep_group': 'Sonar/Beam_group1',
-                'coords': ['channel', 'ping_time', 'range_sample'],
-                'group_descr': "contains backscatter power (uncalibrated) and other beam or channel-specific data.",
+            "beam": {
+                "ep_group": "Sonar/Beam_group1",
+                "coords": ["channel", "ping_time", "range_sample"],
+                "group_descr": "contains backscatter power (uncalibrated) and other beam"
+                + " or channel-specific data.",
             },
-            'beam_power': None,
-            'nmea': {
-                'ep_group': 'Platform/NMEA',
-                'coords': ['location_time'],
+            "beam_power": None,
+            "nmea": {
+                "ep_group": "Platform/NMEA",
+                "coords": ["location_time"],
             },
-        }
+        },
     },
-    'EK60': {
-        'v0.5.x': {
-            'top': {
-                'ep_group': None,
-                'coords': [],
+    "EK60": {
+        "v0.5.x": {
+            "top": {
+                "ep_group": None,
+                "coords": [],
             },
-            'environment': {
-                'ep_group': 'Environment',
-                'coords': ['frequency', 'ping_time'],
+            "environment": {
+                "ep_group": "Environment",
+                "coords": ["frequency", "ping_time"],
             },
-            'platform': {
-                'ep_group': 'Platform',
-                'coords': ['location_time', 'ping_time', 'frequency'],
+            "platform": {
+                "ep_group": "Platform",
+                "coords": ["location_time", "ping_time", "frequency"],
             },
-            'provenance': {
-                'ep_group': 'Provenance',
-                'coords': [],
+            "provenance": {
+                "ep_group": "Provenance",
+                "coords": [],
             },
-            'sonar': {
-                'ep_group': 'Sonar',
-                'coords': [],
+            "sonar": {
+                "ep_group": "Sonar",
+                "coords": [],
             },
-            'vendor': {
-                'ep_group': 'Vendor',
-                'coords': ['frequency', 'pulse_length_bin'],
+            "vendor": {
+                "ep_group": "Vendor",
+                "coords": ["frequency", "pulse_length_bin"],
             },
-            'beam': {
-                'ep_group': 'Beam',
-                'coords': ['frequency', 'ping_time', 'range_bin', None],
+            "beam": {
+                "ep_group": "Beam",
+                "coords": ["frequency", "ping_time", "range_bin", None],
             },
-            'beam_power': None,
-            'nmea': {
-                'ep_group': 'Platform/NMEA',
-                'coords': ['location_time'],
+            "beam_power": None,
+            "nmea": {
+                "ep_group": "Platform/NMEA",
+                "coords": ["location_time"],
             },
         },
-        'v0.6.x': {
-            'top': {
-                'ep_group': None,
-                'coords': [],
+        "v0.6.x": {
+            "top": {
+                "ep_group": None,
+                "coords": [],
             },
-            'environment': {
-                'ep_group': 'Environment',
-                'coords': ['channel', 'ping_time'],
+            "environment": {
+                "ep_group": "Environment",
+                "coords": ["channel", "ping_time"],
             },
-            'platform': {
-                'ep_group': 'Platform',
-                'coords': ['location_time', 'ping_time', 'channel'],
+            "platform": {
+                "ep_group": "Platform",
+                "coords": ["location_time", "ping_time", "channel"],
             },
-            'provenance': {
-                'ep_group': 'Provenance',
-                'coords': [],
+            "provenance": {
+                "ep_group": "Provenance",
+                "coords": [],
             },
-            'sonar': {
-                'ep_group': 'Sonar',
-                'coords': ['beam_group'],
+            "sonar": {
+                "ep_group": "Sonar",
+                "coords": ["beam_group"],
             },
-            'vendor': {
-                'ep_group': 'Vendor',
-                'coords': ['channel', 'pulse_length_bin'],
+            "vendor": {
+                "ep_group": "Vendor",
+                "coords": ["channel", "pulse_length_bin"],
             },
-            'beam': {
-                'ep_group': 'Sonar/Beam_group1',
-                'group_descr': "contains backscatter power (uncalibrated) and other beam or" +
-                               " channel-specific data, including split-beam angle data when they exist.",
-                'coords': ['channel', 'ping_time', 'range_sample', 'beam'],
+            "beam": {
+                "ep_group": "Sonar/Beam_group1",
+                "group_descr": "contains backscatter power (uncalibrated) and other beam or"
+                + " channel-specific data, including split-beam angle data when they exist.",
+                "coords": ["channel", "ping_time", "range_sample", "beam"],
             },
-            'beam_power': None,
-            'nmea': {
-                'ep_group': 'Platform/NMEA',
-                'coords': ['location_time'],
+            "beam_power": None,
+            "nmea": {
+                "ep_group": "Platform/NMEA",
+                "coords": ["location_time"],
             },
-        }
+        },
     },
-    'EK80': {
-        'v0.5.x': {
-            'top': {
-                'ep_group': None,
-                'coords': [],
+    "EK80": {
+        "v0.5.x": {
+            "top": {
+                "ep_group": None,
+                "coords": [],
             },
-            'environment': {
-                'ep_group': 'Environment',
-                'coords': ['ping_time'],
+            "environment": {
+                "ep_group": "Environment",
+                "coords": ["ping_time"],
             },
-            'platform': {
-                'ep_group': 'Platform',
-                'coords': [None, None],
+            "platform": {
+                "ep_group": "Platform",
+                "coords": [None, None],
             },
-            'provenance': {
-                'ep_group': 'Provenance',
-                'coords': [],
+            "provenance": {
+                "ep_group": "Provenance",
+                "coords": [],
             },
-            'sonar': {
-                'ep_group': 'Sonar',
-                'coords': [None, 'frequency'],
+            "sonar": {
+                "ep_group": "Sonar",
+                "coords": [None, "frequency"],
             },
-            'vendor': {
-                'ep_group': 'Vendor',
-                'coords': ['frequency', 'pulse_length_bin', 'cal_frequency', 'cal_channel_id'],
+            "vendor": {
+                "ep_group": "Vendor",
+                "coords": ["frequency", "pulse_length_bin", "cal_frequency", "cal_channel_id"],
             },
-            'beam': {
-                'ep_group': 'Beam',
-                'coords': ['frequency', 'ping_time', 'range_bin', 'quadrant'],
+            "beam": {
+                "ep_group": "Beam",
+                "coords": ["frequency", "ping_time", "range_bin", "quadrant"],
             },
-            'beam_power': {
-                'ep_group': None,
-                'coords': [],
+            "beam_power": {
+                "ep_group": None,
+                "coords": [],
             },
-            'nmea': {
-                'ep_group': 'Platform/NMEA',
-                'coords': ['location_time'],
+            "nmea": {
+                "ep_group": "Platform/NMEA",
+                "coords": ["location_time"],
             },
         },
-        'v0.6.x': {
-            'top': {
-                'ep_group': None,
-                'coords': [],
+        "v0.6.x": {
+            "top": {
+                "ep_group": None,
+                "coords": [],
             },
-            'environment': {
-                'ep_group': 'Environment',
-                'coords': ['ping_time'],
+            "environment": {
+                "ep_group": "Environment",
+                "coords": ["ping_time"],
             },
-            'platform': {
-                'ep_group': 'Platform',
-                'coords': ['mru_time', 'location_time'],
+            "platform": {
+                "ep_group": "Platform",
+                "coords": ["mru_time", "location_time"],
             },
-            'provenance': {
-                'ep_group': 'Provenance',
-                'coords': [],
+            "provenance": {
+                "ep_group": "Provenance",
+                "coords": [],
             },
-            'sonar': {
-                'ep_group': 'Sonar',
-                'coords': ['beam', 'channel'],
+            "sonar": {
+                "ep_group": "Sonar",
+                "coords": ["beam", "channel"],
             },
-            'vendor': {
-                'ep_group': 'Vendor',
-                'coords': ['channel', 'pulse_length_bin', 'cal_frequency', 'cal_channel_id'],
+            "vendor": {
+                "ep_group": "Vendor",
+                "coords": ["channel", "pulse_length_bin", "cal_frequency", "cal_channel_id"],
             },
-            'beam': {
-                'ep_group': 'Sonar/Beam_group1',
-                'coords': ['channel', 'ping_time', 'range_sample', 'quadrant'],
-                'group_descr': "contains complex backscatter data and other beam or channel-specific data.",
+            "beam": {
+                "ep_group": "Sonar/Beam_group1",
+                "coords": ["channel", "ping_time", "range_sample", "quadrant"],
+                "group_descr": "contains complex backscatter data and other beam"
+                + " or channel-specific data.",
             },
-            'beam_power': {
-                'ep_group': 'Sonar/Beam_group2',
-                'coords': ['channel', 'ping_time', 'range_sample'],
-                'group_descr': "contains backscatter power (uncalibrated) and other beam or channel-specific data," +
-                               " including split-beam angle data when they exist.",
+            "beam_power": {
+                "ep_group": "Sonar/Beam_group2",
+                "coords": ["channel", "ping_time", "range_sample"],
+                "group_descr": "contains backscatter power (uncalibrated) and other beam"
+                + " or channel-specific data,"
+                + " including split-beam angle data when they exist.",
             },
-            'nmea': {
-                'ep_group': 'Platform/NMEA',
-                'coords': ['location_time'],
+            "nmea": {
+                "ep_group": "Platform/NMEA",
+                "coords": ["location_time"],
             },
-        }
+        },
     },
 }

--- a/echopype/echodata/convention/echodata_structures.py
+++ b/echopype/echodata/convention/echodata_structures.py
@@ -22,7 +22,7 @@ None to any coords that do not have that coordinate (in that sensor). For exampp
 5. If the group does not apply to the sensor, you should replace the dict with None
 """
 
-SONAR_STRUCTURES = {
+SENSOR_EP_VERSION_MAPPINGS = {
     "AD2CP": {
         "v0.5.x": {
             "top": {

--- a/echopype/echodata/convention/echodata_structures.py
+++ b/echopype/echodata/convention/echodata_structures.py
@@ -1,0 +1,166 @@
+
+#######################################################################################################################
+# PLEASE CAREFULLY REVIEW THE RULES BEFORE APPLYING CHANGES.
+#
+# Rules of the structure:
+#
+# 1. For each sensor, the keys of each group should correspond to the groups in 1.0.yml
+# 2. The ep_group should correspond to the group that would be used to access the DataTree.
+# 2. coords should contain all POSSIBLE unique coordinates.
+# 3. If you add a version structure, please add this version to all sensors.
+# 4. For each coords value carefully compare and modify all corresponding
+# coords of the other groups. For example, if you were to add 'beam' to coords, giving you
+# "coords": ['channel', 'ping_time', 'range_sample', 'beam'], then you should add
+# None to any coords that do not have that coordinate (in that sensor). For exampple,
+# "coords": ['frequency', 'ping_time', 'range_bin', None]
+# 5. If the group does not apply to the sensor, you should replace the dict with None
+#######################################################################################################################
+
+SONAR_STRUCTURES = {
+    'AD2CP': {
+        'v0.5.x': {
+            'top': {'ep_group': None, 'coords': [],},
+            'environment': {'ep_group': None, 'coords': [],},
+            'platform': {'ep_group': None, 'coords': [],},
+            'provenance': {'ep_group': None, 'coords': [],},
+            'sonar': {'ep_group': None, 'coords': [],},
+            'vendor': {'ep_group': None, 'coords': [],},
+            'beam': {'ep_group': None, 'coords': [],},
+            'beam_power': {'ep_group': None, 'coords': [],},
+            'nmea': {'ep_group': None, 'coords': [],},
+        },
+        'v0.6.x': {
+            'top': {'ep_group': None, 'coords': [],},
+            'environment': {'ep_group': None, 'coords': [],},
+            'platform': {'ep_group': None, 'coords': [],},
+            'provenance': {'ep_group': None, 'coords': [],},
+            'sonar': {'ep_group': None, 'coords': [],},
+            'vendor': {'ep_group': None, 'coords': [],},
+            'beam': {'ep_group': None, 'coords': [],},
+            'beam_power': {'ep_group': None, 'coords': [],},
+            'nmea': {'ep_group': None, 'coords': [],},
+        }
+    },
+    'AZFP': {
+        'v0.5.x': {
+            'top': {'ep_group': None, 'coords': [],},
+            'environment': {'ep_group': None, 'coords': [],},
+            'platform': {'ep_group': None, 'coords': [],},
+            'provenance': {'ep_group': None, 'coords': [],},
+            'sonar': {'ep_group': None, 'coords': [],},
+            'vendor': {'ep_group': None, 'coords': [],},
+            'beam': {'ep_group': None, 'coords': [],},
+            'beam_power': {'ep_group': None, 'coords': [],},
+            'nmea': {'ep_group': None, 'coords': [],},
+        },
+        'v0.6.x': {
+            'top': {'ep_group': None, 'coords': [],},
+            'environment': {'ep_group': None, 'coords': [],},
+            'platform': {'ep_group': None, 'coords': [],},
+            'provenance': {'ep_group': None, 'coords': [],},
+            'sonar': {'ep_group': None, 'coords': [],},
+            'vendor': {'ep_group': None, 'coords': [],},
+            'beam': {'ep_group': None, 'coords': [],},
+            'beam_power': {'ep_group': None, 'coords': [],},
+            'nmea': {'ep_group': None, 'coords': [],},
+        }
+    },
+    'EK60': {
+        'v0.5.x': {
+            'top': {
+                'ep_group': None,
+                'coords': [],
+            },
+            'environment': {
+                'ep_group': 'Environment',
+                'coords': ['frequency', 'ping_time'],
+            },
+            'platform': {
+                'ep_group': 'Platform',
+                'coords': ['location_time', 'ping_time', 'frequency'],
+            },
+            'provenance': {
+                'ep_group': 'Provenance',
+                'coords': [],
+            },
+            'sonar': {
+                'ep_group': 'Sonar',
+                'coords': [],
+            },
+            'vendor': {
+                'ep_group': 'Vendor',
+                'coords': ['frequency', 'pulse_length_bin'],
+            },
+            'beam': {
+                'ep_group': 'Beam',
+                'coords': ['frequency', 'ping_time', 'range_bin', None],
+            },
+            'beam_power': None,
+            'nmea': {
+                'ep_group': 'Platform/NMEA',
+                'coords': ['location_time'],
+            },
+        },
+        'v0.6.x': {
+            'top': {
+                'ep_group': None,
+                'coords': [],
+            },
+            'environment': {
+                'ep_group': 'Environment',
+                'coords': ['channel', 'ping_time'],
+            },
+            'platform': {
+                'ep_group': 'Platform',
+                'coords': ['location_time', 'ping_time', 'channel'],
+            },
+            'provenance': {
+                'ep_group': 'Provenance',
+                'coords': [],
+            },
+            'sonar': {
+                'ep_group': 'Sonar',
+                'coords': ['beam_group'],
+            },
+            'vendor': {
+                'ep_group': 'Vendor',
+                'coords': ['channel', 'pulse_length_bin'],
+            },
+            'beam': {
+                'ep_group': 'Sonar/Beam_group1',
+                'group_descr': "contains backscatter power (uncalibrated) and other beam or" +
+                               " channel-specific data, including split-beam angle data when they exist.",
+                'coords': ['channel', 'ping_time', 'range_sample', 'beam'],
+            },
+            'beam_power': None,
+            'nmea': {
+                'ep_group': 'Platform/NMEA',
+                'coords': ['location_time'],
+            },
+        }
+    },
+    'EK80': {
+        'v0.5.x': {
+            'top': {'ep_group': None, 'coords': [],},
+            'environment': {'ep_group': None, 'coords': [],},
+            'platform': {'ep_group': None, 'coords': [],},
+            'provenance': {'ep_group': None, 'coords': [],},
+            'sonar': {'ep_group': None, 'coords': [],},
+            'vendor': {'ep_group': None, 'coords': [],},
+            'beam': {'ep_group': None, 'coords': [],},
+            'beam_power': {'ep_group': None, 'coords': [],},
+            'nmea': {'ep_group': None, 'coords': [],},
+        },
+        'v0.6.x': {
+            'top': {'ep_group': None, 'coords': [],},
+            'environment': {'ep_group': None, 'coords': [],},
+            'platform': {'ep_group': None, 'coords': [],},
+            'provenance': {'ep_group': None, 'coords': [],},
+            'sonar': {'ep_group': None, 'coords': [],},
+            'vendor': {'ep_group': None, 'coords': [],},
+            'beam': {'ep_group': None, 'coords': [],},
+            'beam_power': {'ep_group': None, 'coords': [],},
+            'nmea': {'ep_group': None, 'coords': [],},
+        }
+    },
+}

--- a/echopype/echodata/convention/echodata_structures.py
+++ b/echopype/echodata/convention/echodata_structures.py
@@ -161,8 +161,8 @@ SONAR_STRUCTURES = {
                     "range_sample_echosounder",
                     "altimeter_sample_bin",
                 ],
-                "group_descr": "contains velocity, correlation, and backscatter power " +
-                               "(uncalibrated) data and other data derived from acoustic data",
+                "group_descr": "contains velocity, correlation, and backscatter power "
+                + "(uncalibrated) data and other data derived from acoustic data",
             },
             "beam_power": None,
             "nmea": {
@@ -350,7 +350,7 @@ SONAR_STRUCTURES = {
                 "coords": ["frequency", "ping_time", "range_bin", "quadrant"],
             },
             "beam_power": {
-                "ep_group": 'Beam_power',
+                "ep_group": "Beam_power",
                 "coords": ["frequency", "ping_time", "range_bin"],
             },
             "nmea": {

--- a/echopype/echodata/convention/echodata_structures.py
+++ b/echopype/echodata/convention/echodata_structures.py
@@ -1,9 +1,10 @@
 """
 The purpose of this dictionary is to define the structure of each sensor
-across echopype versions. The dictionary was originally intended to ease
+across echopype versions. The dictionary was developed to ease
 the transition from echopype version 0.5.x to version 0.6.x. This dict
 primarily focuses on names each EchoData group and their coordinates.
-The structure is currently based on the convention file 1.0.yml.
+The structure is currently based on the SONAR-netCDF4 convention
+file 1.0.yml.
 
 PLEASE CAREFULLY REVIEW THE RULES BEFORE APPLYING CHANGES.
 
@@ -160,6 +161,8 @@ SONAR_STRUCTURES = {
                     "range_sample_echosounder",
                     "altimeter_sample_bin",
                 ],
+                "group_descr": "contains velocity, correlation, and backscatter power " +
+                               "(uncalibrated) data and other data derived from acoustic data",
             },
             "beam_power": None,
             "nmea": {
@@ -328,7 +331,7 @@ SONAR_STRUCTURES = {
             },
             "platform": {
                 "ep_group": "Platform",
-                "coords": [None, None],
+                "coords": ["mru_time", "location_time"],
             },
             "provenance": {
                 "ep_group": "Provenance",
@@ -347,8 +350,8 @@ SONAR_STRUCTURES = {
                 "coords": ["frequency", "ping_time", "range_bin", "quadrant"],
             },
             "beam_power": {
-                "ep_group": None,
-                "coords": [],
+                "ep_group": 'Beam_power',
+                "coords": ["frequency", "ping_time", "range_bin"],
             },
             "nmea": {
                 "ep_group": "Platform/NMEA",

--- a/echopype/echodata/convention/echodata_structures.py
+++ b/echopype/echodata/convention/echodata_structures.py
@@ -1,68 +1,181 @@
 
-#############################################################################################
-# PLEASE CAREFULLY REVIEW THE RULES BEFORE APPLYING CHANGES.
-#
-# Rules of the structure:
-#
-# 1. For each sensor, the keys of each group should correspond to the groups in 1.0.yml
-# 2. The ep_group should correspond to the group that would be used to access the DataTree.
-# 2. coords should contain all POSSIBLE unique coordinates.
-# 3. If you add a version structure, please add this version to all sensors.
-# 4. For each coords value carefully compare and modify all corresponding
-# coords of the other groups. For example, if you were to add 'beam' to coords, giving you
-# "coords": ['channel', 'ping_time', 'range_sample', 'beam'], then you should add
-# None to any coords that do not have that coordinate (in that sensor). For exampple,
-# "coords": ['frequency', 'ping_time', 'range_bin', None]
-# 5. If the group does not apply to the sensor, you should replace the dict with None
-#############################################################################################
+"""
+The purpose of this dictionary is to define the structure of each sensor
+across echopype versions. The dictionary was originally intended to ease
+the transition from echopype version 0.5.x to version 0.6.x. This dict
+primarily focuses on names each EchoData group and their coordinates.
+The structure is currently based on the convention file 1.0.yml.
+
+PLEASE CAREFULLY REVIEW THE RULES BEFORE APPLYING CHANGES.
+
+Rules of the structure:
+
+1. For each sensor, the keys of each group should correspond to the groups in 1.0.yml
+2. The ep_group should correspond to the group that would be used to access the DataTree.
+2. coords should contain all POSSIBLE unique coordinates.
+3. If you add a version structure, please add this version to all sensors.
+4. For each coords value carefully compare and modify all corresponding
+coords of the other groups. For example, if you were to add 'beam' to coords, giving you
+'coords': ['channel', 'ping_time', 'range_sample', 'beam'], then you should add
+None to any coords that do not have that coordinate (in that sensor). For exampple,
+'coords': ['frequency', 'ping_time', 'range_bin', None]
+5. If the group does not apply to the sensor, you should replace the dict with None
+"""
 
 SONAR_STRUCTURES = {
     'AD2CP': {
         'v0.5.x': {
-            'top': {'ep_group': None, 'coords': [],},
-            'environment': {'ep_group': None, 'coords': [],},
-            'platform': {'ep_group': None, 'coords': [],},
-            'provenance': {'ep_group': None, 'coords': [],},
-            'sonar': {'ep_group': None, 'coords': [],},
-            'vendor': {'ep_group': None, 'coords': [],},
-            'beam': {'ep_group': None, 'coords': [],},
-            'beam_power': {'ep_group': None, 'coords': [],},
-            'nmea': {'ep_group': None, 'coords': [],},
+            'top': {
+                'ep_group': None,
+                'coords': [],
+            },
+            'environment': {
+                'ep_group': 'Environment',
+                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder'],
+            },
+            'platform': {
+                'ep_group': 'Platform',
+                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder', 'beam',
+                           'range_bin_burst', 'range_bin_average', 'range_bin_echosounder'],
+            },
+            'provenance': {
+                'ep_group': 'Provenance',
+                'coords': [],
+            },
+            'sonar': {
+                'ep_group': 'Sonar',
+                'coords': [],
+            },
+            'vendor': {
+                'ep_group': 'Vendor',
+                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder',
+                           'ping_time_echosounder_raw', 'ping_time_echosounder_raw_transmit', 'sample',
+                           'sample_transmit', 'beam', 'range_bin_average', 'range_bin_burst', 'range_bin_echosounder'],
+            },
+            'beam': {
+                'ep_group': 'Beam',
+                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder', 'beam',
+                           'range_bin_burst', 'range_bin_average', 'range_bin_echosounder', 'altimeter_sample_bin'],
+            },
+            'beam_power': None,
+            'nmea': {
+                'ep_group': 'Platform/NMEA',
+                'coords': ['location_time'],
+            },
         },
         'v0.6.x': {
-            'top': {'ep_group': None, 'coords': [],},
-            'environment': {'ep_group': None, 'coords': [],},
-            'platform': {'ep_group': None, 'coords': [],},
-            'provenance': {'ep_group': None, 'coords': [],},
-            'sonar': {'ep_group': None, 'coords': [],},
-            'vendor': {'ep_group': None, 'coords': [],},
-            'beam': {'ep_group': None, 'coords': [],},
-            'beam_power': {'ep_group': None, 'coords': [],},
-            'nmea': {'ep_group': None, 'coords': [],},
+            'top': {
+                'ep_group': None,
+                'coords': [],
+            },
+            'environment': {
+                'ep_group': 'Environment',
+                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder'],
+            },
+            'platform': {
+                'ep_group': 'Platform',
+                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder', 'beam',
+                           'range_sample_burst', 'range_sample_average', 'range_sample_echosounder'],
+            },
+            'provenance': {
+                'ep_group': 'Provenance',
+                'coords': [],
+            },
+            'sonar': {
+                'ep_group': 'Sonar',
+                'coords': [],
+            },
+            'vendor': {
+                'ep_group': 'Vendor',
+                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder',
+                           'ping_time_echosounder_raw', 'ping_time_echosounder_raw_transmit', 'sample',
+                           'sample_transmit', 'beam', 'range_sample_average', 'range_sample_burst',
+                           'range_sample_echosounder'],
+            },
+            'beam': {
+                'ep_group': 'Sonar/Beam_group1',
+                'coords': ['ping_time', 'ping_time_burst', 'ping_time_average', 'ping_time_echosounder', 'beam',
+                           'range_sample_burst', 'range_sample_average', 'range_sample_echosounder',
+                           'altimeter_sample_bin'],
+            },
+            'beam_power': None,
+            'nmea': {
+                'ep_group': 'Platform/NMEA',
+                'coords': ['location_time'],
+            },
         }
     },
     'AZFP': {
         'v0.5.x': {
-            'top': {'ep_group': None, 'coords': [],},
-            'environment': {'ep_group': None, 'coords': [],},
-            'platform': {'ep_group': None, 'coords': [],},
-            'provenance': {'ep_group': None, 'coords': [],},
-            'sonar': {'ep_group': None, 'coords': [],},
-            'vendor': {'ep_group': None, 'coords': [],},
-            'beam': {'ep_group': None, 'coords': [],},
-            'beam_power': {'ep_group': None, 'coords': [],},
-            'nmea': {'ep_group': None, 'coords': [],},
+            'top': {
+                'ep_group': None,
+                'coords': [],
+            },
+            'environment': {
+                'ep_group': 'Environment',
+                'coords': ['ping_time'],
+            },
+            'platform': {
+                'ep_group': 'Platform',
+                'coords': [],
+            },
+            'provenance': {
+                'ep_group': 'Provenance',
+                'coords': [],
+            },
+            'sonar': {
+                'ep_group': 'Sonar',
+                'coords': [None],
+            },
+            'vendor': {
+                'ep_group': 'Vendor',
+                'coords': ['frequency', 'ping_time', 'ancillary_len', 'ad_len'],
+            },
+            'beam': {
+                'ep_group': 'Beam',
+                'coords': ['frequency', 'ping_time', 'range_bin'],
+            },
+            'beam_power': None,
+            'nmea': {
+                'ep_group': 'Platform/NMEA',
+                'coords': ['location_time'],
+            },
         },
         'v0.6.x': {
-            'top': {'ep_group': None, 'coords': [],},
-            'environment': {'ep_group': None, 'coords': [],},
-            'platform': {'ep_group': None, 'coords': [],},
-            'provenance': {'ep_group': None, 'coords': [],},
-            'sonar': {'ep_group': None, 'coords': [],},
-            'vendor': {'ep_group': None, 'coords': [],},
-            'beam': {'ep_group': None, 'coords': [],},
-            'beam_power': {'ep_group': None, 'coords': [],},
-            'nmea': {'ep_group': None, 'coords': [],},
+            'top': {
+                'ep_group': None,
+                'coords': [],
+            },
+            'environment': {
+                'ep_group': 'Environment',
+                'coords': ['ping_time'],
+            },
+            'platform': {
+                'ep_group': 'Platform',
+                'coords': [],
+            },
+            'provenance': {
+                'ep_group': 'Provenance',
+                'coords': [],
+            },
+            'sonar': {
+                'ep_group': 'Sonar',
+                'coords': ['beam'],
+            },
+            'vendor': {
+                'ep_group': 'Vendor',
+                'coords': ['channel', 'ping_time', 'ancillary_len', 'ad_len'],
+            },
+            'beam': {
+                'ep_group': 'Sonar/Beam_group1',
+                'coords': ['channel', 'ping_time', 'range_sample'],
+                'group_descr': "contains backscatter power (uncalibrated) and other beam or channel-specific data.",
+            },
+            'beam_power': None,
+            'nmea': {
+                'ep_group': 'Platform/NMEA',
+                'coords': ['location_time'],
+            },
         }
     },
     'EK60': {
@@ -141,26 +254,83 @@ SONAR_STRUCTURES = {
     },
     'EK80': {
         'v0.5.x': {
-            'top': {'ep_group': None, 'coords': [],},
-            'environment': {'ep_group': None, 'coords': [],},
-            'platform': {'ep_group': None, 'coords': [],},
-            'provenance': {'ep_group': None, 'coords': [],},
-            'sonar': {'ep_group': None, 'coords': [],},
-            'vendor': {'ep_group': None, 'coords': [],},
-            'beam': {'ep_group': None, 'coords': [],},
-            'beam_power': {'ep_group': None, 'coords': [],},
-            'nmea': {'ep_group': None, 'coords': [],},
+            'top': {
+                'ep_group': None,
+                'coords': [],
+            },
+            'environment': {
+                'ep_group': 'Environment',
+                'coords': ['ping_time'],
+            },
+            'platform': {
+                'ep_group': 'Platform',
+                'coords': [None, None],
+            },
+            'provenance': {
+                'ep_group': 'Provenance',
+                'coords': [],
+            },
+            'sonar': {
+                'ep_group': 'Sonar',
+                'coords': [None, 'frequency'],
+            },
+            'vendor': {
+                'ep_group': 'Vendor',
+                'coords': ['frequency', 'pulse_length_bin', 'cal_frequency', 'cal_channel_id'],
+            },
+            'beam': {
+                'ep_group': 'Beam',
+                'coords': ['frequency', 'ping_time', 'range_bin', 'quadrant'],
+            },
+            'beam_power': {
+                'ep_group': None,
+                'coords': [],
+            },
+            'nmea': {
+                'ep_group': 'Platform/NMEA',
+                'coords': ['location_time'],
+            },
         },
         'v0.6.x': {
-            'top': {'ep_group': None, 'coords': [],},
-            'environment': {'ep_group': None, 'coords': [],},
-            'platform': {'ep_group': None, 'coords': [],},
-            'provenance': {'ep_group': None, 'coords': [],},
-            'sonar': {'ep_group': None, 'coords': [],},
-            'vendor': {'ep_group': None, 'coords': [],},
-            'beam': {'ep_group': None, 'coords': [],},
-            'beam_power': {'ep_group': None, 'coords': [],},
-            'nmea': {'ep_group': None, 'coords': [],},
+            'top': {
+                'ep_group': None,
+                'coords': [],
+            },
+            'environment': {
+                'ep_group': 'Environment',
+                'coords': ['ping_time'],
+            },
+            'platform': {
+                'ep_group': 'Platform',
+                'coords': ['mru_time', 'location_time'],
+            },
+            'provenance': {
+                'ep_group': 'Provenance',
+                'coords': [],
+            },
+            'sonar': {
+                'ep_group': 'Sonar',
+                'coords': ['beam', 'channel'],
+            },
+            'vendor': {
+                'ep_group': 'Vendor',
+                'coords': ['channel', 'pulse_length_bin', 'cal_frequency', 'cal_channel_id'],
+            },
+            'beam': {
+                'ep_group': 'Sonar/Beam_group1',
+                'coords': ['channel', 'ping_time', 'range_sample', 'quadrant'],
+                'group_descr': "contains complex backscatter data and other beam or channel-specific data.",
+            },
+            'beam_power': {
+                'ep_group': 'Sonar/Beam_group2',
+                'coords': ['channel', 'ping_time', 'range_sample'],
+                'group_descr': "contains backscatter power (uncalibrated) and other beam or channel-specific data," +
+                               " including split-beam angle data when they exist.",
+            },
+            'nmea': {
+                'ep_group': 'Platform/NMEA',
+                'coords': ['location_time'],
+            },
         }
     },
 }

--- a/echopype/echodata/convention/echodata_structures.py
+++ b/echopype/echodata/convention/echodata_structures.py
@@ -1,5 +1,5 @@
 
-#######################################################################################################################
+#############################################################################################
 # PLEASE CAREFULLY REVIEW THE RULES BEFORE APPLYING CHANGES.
 #
 # Rules of the structure:
@@ -14,7 +14,7 @@
 # None to any coords that do not have that coordinate (in that sensor). For exampple,
 # "coords": ['frequency', 'ping_time', 'range_bin', None]
 # 5. If the group does not apply to the sensor, you should replace the dict with None
-#######################################################################################################################
+#############################################################################################
 
 SONAR_STRUCTURES = {
     'AD2CP': {


### PR DESCRIPTION
This PR is in reference to issue #596. 

It creates a python file that contains a `dict`, which defines the structure of each sensor across Echopype versions. The structure is currently based on the convention file [`1.0.yml`](https://github.com/OSOceanAcoustics/echopype/blob/dev/echopype/echodata/convention/1.0.yml). 

This is currently a draft, I will be adding in the information for the other sensors.

I would like some input on the file and dictionary name. 