### PR TITLE
For EK60 and EK80 add `beam` and `ping_time` to `Beam_groupX`

### DIFF
--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 import xarray as xr
 from dask.array.core import Array
@@ -127,9 +125,7 @@ class CalibrateEK(CalibrateBase):
         # Params from the Vendor group
 
         # only execute this if cw and power
-        if waveform_mode == "CW" and beam is not None:  # (
-            # self.echodata.beam_power is not None or "beam" not in self.echodata.beam
-         # ):
+        if waveform_mode == "CW" and beam is not None:
             params_from_vend = ["sa_correction", "gain_correction"]
             for p in params_from_vend:
                 # substitute if None in user input
@@ -898,7 +894,7 @@ class CalibrateEK80(CalibrateEK):
                     "Only complex samples are calibrated, but power samples also exist in the raw data file!"  # noqa
                 )
         else:  # only power OR complex samples exist
-            if "beam" in self.echodata.beam.dims:  # data contain only complex samples
+            if "backscatter_i" in self.echodata.beam.variables:  # data contain only complex samples
                 if encode_mode == "power":
                     raise TypeError(
                         "File does not contain power samples! Use encode_mode='complex'"

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import xarray as xr
 from dask.array.core import Array
@@ -123,10 +125,11 @@ class CalibrateEK(CalibrateBase):
             beam = self.echodata.beam
 
         # Params from the Vendor group
+
         # only execute this if cw and power
-        if waveform_mode == "CW" and (
-            self.echodata.beam_power is not None or "beam" not in self.echodata.beam
-        ):
+        if waveform_mode == "CW" and beam is not None:  # (
+            # self.echodata.beam_power is not None or "beam" not in self.echodata.beam
+         # ):
             params_from_vend = ["sa_correction", "gain_correction"]
             for p in params_from_vend:
                 # substitute if None in user input

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -288,55 +288,6 @@ class SetGroupsEK60(SetGroupsBase):
 
         return set_encodings(ds)
 
-    # @staticmethod
-    # def _add_beam_dim(ds: xr.Dataset, add_ping_time_names: list):
-    #     """
-    #     Adds ``beam`` as the last dimension to the appropriate
-    #     variables in ``Sonar/Beam_group1``.
-    #     """
-    #
-    #     # variables to add beam to
-    #     add_beam_names = ["backscatter_r", "angle_athwartship", "angle_alongship"] \
-    #                      + add_ping_time_names
-    #
-    #     for var_name in add_beam_names:
-    #         ds[var_name] = ds[var_name].expand_dims(dim={'beam': np.array(['1'], dtype=str)},
-    #                                                 axis=ds[var_name].ndim)
-    #
-    # @staticmethod
-    # def _add_ping_time_dim(ds: xr.Dataset):
-    #
-    #     # variables to add ping_time to
-    #     add_ping_time_names = ["beam_direction_x", "beam_direction_y", "beam_direction_z",
-    #                            "beamwidth_receive_alongship", "beamwidth_receive_athwartship",
-    #                            "beamwidth_transmit_alongship", "beamwidth_transmit_athwartship",
-    #                            "angle_offset_alongship", "angle_offset_athwartship",
-    #                            "angle_sensitivity_alongship", "angle_sensitivity_athwartship",
-    #                            "equivalent_beam_angle", "gain_correction"]
-    #
-    #     ping_time = ds.ping_time.values
-    #
-    #     for var_name in add_ping_time_names:
-    #         ds[var_name] = ds[var_name].expand_dims(dim={'ping_time': ping_time}, axis=ds[var_name].ndim)
-    #
-    #     return add_ping_time_names
-
-    # def _beam_to_convention(self, ds: xr.Dataset):
-    #     """
-    #     Manipulates the variables in ``Sonar/Beam_group1``
-    #     so that they adhere to convention.
-    #
-    #     This does several things:
-    #     1. Adds ``beam`` dimension to ``backscatter_r``,
-    #     ``angle_athwartship``, and ``angle_alongship``
-    #     2.
-    #     """
-    #
-    #     add_ping_time_names = self._add_ping_time_dim(ds)
-    #
-    #     # add beam dimension to certain variables
-    #     self._add_beam_dim(ds, add_ping_time_names)
-
     def set_beam(self) -> xr.Dataset:
         """Set the /Sonar/Beam_group1 group."""
         # Get channel keys and frequency
@@ -659,7 +610,7 @@ class SetGroupsEK60(SetGroupsBase):
         )  # override keeps the Dataset attributes
 
         # manipulate Dataset to adhere to convention
