### PR TITLE
Overhaul and fix Sonar beam_group variables

### DIFF
--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -449,18 +449,25 @@ def open_raw(
     if sonar_model in ["EK60", "ES70", "EK80", "ES80", "EA640"]:
         tree_dict["Platform/NMEA"] = setgrouper.set_nmea()
     tree_dict["Provenance"] = setgrouper.set_provenance()
-    tree_dict["Sonar"] = setgrouper.set_sonar()
+    # Allocate a tree_dict entry for Sonar? Otherwise, a DataTree error occurs
+    tree_dict["Sonar"] = None
 
     # Set multi beam groups
     beam_groups = setgrouper.set_beam()
     if isinstance(beam_groups, xr.Dataset):
-        # if it's a single dataset like the ek60,
-        # make into list
+        # if it's a single dataset like the ek60, make into list
         beam_groups = [beam_groups]
 
+    valid_beam_groups_count = 0
     for idx, beam_group in enumerate(beam_groups, start=1):
         if beam_group is not None:
+            valid_beam_groups_count += 1
             tree_dict[f"Sonar/Beam_group{idx}"] = beam_group
+
+    if sonar_model in ["EK80", "ES80", "EA640"]:
+        tree_dict["Sonar"] = setgrouper.set_sonar(beam_group_count=valid_beam_groups_count)
+    else:
+        tree_dict["Sonar"] = setgrouper.set_sonar()
 
     tree_dict["Vendor"] = setgrouper.set_vendor()
 

--- a/echopype/convert/set_groups_ad2cp.py
+++ b/echopype/convert/set_groups_ad2cp.py
@@ -23,20 +23,22 @@ def merge_attrs(datasets: List[xr.Dataset]) -> List[xr.Dataset]:
 
 
 class SetGroupsAd2cp(SetGroupsBase):
+    """Class for saving groups to netcdf or zarr from Ad2cp data files."""
+
+    beamgroups_possible = [
+        {
+            "name": "Beam_group1",
+            "descr": (
+                "contains velocity, correlation, and backscatter power (uncalibrated)"
+                " data and other data derived from acoustic data."
+            ),
+        }
+    ]
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.pulse_compressed = self.parser_obj.get_pulse_compressed()
         self.combine_packets()
-
-        self._beamgroups = [
-            {
-                "name": "Beam_group1",
-                "descr": (
-                    "contains velocity, correlation, and backscatter power (uncalibrated)"
-                    " data and other data derived from acoustic data."
-                ),
-            }
-        ]
 
     def combine_packets(self):
         self.ds = None
@@ -372,6 +374,7 @@ class SetGroupsAd2cp(SetGroupsBase):
 
         # Add beam_group and beam_group_descr variables sharing a common dimension
         # (beam_group), using the information from self._beamgroups
+        self._beamgroups = self.beamgroups_possible
         beam_groups_vars, beam_groups_coord = self._beam_groups_vars()
         ds = xr.Dataset(beam_groups_vars, coords=beam_groups_coord)
 

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -25,15 +25,15 @@ class SetGroupsAZFP(SetGroupsBase):
     # Variables that need beam and ping_time dimensions added to them.
     beam_ping_time_names = {"equivalent_beam_angle", "gain_correction"}
 
+    beamgroups_possible = [
+        {
+            "name": "Beam_group1",
+            "descr": "contains backscatter power (uncalibrated) and other beam or channel-specific data.",  # noqa
+        }
+    ]
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        self._beamgroups = [
-            {
-                "name": "Beam_group1",
-                "descr": "contains backscatter power (uncalibrated) and other beam or channel-specific data.",  # noqa
-            }
-        ]
 
     def set_env(self) -> xr.Dataset:
         """Set the Environment group."""
@@ -68,6 +68,7 @@ class SetGroupsAZFP(SetGroupsBase):
 
         # Add beam_group and beam_group_descr variables sharing a common dimension
         # (beam_group), using the information from self._beamgroups
+        self._beamgroups = self.beamgroups_possible
         beam_groups_vars, beam_groups_coord = self._beam_groups_vars()
         ds = xr.Dataset(beam_groups_vars, coords=beam_groups_coord)
 

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -66,9 +66,10 @@ class SetGroupsAZFP(SetGroupsBase):
     def set_sonar(self) -> xr.Dataset:
         """Set the Sonar group."""
 
-        # Add beam_group_name and beam_group_descr variables sharing a common dimension (beam),
-        # using the information from self._beamgroups
-        ds = xr.Dataset(self._beam_groups_vars())
+        # Add beam_group and beam_group_descr variables sharing a common dimension
+        # (beam_group), using the information from self._beamgroups
+        beam_groups_vars, beam_groups_coord = self._beam_groups_vars()
+        ds = xr.Dataset(beam_groups_vars, coords=beam_groups_coord)
 
         # Assemble sonar group dictionary
         sonar_dict = {

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -195,22 +195,24 @@ class SetGroupsBase(abc.ABC):
         return time1, msg_type, lat, lon
 
     def _beam_groups_vars(self):
-        """Stage beam_group_name and beam_group_descr variables sharing a common dimension,
-        beam_group, to be inserted in the Sonar group"""
+        """Stage beam_group coordinate and beam_group_descr variables sharing
+        a common dimension, beam_group, to be inserted in the Sonar group"""
         beam_groups_vars = {
-            "beam_group_name": (
-                ["beam_group"],
-                [di["name"] for di in self._beamgroups],
-                {"long_name": "Beam group name"},
-            ),
             "beam_group_descr": (
                 ["beam_group"],
                 [di["descr"] for di in self._beamgroups],
                 {"long_name": "Beam group description"},
             ),
         }
+        beam_groups_coord = {
+            "beam_group": (
+                ["beam_group"],
+                [di["name"] for di in self._beamgroups],
+                {"long_name": "Beam group name"},
+            ),
+        }
 
-        return beam_groups_vars
+        return beam_groups_vars, beam_groups_coord
 
     def _add_beam_dim(
         self, ds: xr.Dataset, beam_only_names: Set[str], beam_ping_time_names: Set[str]

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -45,18 +45,18 @@ class SetGroupsEK60(SetGroupsBase):
         "gain_correction",
     }
 
+    beamgroups_possible = [
+        {
+            "name": "Beam_group1",
+            "descr": (
+                "contains backscatter power (uncalibrated) and other beam or"
+                " channel-specific data, including split-beam angle data when they exist."
+            ),
+        }
+    ]
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        self._beamgroups = [
-            {
-                "name": "Beam_group1",
-                "descr": (
-                    "contains backscatter power (uncalibrated) and other beam or"
-                    " channel-specific data, including split-beam angle data when they exist."
-                ),
-            }
-        ]
 
         self.old_ping_time = None
         # correct duplicate ping_time
@@ -186,6 +186,7 @@ class SetGroupsEK60(SetGroupsBase):
 
         # Add beam_group and beam_group_descr variables sharing a common dimension
         # (beam_group), using the information from self._beamgroups
+        self._beamgroups = self.beamgroups_possible
         beam_groups_vars, beam_groups_coord = self._beam_groups_vars()
         ds = xr.Dataset(beam_groups_vars, coords=beam_groups_coord)
 

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -184,9 +184,10 @@ class SetGroupsEK60(SetGroupsBase):
     def set_sonar(self) -> xr.Dataset:
         """Set the Sonar group."""
 
-        # Add beam_group_name and beam_group_descr variables sharing a common dimension (beam),
-        # using the information from self._beamgroups
-        ds = xr.Dataset(self._beam_groups_vars())
+        # Add beam_group and beam_group_descr variables sharing a common dimension
+        # (beam_group), using the information from self._beamgroups
+        beam_groups_vars, beam_groups_coord = self._beam_groups_vars()
+        ds = xr.Dataset(beam_groups_vars, coords=beam_groups_coord)
 
         # Assemble sonar group dictionary
         sonar_dict = {

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -196,7 +196,8 @@ class SetGroupsEK80(SetGroupsBase):
                     ["channel"],
                     list(self.parser_obj.config_datagram["configuration"].keys()),
                     self._varattrs["beam_coord_default"]["channel"],
-                )
+                ),
+                "beam_group": beam_groups_coord["beam_group"],
             },
             attrs={"sonar_manufacturer": "Simrad", "sonar_type": "echosounder"},
         )

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -43,22 +43,22 @@ class SetGroupsEK80(SetGroupsBase):
         "beamwidth_twoway_athwartship",
     }
 
