### PR TITLE
Rename ek80 `quadrant` dimemsions and coordinates to `beam`

### DIFF
--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -125,7 +125,7 @@ class CalibrateEK(CalibrateBase):
         # Params from the Vendor group
         # only execute this if cw and power
         if waveform_mode == "CW" and (
-            self.echodata.beam_power is not None or "quadrant" not in self.echodata.beam
+            self.echodata.beam_power is not None or "beam" not in self.echodata.beam
         ):
             params_from_vend = ["sa_correction", "gain_correction"]
             for p in params_from_vend:
@@ -577,7 +577,7 @@ class CalibrateEK80(CalibrateEK):
             backscatter_freq = (
                 backscatter.sel(frequency=freq)
                 .dropna(dim="range_sample", how="all")
-                .dropna(dim="quadrant", how="all")
+                .dropna(dim="beam", how="all")
                 .dropna(dim="ping_time")
             )
             channel_id = str(self.echodata.beam.sel(frequency=freq)["channel_id"].values)
@@ -702,8 +702,8 @@ class CalibrateEK80(CalibrateEK):
             # backscatter data
             pc = self.compress_pulse(chirp, freq_BB=freq_sel.frequency)
             prx = (
-                self.echodata.beam.quadrant.size
-                * np.abs(pc.mean(dim="quadrant")) ** 2
+                self.echodata.beam.beam.size
+                * np.abs(pc.mean(dim="beam")) ** 2
                 / (2 * np.sqrt(2)) ** 2
                 * (np.abs(self.z_er + self.z_et) / self.z_er) ** 2
                 / self.z_et
@@ -722,8 +722,8 @@ class CalibrateEK80(CalibrateEK):
                 self.echodata.beam["backscatter_r"] + 1j * self.echodata.beam["backscatter_i"]
             )
             prx = (
-                self.echodata.beam.quadrant.size
-                * np.abs(backscatter_cw.mean(dim="quadrant")) ** 2
+                self.echodata.beam.beam.size
+                * np.abs(backscatter_cw.mean(dim="beam")) ** 2
                 / (2 * np.sqrt(2)) ** 2
                 * (np.abs(self.z_er + self.z_et) / self.z_er) ** 2
                 / self.z_et
@@ -895,7 +895,7 @@ class CalibrateEK80(CalibrateEK):
                     "Only complex samples are calibrated, but power samples also exist in the raw data file!"  # noqa
                 )
         else:  # only power OR complex samples exist
-            if "quadrant" in self.echodata.beam.dims:  # data contain only complex samples
+            if "beam" in self.echodata.beam.dims:  # data contain only complex samples
                 if encode_mode == "power":
                     raise TypeError(
                         "File does not contain power samples! Use encode_mode='complex'"

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -397,12 +397,12 @@ class SetGroupsEK80(SetGroupsBase):
         ds_tmp = xr.Dataset(
             {
                 "backscatter_r": (
-                    ["ping_time", "range_sample", "quadrant"],
+                    ["ping_time", "range_sample", "beam"],
                     np.real(data),
                     {"long_name": "Real part of backscatter power", "units": "V"},
                 ),
                 "backscatter_i": (
-                    ["ping_time", "range_sample", "quadrant"],
+                    ["ping_time", "range_sample", "beam"],
                     np.imag(data),
                     {"long_name": "Imaginary part of backscatter power", "units": "V"},
                 ),
@@ -418,7 +418,7 @@ class SetGroupsEK80(SetGroupsBase):
                     np.arange(data_shape[1]),
                     self._varattrs["beam_coord_default"]["range_sample"],
                 ),
-                "quadrant": (["quadrant"], np.arange(num_transducer_sectors)),
+                "beam": (["beam"], np.arange(num_transducer_sectors)),
             },
         )
 

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -349,8 +349,8 @@ class EchoData:
             range_meter = range_meter.where(range_meter > 0, 0)  # set negative ranges to 0
 
             # set entries with NaN backscatter data to NaN
