### PR TITLE
Bring `dev` docs up-to-date with `stable`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ exclude: |
   )
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -35,7 +35,8 @@ This diagram depicts the complete workflow we use in the source GitHub repositor
         rel --> main
 
 - ``doc patch``: Updates to the documentation that refer to the current ``echopype``
-  release can be pushed out immediately to the `echopype documentation site <https://echopype.readthedocs.io>`_
+  release can be pushed out immediately to the
+  `echopype documentation site <https://echopype.readthedocs.io>`_
   by contibuting patches (PRs) to the ``stable`` branch. See `Documentation development`_
   below for more details.
 - ``code patch``: Code development is carried out as patches (PRs) to the ``dev``
@@ -76,11 +77,18 @@ Create a `conda <https://docs.conda.io>`_ environment for echopype development
 
 .. code-block:: bash
 
-    conda create -c conda-forge -n echopype --yes python=3.9 --file requirements-dev.txt
+    # create conda environment using the supplied requirements files
+    # note the last one docs/requirements.txt is only required for building docs
+    conda create -c conda-forge -n echopype --yes python=3.9 --file requirements.txt --file requirements-dev.txt --file docs/requirements.txt
+
+    # switch to the newly built environment
     conda activate echopype
+
     # ipykernel is recommended, in order to use with JupyterLab and IPython
     # to aid with development. We recommend you install JupyterLab separately
     conda install -c conda-forge ipykernel
+
+    # install echopype in editable mode (setuptools "develop mode")
     # plot is an extra set of requirements that can be used for plotting.
     # the command will install all the dependencies along with plotting dependencies.
     pip install -e .[plot]
@@ -133,7 +141,6 @@ and `S3 object-storage <https://en.wikipedia.org/wiki/Amazon_S3>`_ sources,
 the latter via `minio <https://minio.io>`_.
 
 `.ci_helpers/run-test.py <https://github.com/OSOceanAcoustics/echopype/blob/main/.ci_helpers/run-test.py>`_
-
 will execute all tests. The entire test suite can be a bit slow, taking up to 40 minutes
 or more. If your changes impact only some of the subpackages (``convert``, ``calibrate``,
 ``preprocess``, etc), you can run ``run-test.py`` with only a subset of tests by passing
@@ -144,7 +151,6 @@ as an argument a comma-separated list of the modules that have changed. For exam
     python .ci_helpers/run-test.py --local --pytest-args="-vv" echopype/calibrate/calibrate_ek.py,echopype/preprocess/noise_est.py
 
 will run only tests associated with the ``calibrate`` and ``preprocess`` subpackages.
-
 For ``run-test.py`` usage information, use the ``-h`` argument:
 ``python .ci_helpers/run-test.py -h``
 
@@ -226,12 +232,13 @@ Documentation versions
 `<https://echopype.readthedocs.io>`_ redirects to the documentation ``stable`` version,
 `<https://echopype.readthedocs.io/en/stable/>`_, which is built from the ``stable`` branch
 on the ``echopype`` GitHub repository. In addition, the ``latest`` version
-(`<https://echopype.readthedocs.io/en/latest/>`_) is built from the ``main`` branch,
-while the hidden `dev` version (`<https://echopype.readthedocs.io/en/dev/>`_) is built
-from the ``dev`` branch. Finally, each new echopype release is built as a new release version
-on ReadTheDocs. Merging pull requests into any of these three branches or issuing a
-new tagged release will automatically result in a new ReadTheDocs build for the
+(`<https://echopype.readthedocs.io/en/latest/>`_) is built from the ``dev`` branch and
+therefore it reflects the bleeding edge development code (which may occasionally break
+the documentation build). Finally, each new echopype release is built as a new release version
+on ReadTheDocs. Merging pull requests into ``stable`` or ``dev`` or issuing a new
+tagged release will automatically result in a new ReadTheDocs build for the
 corresponding version.
 
 We also maintain a test version of the documentation at `<https://doc-test-echopype.readthedocs.io/>`_
 for viewing and debugging larger, more experimental changes, typically from a separate fork.