-        self.beam_to_convention(ds, self.sonar_model)
+        self.beamgroups_to_convention(ds, self.sonar_model)
 
         return set_encodings(ds)
 

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -288,6 +288,55 @@ class SetGroupsEK60(SetGroupsBase):
 
         return set_encodings(ds)
 
+    # @staticmethod
+    # def _add_beam_dim(ds: xr.Dataset, add_ping_time_names: list):
+    #     """
+    #     Adds ``beam`` as the last dimension to the appropriate
+    #     variables in ``Sonar/Beam_group1``.
+    #     """
+    #
+    #     # variables to add beam to
+    #     add_beam_names = ["backscatter_r", "angle_athwartship", "angle_alongship"] \
+    #                      + add_ping_time_names
+    #
+    #     for var_name in add_beam_names:
+    #         ds[var_name] = ds[var_name].expand_dims(dim={'beam': np.array(['1'], dtype=str)},
+    #                                                 axis=ds[var_name].ndim)
+    #
+    # @staticmethod
+    # def _add_ping_time_dim(ds: xr.Dataset):
+    #
+    #     # variables to add ping_time to
+    #     add_ping_time_names = ["beam_direction_x", "beam_direction_y", "beam_direction_z",
+    #                            "beamwidth_receive_alongship", "beamwidth_receive_athwartship",
+    #                            "beamwidth_transmit_alongship", "beamwidth_transmit_athwartship",
+    #                            "angle_offset_alongship", "angle_offset_athwartship",
+    #                            "angle_sensitivity_alongship", "angle_sensitivity_athwartship",
+    #                            "equivalent_beam_angle", "gain_correction"]
+    #
+    #     ping_time = ds.ping_time.values
+    #
+    #     for var_name in add_ping_time_names:
+    #         ds[var_name] = ds[var_name].expand_dims(dim={'ping_time': ping_time}, axis=ds[var_name].ndim)
+    #
+    #     return add_ping_time_names
+
+    # def _beam_to_convention(self, ds: xr.Dataset):
+    #     """
+    #     Manipulates the variables in ``Sonar/Beam_group1``
+    #     so that they adhere to convention.
+    #
+    #     This does several things:
+    #     1. Adds ``beam`` dimension to ``backscatter_r``,
+    #     ``angle_athwartship``, and ``angle_alongship``
+    #     2.
+    #     """
+    #
+    #     add_ping_time_names = self._add_ping_time_dim(ds)
+    #
+    #     # add beam dimension to certain variables
+    #     self._add_beam_dim(ds, add_ping_time_names)
+
     def set_beam(self) -> xr.Dataset:
         """Set the /Sonar/Beam_group1 group."""
         # Get channel keys and frequency
@@ -608,6 +657,9 @@ class SetGroupsEK60(SetGroupsBase):
         ds = xr.merge(
             [ds, xr.merge(ds_backscatter)], combine_attrs="override"
         )  # override keeps the Dataset attributes
+
+        # manipulate Dataset to adhere to convention
+        self.beam_to_convention(ds, self.sonar_model)
 
         return set_encodings(ds)
 

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -386,6 +386,7 @@ class SetGroupsEK80(SetGroupsBase):
             raise ValueError("Transducer sector number changes in the middle of the file!")
         else:
             num_transducer_sectors = num_transducer_sectors[0]
