### PR TITLE
Add missing required Platform variables

### DIFF
--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -243,6 +243,27 @@ class SetGroupsEK60(SetGroupsBase):
                             self.parser_obj.ping_data_dict["transducer_depth"][ch],
                             self._varattrs["platform_var_default"]["water_level"],
                         ),
+                        "transducer_offset_x": (
+                            [],
+                            self.parser_obj.config_datagram["transceivers"][ch].get(
+                                "pos_x", np.nan
+                            ),
+                            self._varattrs["platform_var_default"]["transducer_offset_x"],
+                        ),
+                        "transducer_offset_y": (
+                            [],
+                            self.parser_obj.config_datagram["transceivers"][ch].get(
+                                "pos_y", np.nan
+                            ),
+                            self._varattrs["platform_var_default"]["transducer_offset_y"],
+                        ),
+                        "transducer_offset_z": (
+                            [],
+                            self.parser_obj.config_datagram["transceivers"][ch].get(
+                                "pos_z", np.nan
+                            ),
+                            self._varattrs["platform_var_default"]["transducer_offset_z"],
+                        ),
                         **{
                             var: ([], np.nan, self._varattrs["platform_var_default"][var])
                             for var in [
@@ -255,9 +276,6 @@ class SetGroupsEK60(SetGroupsBase):
                                 "position_offset_x",
                                 "position_offset_y",
                                 "position_offset_z",
-                                "transducer_offset_x",
-                                "transducer_offset_y",
-                                "transducer_offset_z",
                             ]
                         },
                     },
@@ -458,33 +476,6 @@ class SetGroupsEK60(SetGroupsBase):
                         "long_name": "Equivalent beam angle",
                         "units": "sr",
                         "valid_range": (0.0, 4 * np.pi),
-                    },
-                ),
-                "transducer_offset_x": (
-                    ["frequency"],
-                    beam_params["pos_x"],
-                    {
-                        "long_name": "x-axis distance from the platform coordinate system "
-                        "origin to the sonar transducer",
-                        "units": "m",
-                    },
-                ),
-                "transducer_offset_y": (
-                    ["frequency"],
-                    beam_params["pos_y"],
-                    {
-                        "long_name": "y-axis distance from the platform coordinate system "
-                        "origin to the sonar transducer",
-                        "units": "m",
-                    },
-                ),
-                "transducer_offset_z": (
-                    ["frequency"],
-                    beam_params["pos_z"],
-                    {
-                        "long_name": "z-axis distance from the platform coordinate system "
-                        "origin to the sonar transducer",
-                        "units": "m",
                     },
                 ),
                 "gain_correction": (

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -243,6 +243,23 @@ class SetGroupsEK60(SetGroupsBase):
                             self.parser_obj.ping_data_dict["transducer_depth"][ch],
                             self._varattrs["platform_var_default"]["water_level"],
                         ),
+                        **{
+                            var: ([], np.nan, self._varattrs["platform_var_default"][var])
+                            for var in [
+                                "MRU_offset_x",
+                                "MRU_offset_y",
+                                "MRU_offset_z",
+                                "MRU_rotation_x",
+                                "MRU_rotation_y",
+                                "MRU_rotation_z",
+                                "position_offset_x",
+                                "position_offset_y",
+                                "position_offset_z",
+                                "transducer_offset_x",
+                                "transducer_offset_y",
+                                "transducer_offset_z",
+                            ]
+                        },
                     },
                     coords={
                         "ping_time": (

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -114,6 +114,8 @@ class SetGroupsEK80(SetGroupsBase):
     def set_platform(self) -> xr.Dataset:
         """Set the Platform group."""
 
+        ch_ids = self.parser_obj.config_datagram["configuration"].keys()
+
         # Collect variables
         if self.ui_param["water_level"] is not None:
             water_level = self.ui_param["water_level"]
@@ -176,6 +178,36 @@ class SetGroupsEK80(SetGroupsBase):
                     },
                 ),
                 "sentence_type": (["location_time"], msg_type),