+    beamgroups_possible = [
+        {
+            "name": "Beam_group1",
+            "descr": "contains complex backscatter data and other beam or channel-specific data.",  # noqa
+        },
+        {
+            "name": "Beam_group2",
+            "descr": (
+                "contains backscatter power (uncalibrated) and other beam or channel-specific data,"  # noqa
+                " including split-beam angle data when they exist."
+            ),
+        }
+    ]
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        self._beamgroups = [
-            {
-                "name": "Beam_group1",
-                "descr": "contains complex backscatter data and other beam or channel-specific data.",  # noqa
-            },
-            {
-                "name": "Beam_group2",
-                "descr": (
-                    "contains backscatter power (uncalibrated) and other beam or channel-specific data,"  # noqa
-                    " including split-beam angle data when they exist."
-                ),
-            },
-        ]
 
     def set_env(self, env_only=False) -> xr.Dataset:
         """Set the Environment group."""
@@ -150,7 +150,7 @@ class SetGroupsEK80(SetGroupsBase):
         )
         return set_encodings(ds)
 
-    def set_sonar(self) -> xr.Dataset:
+    def set_sonar(self, beam_group_count=1) -> xr.Dataset:
         # Collect unique variables
         params = [
             "transducer_frequency",
@@ -168,6 +168,7 @@ class SetGroupsEK80(SetGroupsBase):
         # Create dataset
         # beam_group_name and beam_group_descr variables sharing a common dimension (beam),
         # using the information from self._beamgroups
+        self._beamgroups = self.beamgroups_possible[:beam_group_count]
         beam_groups_vars = self._beam_groups_vars()
         sonar_vars = {
             "serial_number": (["frequency"], var["serial_number"]),

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -49,7 +49,7 @@ class SetGroupsEK80(SetGroupsBase):
             "descr": (
                 "contains backscatter data (either complex samples or uncalibrated power samples)"  # noqa
                 " and other beam or channel-specific data"
-            )
+            ),
         },
         {
             "name": "Beam_group2",

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -46,7 +46,10 @@ class SetGroupsEK80(SetGroupsBase):
     beamgroups_possible = [
         {
             "name": "Beam_group1",
-            "descr": "contains complex backscatter data and other beam or channel-specific data.",  # noqa
+            "descr": (
+                "contains backscatter data (either complex samples or uncalibrated power samples)"  # noqa
+                " and other beam or channel-specific data"
+            )
         },
         {
             "name": "Beam_group2",

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -197,7 +197,7 @@ class SetGroupsEK80(SetGroupsBase):
                     list(self.parser_obj.config_datagram["configuration"].keys()),
                     self._varattrs["beam_coord_default"]["channel"],
                 ),
-                "beam_group": beam_groups_coord["beam_group"],
+                **beam_groups_coord,
             },
             attrs={"sonar_manufacturer": "Simrad", "sonar_type": "echosounder"},
         )

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -166,10 +166,11 @@ class SetGroupsEK80(SetGroupsBase):
                 var[param].append(data[param])
 
         # Create dataset