+
         data_shape = self.parser_obj.ping_data_dict["complex"][ch].shape
         data_shape = (
             data_shape[0],
@@ -418,7 +419,8 @@ class SetGroupsEK80(SetGroupsBase):
                     np.arange(data_shape[1]),
                     self._varattrs["beam_coord_default"]["range_sample"],
                 ),
-                "beam": (["beam"], np.arange(num_transducer_sectors)),
+                "beam": (["beam"], np.arange(start=1,
+                                             stop=num_transducer_sectors + 1).astype(str)),
             },
         )
 
@@ -663,6 +665,11 @@ class SetGroupsEK80(SetGroupsBase):
                 ds_beam_power = merge_save(ds_power, "power", group_name="/Sonar/Beam_group2")
         else:
             ds_beam = merge_save(ds_power, "power", group_name="/Sonar/Beam_group1")
+
+        # manipulate Datasets to adhere to convention
+        if isinstance(ds_beam_power, xr.Dataset):
+            self.beam_to_convention(ds_beam_power, self.sonar_model)
+        self.beam_to_convention(ds_beam, self.sonar_model)
 
         return [ds_beam, ds_beam_power]
 

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -419,8 +419,7 @@ class SetGroupsEK80(SetGroupsBase):
                     np.arange(data_shape[1]),
                     self._varattrs["beam_coord_default"]["range_sample"],
                 ),
-                "beam": (["beam"], np.arange(start=1,
-                                             stop=num_transducer_sectors + 1).astype(str)),
+                "beam": (["beam"], np.arange(start=1, stop=num_transducer_sectors + 1).astype(str)),
             },
         )
 
@@ -668,8 +667,8 @@ class SetGroupsEK80(SetGroupsBase):
 
         # manipulate Datasets to adhere to convention
         if isinstance(ds_beam_power, xr.Dataset):
-            self.beam_to_convention(ds_beam_power, self.sonar_model)
-        self.beam_to_convention(ds_beam, self.sonar_model)
+            self.beamgroups_to_convention(ds_beam_power, self.sonar_model)
+        self.beamgroups_to_convention(ds_beam, self.sonar_model)
 
         return [ds_beam, ds_beam_power]
 

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -70,8 +70,8 @@ def test_compute_Sv_ek60_echoview(ek60_path):
     # Echoview data is shifted by 1 sample along range (missing the first sample)
     assert np.allclose(
         test_Sv[:, :, 7:],
-        ds_Sv.Sv.isel(ping_time=slice(None, 10), range_sample=slice(8, None)),
-        atol=1e-8,
+        ds_Sv.Sv.isel(ping_time=slice(None, 10), range_sample=slice(8, None), beam=0),
+        atol=1e-8
     )
 
 

--- a/echopype/tests/convert/test_convert_ek60.py
+++ b/echopype/tests/convert/test_convert_ek60.py
@@ -43,7 +43,7 @@ def test_convert_ek60_matlab_raw(ek60_path):
             ds_matlab['rawData'][0]['pings'][0]['power'][0][fidx]
             for fidx in range(5)
         ],
-        echodata.beam.backscatter_r.transpose(
+        echodata.beam.backscatter_r.isel(beam=0).transpose(
             'frequency', 'range_sample', 'ping_time'
         ),
         rtol=0,
@@ -56,7 +56,7 @@ def test_convert_ek60_matlab_raw(ek60_path):
                 ds_matlab['rawData'][0]['pings'][0][angle][0][fidx]
                 for fidx in range(5)
             ],
-            echodata.beam['angle_' + angle].transpose(
+            echodata.beam['angle_' + angle].isel(beam=0).transpose(
                 'frequency', 'range_sample', 'ping_time'
             ),
         )
@@ -91,6 +91,7 @@ def test_convert_ek60_echoview_raw(ek60_path):
                 frequency=fidx,
                 ping_time=slice(None, 10),
                 range_sample=slice(1, None),