+This version is used to test one-off, major breaking changes.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,5 +1,9 @@
+Installation and Examples
+=========================
+
+
 Installation
-============
+------------
 
 Echopype is available and tested for Python>=3.7. The latest release
 can be installed from `PyPI <https://pypi.org/project/echopype/>`_:
@@ -18,3 +22,13 @@ Previous releases are also available on PyPI and conda.
 
 For instructions on installing a development version of echopype,
 see the :doc:`contributing` page.
+
+
+Examples
+--------
+
+Additional `Jupyter notebooks <https://osoceanacoustics.github.io/echopype-examples/>`_
+illustrating the workflow of Echopype are also made available. These
+examples include a quick tour of Echopype, a demonstration of how Echopype can be used
+to explore ship echosounder data from a Pacific Hake survey, and using Echopype to
+visualize the response of zooplankton to a solar eclipse.

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -1,6 +1,7 @@
 Other resources
 ================
 
+
 Software
 --------
 

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -3,6 +3,56 @@ What's new
 
 See `GitHub releases page <https://github.com/OSOceanAcoustics/echopype/releases>`_ for the complete history.
 
+v0.5.6 (2022 Feb 10)
+--------------------
+
+Overview
+~~~~~~~~
+
+This is a minor release that contains an experimental new feature and a number of enhancements, clean-up and bug fixes, which pave the way for the next major release.
+
+New feature
+~~~~~~~~~~~
+
+- (beta) Allow interpolating CTD data in calibration (#464)
+
+  - Interpolation currently allowed along the ``ping_time`` dimension (the ``"stationary"`` case) and across ``latitude`` and ``longitude`` (the ``"mobile"`` case).
+  - This mechanism is enabled via a new ``EnvParams`` class at input of calibration functions.
+
+Enhancements
+~~~~~~~~~~~~
+
+- Make visualize module fully optional with ``matplotlib``, ``cmocean`` being optional dependency (#526, #559)
+- Set range entries with no backscatter data to NaN in output of ``echodata.compute_range()`` (#547) and still allows quick visualization (#555)
+- Add ``codespell`` GitHub action to ensure correct spellings of words (#557)
+- Allow ``sonar_model="EA640"`` for ``open_raw`` (before it had to be "EK80") (#539)
+
+Bug fixes
+~~~~~~~~~
+
+- Allow using ``sonar_model="EA640"`` (#538, #539)
+- Allow flexible and empty environment variables in EA640/EK80 files (#537)
+- Docstring overhaul and fix bugs in ``utils.uwa`` (#525)
+
+Documentation
+~~~~~~~~~~~~~
+
+- Upgrade echopype docs to use jupyter book (#543)
+- Change the RTD ``latest`` to point to the ``dev`` branch (#467)
+
+Testing
+~~~~~~~
+
+- Update convert tests to enable parallel testing (#556)
+- Overhaul tests (#523, #498)
+
+  - use ``pytest.fixture`` for testing
+  - add ES70/ES80/EA640 test files
+  - add new EK80 small test files with parameter combinations
+  - reduce size for a subset of large EK80 test data files
+
+- Add packaging testing for the ``dev`` branch (#554)
+
 
 v0.5.5 (2021 Dec 10)
 --------------------

--- a/docs/source/why.rst
+++ b/docs/source/why.rst
@@ -21,7 +21,7 @@ other climate and oceanographic data sets, facilitating the integration of
 ocean sonar data in interdisciplinary oceanographic research.
 
 .. _netCDF:
-   https://www.unidata.ucar.edu/software/netcdf/docs/netcdf_introduction.html
+   https://www.unidata.ucar.edu/software/netcdf/
 .. _xarray: http://xarray.pydata.org/
 .. _dask: http://dask.pydata.org/
 .. _pandas: https://pandas.pydata.org/


### PR DESCRIPTION
This should bring all the updates that are currently in `stable` only to `dev`.

There are some changes that appear in the codebase and not the docs, but those are related to pre-commit reformatting and not actual changes to the code.