### PR TITLE
For AZFP add `beam` and `ping_time` to Beam_group1

### DIFF
--- a/.ci_helpers/run-test.py
+++ b/.ci_helpers/run-test.py
@@ -132,8 +132,8 @@ if __name__ == "__main__":
         print("No test(s) were run.")
         sys.exit(0)
     if all(True if e == 0 else False for e in total_exit_codes):
-        print("All test run successful")
+        print("All tests have been run successfully!")
         sys.exit(0)
     else:
-        print("Some run failed. Please see log.")
+        print("Some runs have failed. Please see the log.")
         sys.exit(1)

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -205,6 +205,10 @@ class SetGroupsAZFP(SetGroupsBase):
                 "tilt_Y_d": parameters["Y_d"],
             },
         )
+
+        # manipulate Dataset to adhere to convention
+        self.beamgroups_to_convention(ds, self.sonar_model)
+
         return set_encodings(ds)
 
     def set_vendor(self) -> xr.Dataset:

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -11,21 +11,19 @@ from .set_groups_base import SetGroupsBase
 class SetGroupsAZFP(SetGroupsBase):
     """Class for saving groups to netcdf or zarr from AZFP data files."""
 
-    """
-    The sets beam_only_names, ping_time_only_names, and
-    beam_ping_time_names are used in set_groups_base and
-    in converting from v0.5.x to v0.6.0. The values within
-    these sets are applied to all Sonar/Beam_groupX groups.
-    """
+    # The sets beam_only_names, ping_time_only_names, and
+    # beam_ping_time_names are used in set_groups_base and
+    # in converting from v0.5.x to v0.6.0. The values within
+    # these sets are applied to all Sonar/Beam_groupX groups.
 
     # Variables that need only the beam dimension added to them.
-    beam_only_names = {}
+    beam_only_names = {"backscatter_r"}
 
     # Variables that need only the ping_time dimension added to them.
-    ping_time_only_names = {}
+    ping_time_only_names = {"sample_interval", "transmit_duration_nominal"}
 
     # Variables that need beam and ping_time dimensions added to them.
-    beam_ping_time_names = {}
+    beam_ping_time_names = {"equivalent_beam_angle", "gain_correction"}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -222,8 +220,10 @@ class SetGroupsAZFP(SetGroupsBase):
             },
         )
 
-        # manipulate Dataset to adhere to convention
-        self.beamgroups_to_convention(ds, self.sonar_model)
+        # Manipulate some Dataset dimensions to adhere to convention
+        self.beamgroups_to_convention(
+            ds, self.beam_only_names, self.beam_ping_time_names, self.ping_time_only_names
+        )
 
         return set_encodings(ds)
 

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -23,12 +23,16 @@ beam_only_names = {
         "frequency_start",
         "frequency_end",
     },
-    "AZFP": {},  # {"backscatter_r"}
+    "AZFP": {"backscatter_r"},
 }
 
 # Variables that need only the ping_time dimension added to them.
 # These lists include all Sonar beam groups.
-ping_time_only_names = {"EK60": {"beam_type"}, "EK80": {"beam_type"}, "AZFP": {}}
+ping_time_only_names = {
+    "EK60": {"beam_type"},
+    "EK80": {"beam_type"},
+    "AZFP": {"sample_interval", "transmit_duration_nominal"},
+}
 
 # Variables that need beam and ping_time dimensions added to them.
 # These lists include all Sonar beam groups.
@@ -60,7 +64,7 @@ beam_ping_time_names = {
         "beamwidth_twoway_alongship",
         "beamwidth_twoway_athwartship",
     },
-    "AZFP": {},  # {"equivalent_beam_angle", "gain_correction"}
+    "AZFP": {"equivalent_beam_angle", "gain_correction"},
 }
 
 

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -17,12 +17,10 @@ from .set_groups_base import DEFAULT_CHUNK_SIZE, SetGroupsBase
 class SetGroupsEK60(SetGroupsBase):
     """Class for saving groups to netcdf or zarr from EK60 data files."""
 