+                "transducer_offset_x": (
+                    ["frequency"],
+                    [
+                        self.parser_obj.config_datagram["configuration"][ch].get(
+                            "transducer_offset_x", np.nan
+                        )
+                        for ch in ch_ids
+                    ],
+                    self._varattrs["platform_var_default"]["transducer_offset_x"],
+                ),
+                "transducer_offset_y": (
+                    ["frequency"],
+                    [
+                        self.parser_obj.config_datagram["configuration"][ch].get(
+                            "transducer_offset_y", np.nan
+                        )
+                        for ch in ch_ids
+                    ],
+                    self._varattrs["platform_var_default"]["transducer_offset_y"],
+                ),
+                "transducer_offset_z": (
+                    ["frequency"],
+                    [
+                        self.parser_obj.config_datagram["configuration"][ch].get(
+                            "transducer_offset_z", np.nan
+                        )
+                        for ch in ch_ids
+                    ],
+                    self._varattrs["platform_var_default"]["transducer_offset_z"],
+                ),
                 "water_level": (
                     [],
                     water_level,
@@ -341,33 +373,6 @@ class SetGroupsEK80(SetGroupsBase):
                         "long_name": "Equivalent beam angle",
                         "units": "sr",
                         "valid_range": (0.0, 4 * np.pi),
-                    },
-                ),
-                "transducer_offset_x": (
-                    ["frequency"],
-                    beam_params["transducer_offset_x"],
-                    {
-                        "long_name": "x-axis distance from the platform coordinate system "
-                        "origin to the sonar transducer",
-                        "units": "m",
-                    },
-                ),
-                "transducer_offset_y": (
-                    ["frequency"],
-                    beam_params["transducer_offset_y"],
-                    {
-                        "long_name": "y-axis distance from the platform coordinate system "
-                        "origin to the sonar transducer",
-                        "units": "m",
-                    },
-                ),
-                "transducer_offset_z": (
-                    ["frequency"],
-                    beam_params["transducer_offset_z"],
-                    {
-                        "long_name": "z-axis distance from the platform coordinate system "
-                        "origin to the sonar transducer",
-                        "units": "m",
                     },
                 ),
                 "transceiver_software_version": (

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -185,6 +185,20 @@ class SetGroupsEK80(SetGroupsBase):
                         "units": "m",
                     },
                 ),