-        # beam_group_name and beam_group_descr variables sharing a common dimension (beam),
-        # using the information from self._beamgroups
+        # Add beam_group and beam_group_descr variables sharing a common dimension
+        # (beam_group), using the information from self._beamgroups
         self._beamgroups = self.beamgroups_possible[:beam_group_count]
-        beam_groups_vars = self._beam_groups_vars()
+        beam_groups_vars, beam_groups_coord = self._beam_groups_vars()
+
         sonar_vars = {
             "serial_number": (["frequency"], var["serial_number"]),
             "sonar_model": (["frequency"], var["transducer_name"]),
@@ -185,7 +186,10 @@ class SetGroupsEK80(SetGroupsBase):
         }
         ds = xr.Dataset(
             {**sonar_vars, **beam_groups_vars},
-            coords={"frequency": var["transducer_frequency"]},
+            coords={
+                "frequency": (var["transducer_frequency"]),
+                **beam_groups_coord
+            },
             attrs={
                 "sonar_manufacturer": "Simrad",
                 "sonar_type": "echosounder",

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -54,7 +54,7 @@ class SetGroupsEK80(SetGroupsBase):
                 "contains backscatter power (uncalibrated) and other beam or channel-specific data,"  # noqa
                 " including split-beam angle data when they exist."
             ),
-        }
+        },
     ]
 
     def __init__(self, *args, **kwargs):
