### PR TITLE
Change sonar group description

### DIFF
--- a/echopype/echodata/convention/1.0.yml
+++ b/echopype/echodata/convention/1.0.yml
@@ -30,7 +30,7 @@ groups:
     ep_group: Provenance
   sonar:
     name: Sonar
-    description: contains sonar system metadata and sonar data beam groups.
+    description: contains sonar system metadata and sonar beam groups.
     ep_group: Sonar
   beam:
     name: Beam_group1

--- a/echopype/echodata/convention/1.0.yml
+++ b/echopype/echodata/convention/1.0.yml
@@ -30,7 +30,7 @@ groups:
     ep_group: Provenance
   sonar:
     name: Sonar
-    description: contains specific metadata for the sonar system.
+    description: contains sonar system metadata and sonar data beam groups.
     ep_group: Sonar
   beam:
     name: Beam_group1


### PR DESCRIPTION
This PR addresses issue #624. It changes the sonar group description in `1.0.yml` so that it correctly reflects what is contained in the Sonar group. This is especially important as this information is displayed in the repr. 