### PR TITLE
Handle plotting of dimension frequency to channel

### DIFF
--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -21,11 +21,15 @@ param_testdata = [
         None,
         {},
     ),
-    (
+    pytest.param(
         ek60_path / "DY1002_EK60-D20100318-T023008_rep_freq.raw",
         "EK60",
         None,
-        {}
+        {},
+        marks=pytest.mark.xfail(
+            run=False,
+            reason="Repeated frequencies not supported at the moment.",
+        ),
     ),
     (
         ek80_path / "echopype-test-D20211004-T235930.raw",

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -22,6 +22,12 @@ param_testdata = [
         {},
     ),
     (
+        ek60_path / "DY1002_EK60-D20100318-T023008_rep_freq.raw",
+        "EK60",
+        None,
+        {}
+    ),
+    (
         ek80_path / "echopype-test-D20211004-T235930.raw",
         "EK80",
         None,

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -21,15 +21,11 @@ param_testdata = [
         None,
         {},
     ),
-    pytest.param(
+    (
         ek60_path / "DY1002_EK60-D20100318-T023008_rep_freq.raw",
         "EK60",
         None,
         {},
-        marks=pytest.mark.xfail(
-            run=False,
-            reason="Repeated frequencies not supported at the moment.",
-        ),
     ),
     (
         ek80_path / "echopype-test-D20211004-T235930.raw",

--- a/echopype/visualize/api.py
+++ b/echopype/visualize/api.py
@@ -27,7 +27,7 @@ def create_echogram(
         Otherwise all channels will be plotted.
     frequency : int, float, or list of float or ints, optional
         The frequency to be plotted.
-        Otherwise all frequency will be plotted.
+        If not specified, all frequency will be plotted.
     get_range : bool, optional
         Flag as to whether range (``echo_range``) should be computed or not,
         by default it will just plot `range_sample`` as the yaxis.

--- a/echopype/visualize/api.py
+++ b/echopype/visualize/api.py
@@ -10,6 +10,7 @@ from ..echodata import EchoData
 def create_echogram(
     data: Union[EchoData, xr.Dataset],
     channel: Union[str, List[str], None] = None,
+    frequency: Union[str, List[str], None] = None,
     get_range: Optional[bool] = None,
     range_kwargs: dict = {},
     water_level: Union[int, float, xr.DataArray, bool, None] = None,
@@ -24,6 +25,9 @@ def create_echogram(
     channel : str or list of str, optional
         The channel to be plotted.
         Otherwise all channels will be plotted.
+    frequency : int, float, or list of float or ints, optional
+        The frequency to be plotted.
+        Otherwise all frequency will be plotted.
     get_range : bool, optional
         Flag as to whether range (``echo_range``) should be computed or not,
         by default it will just plot `range_sample`` as the yaxis.
@@ -63,8 +67,15 @@ def create_echogram(
         'units': 'm',
     }
 
+    if channel and frequency:
+        warnings.warn(
+            "Both channel and frequency are specified. Channel filtering will be used."
+        )
+
     if isinstance(channel, list) and len(channel) == 1:
         channel = channel[0]
+    elif isinstance(frequency, list) and len(frequency) == 1:
+        frequency = frequency[0]
 
     if isinstance(data, EchoData):
         if data.sonar_model.lower() == 'ad2cp':
@@ -169,6 +180,7 @@ def create_echogram(
         yaxis=yaxis,
         variable=variable,
         channel=channel,
+        frequency=frequency,
         **kwargs,
     )
 

--- a/echopype/visualize/plot.py
+++ b/echopype/visualize/plot.py
@@ -138,7 +138,7 @@ def _plot_echogram(
     # perform frequency filtering
     if channel is not None:
         if 'channel' not in ds.dims:
-            raise ValueError("Channel filtering is not available for your dataset!")
+            raise ValueError("Channel filtering is not available because channel is not a dimension for your dataset!")
         ds = ds.sel(channel=channel)
         filter_val = channel
     elif frequency is not None:
@@ -153,7 +153,7 @@ def _plot_echogram(
             ds = ds.sel(frequency=frequency)
 
         if duplicates:
-            raise ValueError("Duplicate frequency found, please use channels for filtering.")
+            raise ValueError("Duplicate frequency found, please use channel for filtering.")
         filter_val = frequency
         filter_var = 'frequency'
 

--- a/echopype/visualize/plot.py
+++ b/echopype/visualize/plot.py
@@ -159,9 +159,9 @@ def _plot_echogram(
 
     if 'backscatter_i' in ds.variables:
         col = 'beam'
+        kwargs.setdefault('figsize', (15, 5))
         kwargs.update(
             {
-                'figsize': (15, 5),
                 'col_wrap': None,
             }
         )
@@ -208,6 +208,9 @@ def _plot_echogram(
         ):
             # Handle the nans for echodata and Sv
             filtered_ds = filtered_ds.sel(
+                ping_time=filtered_ds.echo_range.dropna(dim='ping_time').ping_time
+            )
+            filtered_ds = filtered_ds.sel(
                 range_sample=filtered_ds.echo_range.dropna(dim='range_sample').range_sample
             )
         plot = filtered_ds.plot.pcolormesh(
@@ -243,6 +246,9 @@ def _plot_echogram(
                 and variable in ['backscatter_r', 'Sv']
             ):
                 # Handle the nans for echodata and Sv
+                d = d.sel(
+                    ping_time=d.echo_range.dropna(dim='ping_time').ping_time
+                )
                 d = d.sel(
                     range_sample=d.echo_range.dropna(dim='range_sample').range_sample
                 )

--- a/echopype/visualize/plot.py
+++ b/echopype/visualize/plot.py
@@ -125,6 +125,9 @@ def _plot_echogram(
 
     row = None
     col = None
+    # perform frequency filtering
+    # if (frequency is not None) and ('channel' in ds.dims):
+    #     ds = ds.where(ds.frequency_nominal.isin(frequency), drop=True)
 
     if 'backscatter_i' in ds.variables:
         col = 'beam'

--- a/echopype/visualize/plot.py
+++ b/echopype/visualize/plot.py
@@ -208,7 +208,7 @@ def _plot_echogram(
         ):
             # Handle the nans for echodata and Sv
             filtered_ds = filtered_ds.sel(
-                ping_time=filtered_ds.echo_range.dropna(dim='ping_time').ping_time
+                ping_time=filtered_ds.echo_range.dropna(dim='ping_time', how='all').ping_time
             )
             filtered_ds = filtered_ds.sel(
                 range_sample=filtered_ds.echo_range.dropna(dim='range_sample').range_sample
@@ -247,7 +247,7 @@ def _plot_echogram(
             ):
                 # Handle the nans for echodata and Sv
                 d = d.sel(
-                    ping_time=d.echo_range.dropna(dim='ping_time').ping_time
+                    ping_time=d.echo_range.dropna(dim='ping_time', how='all').ping_time
                 )
                 d = d.sel(
                     range_sample=d.echo_range.dropna(dim='range_sample').range_sample


### PR DESCRIPTION
This PR follows #657. The visualize module can now handle the change from frequency to channels, and should behave the same way. However, I currently do not have the full way to test this, since I need the updated code for `compute_range` to check on the `get_range` behavior. In the mean time below is a demo of the result from a sample netCDF that @b-reyes has provided.

## Demo

```
import echopype
from echopype import visualize as epviz

ed = echopype.open_converted('v060_EK80_beam_1_2_with_channel_beam.nc')
range_kwargs = {"encode_mode":"complex", "waveform_mode":"CW"}
plots = epviz.create_echogram(
    ed, robust=True, get_range=False, range_kwargs=range_kwargs
)
```
![Screenshot from 2022-05-03 10-44-53](https://user-images.githubusercontent.com/17802172/166509417-4ecaf058-bd3f-4376-9cd8-0098f470c776.png)
