### PR TITLE
Rename `heave` to `vertical_offset`

### DIFF
--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -231,10 +231,10 @@ class SetGroupsEK60(SetGroupsBase):
                             self.parser_obj.ping_data_dict["roll"][ch],
                             self._varattrs["platform_var_default"]["roll"],
                         ),
-                        "heave": (
+                        "vertical_offset": (
                             ["ping_time"],
                             self.parser_obj.ping_data_dict["heave"][ch],
-                            self._varattrs["platform_var_default"]["heave"],
+                            self._varattrs["platform_var_default"]["vertical_offset"],
                         ),
                         "water_level": (
                             ["ping_time"],

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -153,10 +153,7 @@ class SetGroupsEK80(SetGroupsBase):
                 "vertical_offset": (
                     ["mru_time"],
                     np.array(self.parser_obj.mru.get("heave", [np.nan])),
-                    {
-                        "long_name": "Platform vertical offset from nominal",
-                        "units": "m",
-                    },
+                    self._varattrs["platform_var_default"]["vertical_offset"],
                 ),
                 "latitude": (
                     ["location_time"],

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -150,14 +150,12 @@ class SetGroupsEK80(SetGroupsBase):
                         "valid_range": (-90.0, 90.0),
                     },
                 ),
-                "heave": (
+                "vertical_offset": (
                     ["mru_time"],
                     np.array(self.parser_obj.mru.get("heave", [np.nan])),
                     {
-                        "long_name": "Platform heave",
-                        "standard_name": "platform_heave_angle",
-                        "units": "arc_degree",
-                        "valid_range": (-90.0, 90.0),
+                        "long_name": "Platform vertical offset from nominal",
+                        "units": "m",
                     },
                 ),
                 "latitude": (

--- a/echopype/echodata/convention/1.0.yml
+++ b/echopype/echodata/convention/1.0.yml
@@ -89,11 +89,9 @@ variable_and_varattributes:
       standard_name: platform_roll_angle
       units: arc_degree
       valid_range: (-90.0, 90.0)
-    heave:
-      long_name: Platform heave
-      standard_name: platform_heave_angle
-      units: arc_degree
-      valid_range: (-90.0, 90.0)
+    vertical_offset:
+      long_name: Platform vertical offset from nominal
+      units: m
     water_level:
       long_name: z-axis distance from the platform coordinate system origin to the sonar transducer
       units: m

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -469,7 +469,7 @@ class EchoData:
         in `extra_platform_data` with the following variable names will be used:
             - `"pitch"`
             - `"roll"`
-            - `"heave"`
+            - `"vertical_offset"`
             - `"latitude"`
             - `"longitude"`
             - `"water_level"`
@@ -565,7 +565,7 @@ class EchoData:
         dropped_vars_target = [
             "pitch",
             "roll",
-            "heave",
+            "vertical_offset",
             "latitude",
             "longitude",
             "water_level",
@@ -609,12 +609,12 @@ class EchoData:
                         platform.get("roll", np.full(num_obs, np.nan)),
                     ),
                 ),
-                "heave": (
+                "vertical_offset": (
                     "location_time",
                     mapping_search_variable(
                         extra_platform_data,
-                        ["heave", "HEAVE"],
-                        platform.get("heave", np.full(num_obs, np.nan)),
+                        ["heave", "HEAVE", "vertical_offset", "VERTICAL_OFFSET"],
+                        platform.get("vertical_offset", np.full(num_obs, np.nan)),
                     ),
                 ),
                 "latitude": (


### PR DESCRIPTION
Part of #592 

Renames `heave` to `vertical_offset` in accordance with the [SONAR-netCDF4 convention 1.0](https://www.ices.dk/sites/pub/Publication%20Reports/Cooperative%20Research%20Report%20(CRR)/CRR341.pdf):
![image](https://user-images.githubusercontent.com/49664304/162897803-a5c19c3e-8722-4ad6-bac2-239a9605cacd.png)

Note that only the variable in the converted dataset will be renamed; the parsers will still use the name `heave` to match the raw data specification.