### PR TITLE
Add setattr functionality to echodata and more tests

### DIFF
--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -227,6 +227,8 @@ class EchoData:
                 group_path = "Top-level"
             msg_list = ["This access pattern will be deprecated in future releases."]
             if attr_value is not None:
+                if self._tree is None:
+                    raise ValueError("Datatree not found!")
                 msg_list.append(f"Access the group directly by doing echodata['{group_path}']")
                 if group_path == "Top-level":
                     node = self._tree

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -164,7 +164,7 @@ class EchoData:
                 self.sonar_model = ds.keywords.upper()  # type: ignore
 
             if isinstance(ds, xr.Dataset):
-                setattr(self, group, ds)
+                setattr(self, group, node)
 
     @property
     def version_info(self) -> Tuple[int]:
@@ -183,7 +183,8 @@ class EchoData:
             for i in self._tree.groups
         }
 
-    def __get_dataset(self, node: DataTree) -> Optional[xr.Dataset]:
+    @staticmethod
+    def __get_dataset(node: DataTree) -> Optional[xr.Dataset]:
         if node.has_data or node.has_attrs:
             return node.ds
         return None
@@ -227,11 +228,30 @@ class EchoData:
             msg_list = ["This access pattern will be deprecated in future releases."]
             if attr_value is not None:
                 msg_list.append(f"Access the group directly by doing echodata['{group_path}']")
+                if group_path == "Top-level":
+                    node = self._tree
+                else:
+                    node = self._tree[group_path]
+                attr_value = self.__get_dataset(node)
             else:
                 msg_list.append(f"No group path exists for '{self.__class__.__name__}.{__name}'")
             msg = " ".join(msg_list)
             warnings.warn(message=msg, category=DeprecationWarning, stacklevel=2)
         return attr_value
+
+    def __setattr__(self, __name: str, __value: Any) -> None:
+        attr_value = __value
+        if isinstance(__value, DataTree) and __name != "_tree":
+            attr_value = self.__get_dataset(__value)
+        elif isinstance(__value, xr.Dataset):
+            group_map = sonarnetcdf_1.yaml_dict["groups"]
+            if __name in group_map:
+                group = group_map.get(__name)
+                group_path = group["ep_group"]
+                self._tree[group_path].ds = __value
+                if __name == "top":
+                    self._tree.ds = __value
+        super().__setattr__(__name, attr_value)
 
     def compute_range(
         self,

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -248,9 +248,10 @@ class EchoData:
             if __name in group_map:
                 group = group_map.get(__name)
                 group_path = group["ep_group"]
-                self._tree[group_path].ds = __value
-                if __name == "top":
-                    self._tree.ds = __value
+                if self._tree:
+                    self._tree[group_path].ds = __value
+                    if __name == "top":
+                        self._tree.ds = __value
         super().__setattr__(__name, attr_value)
 
     def compute_range(

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -227,14 +227,13 @@ class EchoData:
                 group_path = "Top-level"
             msg_list = ["This access pattern will be deprecated in future releases."]
             if attr_value is not None:
-                if self._tree is None:
-                    raise ValueError("Datatree not found!")
                 msg_list.append(f"Access the group directly by doing echodata['{group_path}']")
-                if group_path == "Top-level":
-                    node = self._tree
-                else:
-                    node = self._tree[group_path]
-                attr_value = self.__get_dataset(node)
+                if self._tree:
+                    if group_path == "Top-level":
+                        node = self._tree
+                    else:
+                        node = self._tree[group_path]
+                    attr_value = self.__get_dataset(node)
             else:
                 msg_list.append(f"No group path exists for '{self.__class__.__name__}.{__name}'")
             msg = " ".join(msg_list)

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -250,9 +250,10 @@ class EchoData:
                 group = group_map.get(__name)
                 group_path = group["ep_group"]
                 if self._tree:
-                    self._tree[group_path].ds = __value
                     if __name == "top":
                         self._tree.ds = __value
+                    else:
+                        self._tree[group_path].ds = __value
         super().__setattr__(__name, attr_value)
 
     def compute_range(

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -2,6 +2,8 @@ from textwrap import dedent
 
 import fsspec
 
+from zarr.errors import GroupNotFoundError
+
 import echopype
 from echopype.calibrate.calibrate_base import EnvParams
 from echopype.echodata import EchoData
@@ -272,6 +274,52 @@ class TestEchoData:
             "<pre>&lt;EchoData"
         ) and html_fallback.endswith("</pre>")
 
+    def test_setattr(self, converted_zarr):
+        sample_data = xr.Dataset({"x": [0, 0, 0]})
+        ed = EchoData.from_file(converted_raw_path=converted_zarr)
+        current_ed_beam = ed.beam
+        ed.beam = sample_data
+
+        assert ed.beam.equals(sample_data) is True
+        assert ed.beam.equals(ed['Sonar/Beam_group1']) is True
+        assert ed.beam.equals(current_ed_beam) is False
+
+    def test_getitem(self, converted_zarr):
+        ed = EchoData.from_file(converted_raw_path=converted_zarr)
+        beam = ed['Sonar/Beam_group1']
+        assert isinstance(beam, xr.Dataset)
+        try:
+            ed['MyGroup']
+        except Exception as e:
+            assert isinstance(e, GroupNotFoundError)
+
+        ed._tree = None
+        try:
+            ed['Sonar']
+        except Exception as e:
+            assert isinstance(e, ValueError)
+
+    def test_getattr(self, converted_zarr):
+        ed = EchoData.from_file(converted_raw_path=converted_zarr)
+        expected_groups = {
+            'top': 'Top-level',
+            'environment': 'Environment',
+            'platform': 'Platform',
+            'nmea': 'Platform/NMEA',
+            'provenance': 'Provenance',
+            'sonar': 'Sonar',
+            'beam': 'Sonar/Beam_group1',
+            'vendor': 'Vendor',
+        }
+        for group, path in expected_groups.items():
+            ds = getattr(ed, group)
+            assert ds.equals(ed[path])
+
+    def test_setitem(self, converted_zarr):
+        ed = EchoData.from_file(converted_raw_path=converted_zarr)
+        ed['Sonar/Beam_group1'] = ed['Sonar/Beam_group1'].rename({'frequency': 'channel'})
+
+        assert sorted(ed['Sonar/Beam_group1'].dims.keys()) == ['channel', 'ping_time', 'range_bin']
 
 def test_open_converted(ek60_converted_zarr, minio_bucket):  # noqa
     def _check_path(zarr_path):


### PR DESCRIPTION
This PR addresses #664 where when getting the attribute, say `.beam` on echodata object, the underlying dataset may differ from the tree dataset. Additionally, after setting the attribute, the dataset may differ. This PR now introduces `__setattr__` built-in method for us to fine tune the behavior of attribute setting such as `EchoData.beam = some_other_dataset`.