@@ -186,10 +186,7 @@ class SetGroupsEK80(SetGroupsBase):
         }
         ds = xr.Dataset(
             {**sonar_vars, **beam_groups_vars},
-            coords={
-                "frequency": (var["transducer_frequency"]),
-                **beam_groups_coord
-            },
+            coords={"frequency": (var["transducer_frequency"]), **beam_groups_coord},
             attrs={
                 "sonar_manufacturer": "Simrad",
                 "sonar_type": "echosounder",

--- a/echopype/echodata/convention/1.0.yml
+++ b/echopype/echodata/convention/1.0.yml
@@ -43,7 +43,7 @@ groups:
     description: >-
       contains backscatter power (uncalibrated) and other beam or channel-specific data,
       including split-beam angle data when they exist.
-      Only exists if complex backscatter data they already in Sonar/Beam_group1
+      Only exists if complex backscatter data are already in Sonar/Beam_group1
     ep_group: Sonar/Beam_group2
   vendor:
     name: Vendor specific


### PR DESCRIPTION
Working on something else, I realized there were some problems with my initial implementation of the `Sonar` `beam_group_name` and `beam_group_descr` variables and associated `SetGroups<SENSOR>._beamgroups` property. For reference, this implementation was part of PR #574 (see especially https://github.com/OSOceanAcoustics/echopype/pull/574#issuecomment-1062552195).

### Problems

1. While the `beam_group_` variables had a `beam_group` dimension, there was no corresponding coordinate variable.
2. For AD2CP, SetGroupsAd2cp._beamgroups` was present (added in PR #617), but the `beam_group_` variables were not being created.
3. For EK80, it assumed that the two Beam groups were always present. The `beam_group_` variables were being added as length 2, even when only one Beam group (`Beam_group1`) was actually created.

### In this PR

All 3 problems are addressed in this PR. For problem 1, I renamed `beam_group_name` to `beam_group` and made it the previously missing coordinate variable.

Problem 3 (EK80 variable-number-of-beam-groups issue) was more complicated. Previously I set the `SetGroupsEK80._beamgroups` property in the `__init__`, and it was fixed. I've moved the dict of the 2 possible beam groups to a new `SetGroupsEK80` *class* property, `beamgroups_possible`. The decision of whether there is 1 or 2 beam groups present apparently can only be made after `set_beam` is executed. Therefore, I modified `convert/api.py` so that `set_sonar` is executed after `set_beam`, and for EK80 added a new `beam_group_count` argument to `set_sonar`.

Everything seems to work as expected now.

**TODO:** Add a test.

@leewujung : I added the `set_sonar` `beam_group_count` argument  to EK80 only. That keeps the other `SetGroups<SENSOR>` classes a bit cleaner, but with the downside that the `set_sonar` methods are no longer exactly identical across `SetGroups<SENSOR>` classes. Thoughts?

@lsetiawan : When flipping the order of execution in `convert/api.py` so that `set_sonar` happens after `set_beam`, a datatree error occurred. See below. I don't fully understand how it's happening, given that `tree_dict` assignments are just dictionary assignments. But I found that I could eliminate the error by preassigning `tree_dict["Sonar"] = None` before `tree_dict[f"Sonar/Beam_group{idx}"]` is assigned. Do you think this could be simplified a bit?

#### Error in `convert/api.py` when `tree_dict["Sonar"] = None` is not preassigned before `tree_dict[f"Sonar/Beam_group{idx}"]`:

```python
--> 477 tree = DataTree.from_dict(tree_dict)
    478 echodata = EchoData(source_file=file_chk, xml_path=xml_chk, sonar_model=sonar_model)
    479 echodata._set_tree(tree)

File ~/miniconda3/envs/echopype_dev/lib/python3.9/site-packages/datatree/datatree.py:179, in DataTree.from_dict(cls, data_objects, name)
    177         # Create and set new node
    178         new_node = cls(name=node_name, data=data)
--> 179         obj.set_node(
    180             relative_path,
    181             new_node,
    182             allow_overwrite=False,
    183             new_nodes_along_path=True,
    184         )
    185 return obj

File ~/miniconda3/envs/echopype_dev/lib/python3.9/site-packages/datatree/treenode.py:194, in TreeNode.set_node(self, path, node, new_nodes_along_path, allow_overwrite)
    191         del child
    192     else:
    193         # TODO should this be before we walk to the new node?
--> 194         raise KeyError(
    195             f"Cannot set item at {path} whilst that path already points to a "
    196             f"{type(parent.get_node(node_name))} object"
    197         )
    199 # Place new child node at this location
    200 parent.add_child(node)

KeyError: "Cannot set item at / whilst that path already points to a <class 'datatree.datatree.DataTree'> object"