-            if "quadrant" in beam["backscatter_r"].dims:
-                valid_idx = ~beam["backscatter_r"].isel(quadrant=0).drop("quadrant").isnull()
+            if "beam" in beam["backscatter_r"].dims:
+                valid_idx = ~beam["backscatter_r"].isel(beam=0).drop("beam").isnull()
             else:
                 valid_idx = ~beam["backscatter_r"].isnull()
             range_meter = range_meter.where(valid_idx)

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -227,7 +227,7 @@ def test_compute_Sv_ek80_pc_echoview(ek80_path):
     pc = cal_obj.compress_pulse(chirp, freq_BB=freq_center.frequency)
     pc_mean = (
         pc.pulse_compressed_output.isel(frequency=0)
-        .mean(dim='quadrant')
+        .mean(dim='beam')
         .dropna('range_sample')
     )
 

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -160,11 +160,11 @@ def test_convert_ek80_complex_echoview(ek80_path):
     # Test complex parsed data
     df_bb = pd.read_csv(
         ek80_echoview_bb_power_csv, header=None, skiprows=[0]
-    )  # averaged across quadrants
+    )  # averaged across beams
     assert np.allclose(
         echodata.beam.backscatter_r.sel(frequency=70e3)
         .dropna('range_sample')
-        .mean(dim='quadrant'),
+        .mean(dim='beam'),
         df_bb.iloc[::2, 14:],  # real rows
         rtol=0,
         atol=8e-6,
@@ -172,7 +172,7 @@ def test_convert_ek80_complex_echoview(ek80_path):
     assert np.allclose(
         echodata.beam.backscatter_i.sel(frequency=70e3)
         .dropna('range_sample')
-        .mean(dim='quadrant'),
+        .mean(dim='beam'),
         df_bb.iloc[1::2, 14:],  # imag rows
         rtol=0,
         atol=4e-6,

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -388,7 +388,7 @@ def test_nan_range_entries(range_check_files):
     if sonar_model == "EK80":
         ds_Sv = echopype.calibrate.compute_Sv(echodata, waveform_mode='BB', encode_mode='complex')
         range_output = echodata.compute_range(env_params=[], ek_waveform_mode='BB')
-        nan_locs_backscatter_r = ~echodata.beam.backscatter_r.isel(quadrant=0).drop("quadrant").isnull()
+        nan_locs_backscatter_r = ~echodata.beam.backscatter_r.isel(beam=0).drop("beam").isnull()
     else:
         ds_Sv = echopype.calibrate.compute_Sv(echodata)
         range_output = echodata.compute_range(env_params=[])

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -119,7 +119,7 @@ def test_plot_multi_get_range(
     assert isinstance(plots, list) is True
     assert all(isinstance(plot, FacetGrid) for plot in plots) is True
 
-    # Quadrant shape check
+    # Beam shape check
     if (
         sonar_model.lower() == 'ek80'
         and range_kwargs['encode_mode'] == 'complex'

--- a/echopype/visualize/plot.py
+++ b/echopype/visualize/plot.py
@@ -25,7 +25,7 @@ def _set_label(
     if isinstance(fg, FacetGrid):
         text_pos = [0.02, 0.06]
         fontsize = 14
-        if col == 'quadrant':
+        if col == 'beam':
             if isinstance(frequency, list) or frequency is None:
                 for rl in fg.row_labels:
                     if rl is not None:
@@ -33,7 +33,7 @@ def _set_label(
 
                 for idx, cl in enumerate(fg.col_labels):
                     if cl is not None:
-                        cl.set_text(f'Quadrant {fg.col_names[idx]}')
+                        cl.set_text(f'Beam {fg.col_names[idx]}')
 
             text_pos = [0.04, 0.06]
             fontsize = 13
@@ -46,7 +46,7 @@ def _set_label(
                     ax.set_title('')
             else:
                 freq = frequency
-                ax.set_title(f'Quadrant {fg.col_names[idx]}')
+                ax.set_title(f'Beam {fg.col_names[idx]}')
             ax.text(
                 *text_pos,
                 f"{int(freq / 1000)} kHz",
@@ -129,8 +129,8 @@ def _plot_echogram(
     row = None
     col = None
 
-    if 'quadrant' in ds[variable].dims:
-        col = 'quadrant'
+    if 'beam' in ds[variable].dims:
+        col = 'beam'
         kwargs.update(
             {
                 'figsize': (15, 5),


### PR DESCRIPTION
Addresses the first, easy part of #520:
> For EK80 there is already a dimension called `quadrant` that is conceptually equivalent (for our purposes) to the `beam` dimension as defined in SONAR-netCDF4 v1. We will need to rename it to beam.

This PR involved just simple search-and-replace steps.