+                **{
+                    var: ([], np.nan, self._varattrs["platform_var_default"][var])
+                    for var in [
+                        "MRU_offset_x",
+                        "MRU_offset_y",
+                        "MRU_offset_z",
+                        "MRU_rotation_x",
+                        "MRU_rotation_y",
+                        "MRU_rotation_z",
+                        "position_offset_x",
+                        "position_offset_y",
+                        "position_offset_z",
+                    ]
+                },
             },
             coords={
                 "mru_time": (

--- a/echopype/echodata/convention/1.0.yml
+++ b/echopype/echodata/convention/1.0.yml
@@ -79,16 +79,55 @@ variable_and_varattributes:
       standard_name: longitude
       units: degrees_east
       valid_range: (-180.0, 180.0)
+    MRU_offset_x:
+      long_name: Distance along the x-axis from the platform coordinate system origin to the motion reference unit sensor origin
+      units: m
+    MRU_offset_y:
+      long_name: Distance along the y-axis from the platform coordinate system origin to the motion reference unit sensor origin
+      units: m
+    MRU_offset_z:
+      long_name: Distance along the z-axis from the platform coordinate system origin to the motion reference unit sensor origin
+      units: m
+    MRU_rotation_x:
+      long_name: Extrinsic rotation about the x-axis from the platform to MRU coordinate systems
+      units: arc_degree
+      valid_range: (–180.0, 180.0)
+    MRU_rotation_y:
+      long_name: Extrinsic rotation about the y-axis from the platform to MRU coordinate systems
+      units: arc_degree
+      valid_range: (–180.0, 180.0)
+    MRU_rotation_z:
+      long_name: Extrinsic rotation about the z-axis from the platform to MRU coordinate systems
+      units: arc_degree
+      valid_range: (–180.0, 180.0)
     pitch:
       long_name: Platform pitch
       standard_name: platform_pitch_angle
       units: arc_degree
       valid_range: (-90.0, 90.0)
+    position_offset_x:
+      long_name: Distance along the x-axis from the platform coordinate system origin to the latitude/longitude sensor origin
+      units: m
+    position_offset_y:
+      long_name: Distance along the y-axis from the platform coordinate system origin to the latitude/longitude sensor origin
+      units: m
+    position_offset_z:
+      long_name: Distance along the z-axis from the platform coordinate system origin to the latitude/longitude sensor origin
+      units: m
     roll:
       long_name: Platform roll
       standard_name: platform_roll_angle
       units: arc_degree
       valid_range: (-90.0, 90.0)
+    transducer_offset_x:
+      long_name: x-axis distance from the platform coordinate system origin to the sonar transducer
+      units: m
+    transducer_offset_y:
+      long_name: y-axis distance from the platform coordinate system origin to the sonar transducer
+      units: m
+    transducer_offset_z:
+      long_name: z-axis distance from the platform coordinate system origin to the sonar transducer
+      units: m
     vertical_offset:
       long_name: Platform vertical offset from nominal
       units: m

--- a/echopype/tests/convert/test_convert_ek60.py
+++ b/echopype/tests/convert/test_convert_ek60.py
@@ -37,6 +37,30 @@ def test_convert_ek60_matlab_raw(ek60_path):
     # Compare with matlab outputs
     ds_matlab = loadmat(ek60_matlab_path)
 
+    # check platform
+    nan_plat_vars = [
+        "MRU_offset_x",
+        "MRU_offset_y",
+        "MRU_offset_z",
+        "MRU_rotation_x",
+        "MRU_rotation_y",
+        "MRU_rotation_z",
+        "position_offset_x",
+        "position_offset_y",
+        "position_offset_z"
+    ]
+    for plat_var in nan_plat_vars:
+        assert plat_var in echodata["Platform"]
+        assert np.isnan(echodata["Platform"][plat_var]).all()
+    zero_plat_vars = [
+        "transducer_offset_x",
+        "transducer_offset_y",
+        "transducer_offset_z",
+    ]
+    for plat_var in zero_plat_vars:
+        assert plat_var in echodata["Platform"]
+        assert (echodata["Platform"][plat_var] == 0).all()
+
     # power
     assert np.allclose(
         [
@@ -95,6 +119,30 @@ def test_convert_ek60_echoview_raw(ek60_path):
             atol=9e-6,
             rtol=atol,
         )
+
+    # check platform
+    nan_plat_vars = [
+        "MRU_offset_x",
+        "MRU_offset_y",
+        "MRU_offset_z",
+        "MRU_rotation_x",
+        "MRU_rotation_y",
+        "MRU_rotation_z",
+        "position_offset_x",
+        "position_offset_y",
+        "position_offset_z"
+    ]
+    for plat_var in nan_plat_vars:
+        assert plat_var in echodata["Platform"]
+        assert np.isnan(echodata["Platform"][plat_var]).all()
+    zero_plat_vars = [
+        "transducer_offset_x",
+        "transducer_offset_y",
+        "transducer_offset_z",
+    ]
+    for plat_var in zero_plat_vars:
+        assert plat_var in echodata["Platform"]
+        assert (echodata["Platform"][plat_var] == 0).all()
 
 
 def test_convert_ek60_duplicate_ping_times(ek60_path):

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -73,6 +73,30 @@ def test_convert_ek80_complex_matlab(ek80_path):
         ),  # imag part
     )
 
+    # check platform
+    nan_plat_vars = [
+        "MRU_offset_x",
+        "MRU_offset_y",
+        "MRU_offset_z",
+        "MRU_rotation_x",
+        "MRU_rotation_y",
+        "MRU_rotation_z",
+        "position_offset_x",
+        "position_offset_y",
+        "position_offset_z"
+    ]
+    for plat_var in nan_plat_vars:
+        assert plat_var in echodata["Platform"]
+        assert np.isnan(echodata["Platform"][plat_var]).all()
+    zero_plat_vars = [
+        "transducer_offset_x",
+        "transducer_offset_y",
+        "transducer_offset_z",
+    ]
+    for plat_var in zero_plat_vars:
+        assert plat_var in echodata["Platform"]
+        assert (echodata["Platform"][plat_var] == 0).all()
+
 
 def test_convert_ek80_cw_power_angle_echoview(ek80_path):
     """Compare parsed EK80 CW power/angle data with csv exported by EchoView."""
@@ -146,6 +170,31 @@ def test_convert_ek80_cw_power_angle_echoview(ek80_path):
                 atol=5e-5,
             )
 