-    """
-    The sets beam_only_names, ping_time_only_names, and
-    beam_ping_time_names are used in set_groups_base and
-    in converting from v0.5.x to v0.6.0. The values within
-    these sets are applied to all Sonar/Beam_groupX groups.
-    """
+    # The sets beam_only_names, ping_time_only_names, and
+    # beam_ping_time_names are used in set_groups_base and
+    # in converting from v0.5.x to v0.6.0. The values within
+    # these sets are applied to all Sonar/Beam_groupX groups.
 
     # Variables that need only the beam dimension added to them.
     beam_only_names = {"backscatter_r", "angle_athwartship", "angle_alongship"}

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -11,12 +11,10 @@ from .set_groups_base import SetGroupsBase
 class SetGroupsEK80(SetGroupsBase):
     """Class for saving groups to netcdf or zarr from EK80 data files."""
 
-    """
-    The sets beam_only_names, ping_time_only_names, and
-    beam_ping_time_names are used in set_groups_base and
-    in converting from v0.5.x to v0.6.0. The values within
-    these sets are applied to all Sonar/Beam_groupX groups.
-    """
+    # The sets beam_only_names, ping_time_only_names, and
+    # beam_ping_time_names are used in set_groups_base and
+    # in converting from v0.5.x to v0.6.0. The values within
+    # these sets are applied to all Sonar/Beam_groupX groups.
 
     # Variables that need only the beam dimension added to them.
     beam_only_names = {

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -371,12 +371,6 @@ class EchoData:
             )
             range_meter.name = "echo_range"  # add name to facilitate xr.merge
 
-            # duplicate range for all ping_times for consistency with EK case
-            # if it is not indexed by ping_time then echopype.preprocess.compute_MVBS will fail
-            #   because it expects the range included in the Sv/TS dataset
-            #   to be indexed by ping_time
-            range_meter = range_meter.expand_dims({"ping_time": self.beam["ping_time"]}, axis=1)
-
             return range_meter
 
         # EK

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -154,13 +154,12 @@ def test_compute_Sv_azfp(azfp_path):
         }
         for fidx in range(4):  # loop through all freq
             assert np.alltrue(
-                ds_cmp.echo_range.isel(frequency=fidx).values
+                ds_cmp.echo_range.isel(frequency=fidx, ping_time=0).values[None, :]
                 == ds_base['Output'][0]['Range'][fidx]
             )
             assert np.allclose(
                 ds_cmp[cal_type_in_ds_cmp[cal_type]]
-                .isel(frequency=fidx)
-                .values,
+                .isel(frequency=fidx, beam=0).drop('beam').values,
                 ds_base['Output'][0][cal_type][fidx],
                 atol=1e-13,
                 rtol=0,

--- a/echopype/tests/convert/test_convert_azfp.py
+++ b/echopype/tests/convert/test_convert_azfp.py
@@ -48,7 +48,7 @@ def test_convert_azfp_01a_matlab_raw(azfp_path):
         np.array(
             [ds_matlab_output['Output'][0]['N'][fidx] for fidx in range(4)]
         ),
-        echodata.beam.backscatter_r.values,
+        echodata.beam.backscatter_r.isel(beam=0).drop('beam').values,
     )
     # tilt x-y
     assert np.array_equal(
@@ -109,7 +109,7 @@ def test_convert_azfp_01a_raw_echoview(azfp_path):
     echodata = open_raw(
         raw_file=azfp_01a_path, sonar_model='AZFP', xml_path=azfp_xml_path
     )
-    assert np.array_equal(test_power, echodata.beam.backscatter_r)
+    assert np.array_equal(test_power, echodata.beam.backscatter_r.isel(beam=0).drop('beam'))
 
 
 def test_convert_azfp_01a_different_ranges(azfp_path):
@@ -123,7 +123,7 @@ def test_convert_azfp_01a_different_ranges(azfp_path):
     )
     assert echodata.beam.backscatter_r.isel(frequency=0).dropna(
         'range_sample'
-    ).shape == (360, 438)
+    ).shape == (360, 438, 1)
     assert echodata.beam.backscatter_r.isel(frequency=3).dropna(
         'range_sample'
-    ).shape == (360, 135)
+    ).shape == (360, 135, 1)


### PR DESCRIPTION
This PR addresses the addition of the dimensions `beam` and `ping_time` to variables within Beam_group1 for the AZFP sensor. The specific variables were identified in #520. The modifications necessary for EK60 and EK80 were completed in #638. Note that this PR uses the infrastructure created in #638 to add the necessary dimensions to the beam group.