+                beam=0
             ),
             atol=9e-6,
             rtol=atol,

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -103,9 +103,8 @@ def test_convert_ek80_cw_power_angle_echoview(ek80_path):
         test_power = pd.read_csv(file, delimiter=';').iloc[:, 13:].values
         assert np.allclose(
             test_power,
-            echodata.beam.backscatter_r.sel(frequency=freq * 1e3).dropna(
-                'range_sample'
-            ),
+            echodata.beam.backscatter_r.sel(frequency=freq * 1e3,
+                                            beam='1').dropna('range_sample'),
             rtol=0,
             atol=1.1e-5,
         )
@@ -131,7 +130,7 @@ def test_convert_ek80_cw_power_angle_echoview(ek80_path):
         for ping_idx in df_angle['Ping_index'].value_counts().index:
             assert np.allclose(
                 df_angle.loc[df_angle['Ping_index'] == ping_idx, ' Major'],
-                major.sel(frequency=freq * 1e3)
+                major.sel(frequency=freq * 1e3, beam='1')
                 .isel(ping_time=ping_idx)
                 .dropna('range_sample'),
                 rtol=0,
@@ -139,7 +138,7 @@ def test_convert_ek80_cw_power_angle_echoview(ek80_path):
             )
             assert np.allclose(
                 df_angle.loc[df_angle['Ping_index'] == ping_idx, ' Minor'],
-                minor.sel(frequency=freq * 1e3)
+                minor.sel(frequency=freq * 1e3, beam='1')
                 .isel(ping_time=ping_idx)
                 .dropna('range_sample'),
                 rtol=0,

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -391,7 +391,7 @@ def test_nan_range_entries(range_check_files):
     else:
         ds_Sv = echopype.calibrate.compute_Sv(echodata)
         range_output = echodata.compute_range(env_params=[])
-        nan_locs_backscatter_r = ~echodata.beam.backscatter_r.isnull()
+        nan_locs_backscatter_r = ~echodata.beam.backscatter_r.isel(beam=0).drop("beam").isnull()
 
     nan_locs_Sv_range = ~ds_Sv.echo_range.isnull()
     nan_locs_range = ~range_output.isnull()

--- a/echopype/visualize/plot.py
+++ b/echopype/visualize/plot.py
@@ -130,7 +130,7 @@ def _plot_echogram(
     row = None
     col = None
 
-    if 'backscatter_i' in ds.variables.keys():  # 'beam' in ds[variable].dims:
+    if 'backscatter_i' in ds.variables:
         col = 'beam'
         kwargs.update(
             {

--- a/echopype/visualize/plot.py
+++ b/echopype/visualize/plot.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 import matplotlib.pyplot as plt
 import matplotlib.cm
@@ -129,7 +130,7 @@ def _plot_echogram(
     row = None
     col = None
 
-    if 'beam' in ds[variable].dims:
+    if 'backscatter_i' in ds.variables.keys():  # 'beam' in ds[variable].dims:
         col = 'beam'
         kwargs.update(
             {
@@ -140,6 +141,8 @@ def _plot_echogram(
         filtered_ds = np.abs(ds.backscatter_r + 1j * ds.backscatter_i)
     else:
         filtered_ds = ds[variable]
+        if 'beam' in filtered_ds.dims:
+            filtered_ds = filtered_ds.isel(beam=0).drop('beam')
 
     # perform frequency filtering
     if frequency:
@@ -227,6 +230,7 @@ def _plot_echogram(
                     .dropna(dim='range_sample')
                     .data
                 )
+
             plot = d.plot.pcolormesh(
                 x=xaxis,
                 y=yaxis,


### PR DESCRIPTION
This PR addresses the addition of the dimensions `beam` and `ping_time` to variables within `Beam_groupX`. The specific variables were identified in #520. Note that this PR is only concerned with the sensors EK60 and EK80. The modifications necessary for AZFP will take place in a different PR. 

To complete this task, I have added the function `beamgroups_to_convention()` in `echopype/convert/set_groups_base.py`. This function depends on several dictionaries I have defined at the top of the file. This function is called at the bottom of `set_beam()` in the `set_groups_ekXX.py` files. Note: currently, my intention is to use this function again when I create my code for the conversion from v0.5.x to v0.6.x in `open_converted`.