+    # check platform
+    nan_plat_vars = [
+        "MRU_offset_x",
+        "MRU_offset_y",
+        "MRU_offset_z",
+        "MRU_rotation_x",
+        "MRU_rotation_y",
+        "MRU_rotation_z",
+        "position_offset_x",
+        "position_offset_y",
+        "position_offset_z"
+    ]
+    for plat_var in nan_plat_vars:
+        assert plat_var in echodata["Platform"]
+        assert np.isnan(echodata["Platform"][plat_var]).all()
+    zero_plat_vars = [
+        "transducer_offset_x",
+        "transducer_offset_y",
+    ]
+    for plat_var in zero_plat_vars:
+        assert plat_var in echodata["Platform"]
+        assert (echodata["Platform"][plat_var] == 0).all()
+    assert "transducer_offset_z" in echodata["Platform"]
+    assert (echodata["Platform"]["transducer_offset_z"] == 9.15).all()
+
 
 def test_convert_ek80_complex_echoview(ek80_path):
     """Compare parsed EK80 BB data with csv exported by EchoView."""
@@ -178,6 +227,30 @@ def test_convert_ek80_complex_echoview(ek80_path):
         atol=4e-6,
     )
 
+    # check platform
+    nan_plat_vars = [
+        "MRU_offset_x",
+        "MRU_offset_y",
+        "MRU_offset_z",
+        "MRU_rotation_x",
+        "MRU_rotation_y",
+        "MRU_rotation_z",
+        "position_offset_x",
+        "position_offset_y",
+        "position_offset_z"
+    ]
+    for plat_var in nan_plat_vars:
+        assert plat_var in echodata["Platform"]
+        assert np.isnan(echodata["Platform"][plat_var]).all()
+    zero_plat_vars = [
+        "transducer_offset_x",
+        "transducer_offset_y",
+        "transducer_offset_z",
+    ]
+    for plat_var in zero_plat_vars:
+        assert plat_var in echodata["Platform"]
+        assert (echodata["Platform"][plat_var] == 0).all()
+
 
 def test_convert_ek80_cw_bb_in_single_file(ek80_path):
     """Make sure can convert a single EK80 file containing both CW and BB mode data."""
@@ -190,6 +263,30 @@ def test_convert_ek80_cw_bb_in_single_file(ek80_path):
     assert echodata.beam_power is not None
     assert echodata.beam is not None
 
+    # check platform
+    nan_plat_vars = [
+        "MRU_offset_x",
+        "MRU_offset_y",
+        "MRU_offset_z",
+        "MRU_rotation_x",
+        "MRU_rotation_y",
+        "MRU_rotation_z",
+        "position_offset_x",
+        "position_offset_y",
+        "position_offset_z"
+    ]
+    for plat_var in nan_plat_vars:
+        assert plat_var in echodata["Platform"]
+        assert np.isnan(echodata["Platform"][plat_var]).all()
+    zero_plat_vars = [
+        "transducer_offset_x",
+        "transducer_offset_y",
+        "transducer_offset_z",
+    ]
+    for plat_var in zero_plat_vars:
+        assert plat_var in echodata["Platform"]
+        assert (echodata["Platform"][plat_var] == 0).all()
+
 
 def test_convert_ek80_freq_subset(ek80_path):
     """Make sure can convert EK80 file with multiple frequency channels off."""
@@ -200,3 +297,27 @@ def test_convert_ek80_freq_subset(ek80_path):
 
     # Check if converted output has only 2 frequency channels
     assert echodata.beam.frequency.size == 2
+
+    # check platform
+    nan_plat_vars = [
+        "MRU_offset_x",
+        "MRU_offset_y",
+        "MRU_offset_z",
+        "MRU_rotation_x",
+        "MRU_rotation_y",
+        "MRU_rotation_z",
+        "position_offset_x",
+        "position_offset_y",
+        "position_offset_z"
+    ]
+    for plat_var in nan_plat_vars:
+        assert plat_var in echodata["Platform"]
+        assert np.isnan(echodata["Platform"][plat_var]).all()
+    zero_plat_vars = [
+        "transducer_offset_x",
+        "transducer_offset_y",
+        "transducer_offset_z",
+    ]
+    for plat_var in zero_plat_vars:
+        assert plat_var in echodata["Platform"]
+        assert (echodata["Platform"][plat_var] == 0).all()


### PR DESCRIPTION
Part of #592 

- Adds missing required variables in the Platform group as NaN
- Moves `transducer_offset_x/y/z` from Beam to Platform in accordance with the convention