### PR TITLE
Add comment attribute to all _alongship/_athwartship variables and use two-way beamwidth variables

### DIFF
--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -414,10 +414,10 @@ class SetGroupsEK60(SetGroupsBase):
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
                         "comment": (
-                            "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. " # noqa
-                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
-                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data." # noqa
-                        )
+                            "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. "  # noqa
+                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
+                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data."  # noqa
+                        ),
                     },
                 ),
                 "beamwidth_twoway_athwartship": (
@@ -429,10 +429,10 @@ class SetGroupsEK60(SetGroupsBase):
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
                         "comment": (
-                            "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. " # noqa
-                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
-                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data." # noqa
-                        )
+                            "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. "  # noqa
+                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
+                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data."  # noqa
+                        ),
                     },
                 ),
                 "beam_direction_x": (
@@ -474,9 +474,9 @@ class SetGroupsEK60(SetGroupsBase):
                     {
                         "long_name": "electrical alongship angle of the transducer",
                         "comment": (
-                            "Introduced in echopype for Simrad echosounders. " # noqa
-                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
-                        )
+                            "Introduced in echopype for Simrad echosounders. "  # noqa
+                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
+                        ),
                     },
                 ),
                 "angle_offset_athwartship": (
@@ -485,9 +485,9 @@ class SetGroupsEK60(SetGroupsBase):
                     {
                         "long_name": "electrical athwartship angle of the transducer",
                         "comment": (
-                            "Introduced in echopype for Simrad echosounders. " # noqa
-                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
-                        )
+                            "Introduced in echopype for Simrad echosounders. "  # noqa
+                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
+                        ),
                     },
                 ),
                 "angle_sensitivity_alongship": (
@@ -496,9 +496,9 @@ class SetGroupsEK60(SetGroupsBase):
                     {
                         "long_name": "alongship sensitivity of the transducer",
                         "comment": (
-                            "Introduced in echopype for Simrad echosounders. " # noqa
-                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
-                        )
+                            "Introduced in echopype for Simrad echosounders. "  # noqa
+                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
+                        ),
                     },
                 ),
                 "angle_sensitivity_athwartship": (
@@ -507,9 +507,9 @@ class SetGroupsEK60(SetGroupsBase):
                     {
                         "long_name": "athwartship sensitivity of the transducer",
                         "comment": (
-                            "Introduced in echopype for Simrad echosounders. " # noqa
-                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
-                        )
+                            "Introduced in echopype for Simrad echosounders. "  # noqa
+                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
+                        ),
                     },
                 ),
                 "equivalent_beam_angle": (
@@ -639,9 +639,9 @@ class SetGroupsEK60(SetGroupsBase):
                             {
                                 "long_name": "electrical athwartship angle",
                                 "comment": (
-                                    "Introduced in echopype for Simrad echosounders. " # noqa
-                                    + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
-                                )
+                                    "Introduced in echopype for Simrad echosounders. "  # noqa
+                                    + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
+                                ),
                             },
                         ),
                         "angle_alongship": (
@@ -650,9 +650,9 @@ class SetGroupsEK60(SetGroupsBase):
                             {
                                 "long_name": "electrical alongship angle",
                                 "comment": (
-                                    "Introduced in echopype for Simrad echosounders. " # noqa
-                                    + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
-                                )
+                                    "Introduced in echopype for Simrad echosounders. "  # noqa
+                                    + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
+                                ),
                             },
                         ),
                     }

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -405,9 +405,7 @@ class SetGroupsEK60(SetGroupsBase):
                     beam_params["beam_type"],
                     {"long_name": "type of transducer (0-single, 1-split)"},
                 ),
-                # TODO: check EK60 data spec:
-                #  the beamwidths provided are most likely 2-way beamwidth so below needs to change
-                "beamwidth_receive_alongship": (
+                "beamwidth_twoway_alongship": (
                     ["channel"],
                     beam_params["beamwidth_alongship"],
                     {
@@ -415,9 +413,14 @@ class SetGroupsEK60(SetGroupsBase):
                         "alongship axis of beam",
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
+                        "comment": (
+                            "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. " # noqa
+                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
+                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data." # noqa
+                        )
                     },
                 ),
-                "beamwidth_receive_athwartship": (
+                "beamwidth_twoway_athwartship": (
                     ["channel"],
                     beam_params["beamwidth_athwartship"],
                     {
@@ -425,26 +428,11 @@ class SetGroupsEK60(SetGroupsBase):
                         "athwartship axis of beam",
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
-                    },
-                ),
-                "beamwidth_transmit_alongship": (
-                    ["channel"],
-                    beam_params["beamwidth_alongship"],
-                    {
-                        "long_name": "Half power one-way transmit beam width along "
-                        "alongship axis of beam",
-                        "units": "arc_degree",
-                        "valid_range": (0.0, 360.0),
-                    },
-                ),
-                "beamwidth_transmit_athwartship": (
-                    ["channel"],
-                    beam_params["beamwidth_athwartship"],
-                    {
-                        "long_name": "Half power one-way transmit beam width along "
-                        "athwartship axis of beam",
-                        "units": "arc_degree",
-                        "valid_range": (0.0, 360.0),
+                        "comment": (
+                            "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. " # noqa
+                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
+                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data." # noqa
+                        )
                     },
                 ),
                 "beam_direction_x": (
@@ -483,22 +471,46 @@ class SetGroupsEK60(SetGroupsBase):
                 "angle_offset_alongship": (
                     ["channel"],
                     beam_params["angle_offset_alongship"],
-                    {"long_name": "electrical alongship angle of the transducer"},
+                    {
+                        "long_name": "electrical alongship angle of the transducer",
+                        "comment": (
+                            "Introduced in echopype for Simrad echosounders. " # noqa
+                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
+                        )
+                    },
                 ),
                 "angle_offset_athwartship": (
                     ["channel"],
                     beam_params["angle_offset_athwartship"],
-                    {"long_name": "electrical athwartship angle of the transducer"},
+                    {
+                        "long_name": "electrical athwartship angle of the transducer",
+                        "comment": (
+                            "Introduced in echopype for Simrad echosounders. " # noqa
+                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
+                        )
+                    },
                 ),
                 "angle_sensitivity_alongship": (
                     ["channel"],
                     beam_params["angle_sensitivity_alongship"],
-                    {"long_name": "alongship sensitivity of the transducer"},
+                    {
+                        "long_name": "alongship sensitivity of the transducer",
+                        "comment": (
+                            "Introduced in echopype for Simrad echosounders. " # noqa
+                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
+                        )
+                    },
                 ),
                 "angle_sensitivity_athwartship": (
                     ["channel"],
                     beam_params["angle_sensitivity_athwartship"],
-                    {"long_name": "athwartship sensitivity of the transducer"},
+                    {
+                        "long_name": "athwartship sensitivity of the transducer",
+                        "comment": (
+                            "Introduced in echopype for Simrad echosounders. " # noqa
+                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
+                        )
+                    },
                 ),
                 "equivalent_beam_angle": (
                     ["channel"],
@@ -624,12 +636,24 @@ class SetGroupsEK60(SetGroupsBase):
                         "angle_athwartship": (
                             ["ping_time", "range_sample"],
                             self.parser_obj.ping_data_dict["angle"][ch][:, :, 0],
-                            {"long_name": "electrical athwartship angle"},
+                            {
+                                "long_name": "electrical athwartship angle",
+                                "comment": (
+                                    "Introduced in echopype for Simrad echosounders. " # noqa
+                                    + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
+                                )
+                            },
                         ),
                         "angle_alongship": (
                             ["ping_time", "range_sample"],
                             self.parser_obj.ping_data_dict["angle"][ch][:, :, 1],
-                            {"long_name": "electrical alongship angle"},
+                            {
+                                "long_name": "electrical alongship angle",
+                                "comment": (
+                                    "Introduced in echopype for Simrad echosounders. " # noqa
+                                    + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
+                                )
+                            },
                         ),
                     }
                 )

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -409,14 +409,13 @@ class SetGroupsEK60(SetGroupsBase):
                     ["channel"],
                     beam_params["beamwidth_alongship"],
                     {
-                        "long_name": "Half power one-way receive beam width along "
-                        "alongship axis of beam",
+                        "long_name": "Half power two-way beam width along alongship axis of beam", # noqa
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
                         "comment": (
                             "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. "  # noqa
-                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
-                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data."  # noqa
+                            "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
+                            "The convention defines one-way transmit or receive beamwidth (beamwidth_receive_minor and beamwidth_transmit_minor), but Simrad echosounders record two-way beamwidth in the data." # noqa
                         ),
                     },
                 ),
@@ -424,14 +423,13 @@ class SetGroupsEK60(SetGroupsBase):
                     ["channel"],
                     beam_params["beamwidth_athwartship"],
                     {
-                        "long_name": "Half power one-way receive beam width along "
-                        "athwartship axis of beam",
+                        "long_name": "Half power two-way beam width along athwartship axis of beam", # noqa
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
                         "comment": (
                             "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. "  # noqa
-                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
-                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data."  # noqa
+                            "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
+                            "The convention defines one-way transmit or receive beamwidth (beamwidth_receive_major and beamwidth_transmit_major), but Simrad echosounders record two-way beamwidth in the data." # noqa
                         ),
                     },
                 ),
@@ -472,10 +470,10 @@ class SetGroupsEK60(SetGroupsBase):
                     ["channel"],
                     beam_params["angle_offset_alongship"],
                     {
-                        "long_name": "electrical alongship angle of the transducer",
+                        "long_name": "electrical alongship angle offset of the transducer",
                         "comment": (
                             "Introduced in echopype for Simrad echosounders. "  # noqa
-                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
+                            "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
                         ),
                     },
                 ),
@@ -483,10 +481,10 @@ class SetGroupsEK60(SetGroupsBase):
                     ["channel"],
                     beam_params["angle_offset_athwartship"],
                     {
-                        "long_name": "electrical athwartship angle of the transducer",
+                        "long_name": "electrical athwartship angle offset of the transducer",
                         "comment": (
                             "Introduced in echopype for Simrad echosounders. "  # noqa
-                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
+                            "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
                         ),
                     },
                 ),
@@ -494,10 +492,10 @@ class SetGroupsEK60(SetGroupsBase):
                     ["channel"],
                     beam_params["angle_sensitivity_alongship"],
                     {
-                        "long_name": "alongship sensitivity of the transducer",
+                        "long_name": "alongship angle sensitivity of the transducer",
                         "comment": (
                             "Introduced in echopype for Simrad echosounders. "  # noqa
-                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
+                            "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
                         ),
                     },
                 ),
@@ -505,10 +503,10 @@ class SetGroupsEK60(SetGroupsBase):
                     ["channel"],
                     beam_params["angle_sensitivity_athwartship"],
                     {
-                        "long_name": "athwartship sensitivity of the transducer",
+                        "long_name": "athwartship angle sensitivity of the transducer",
                         "comment": (
                             "Introduced in echopype for Simrad echosounders. "  # noqa
-                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
+                            "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
                         ),
                     },
                 ),

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -409,13 +409,13 @@ class SetGroupsEK60(SetGroupsBase):
                     ["channel"],
                     beam_params["beamwidth_alongship"],
                     {
-                        "long_name": "Half power two-way beam width along alongship axis of beam", # noqa
+                        "long_name": "Half power two-way beam width along alongship axis of beam",  # noqa
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
                         "comment": (
                             "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. "  # noqa
                             "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
-                            "The convention defines one-way transmit or receive beamwidth (beamwidth_receive_minor and beamwidth_transmit_minor), but Simrad echosounders record two-way beamwidth in the data." # noqa
+                            "The convention defines one-way transmit or receive beamwidth (beamwidth_receive_minor and beamwidth_transmit_minor), but Simrad echosounders record two-way beamwidth in the data."  # noqa
                         ),
                     },
                 ),
@@ -423,13 +423,13 @@ class SetGroupsEK60(SetGroupsBase):
                     ["channel"],
                     beam_params["beamwidth_athwartship"],
                     {
-                        "long_name": "Half power two-way beam width along athwartship axis of beam", # noqa
+                        "long_name": "Half power two-way beam width along athwartship axis of beam",  # noqa
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
                         "comment": (
                             "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. "  # noqa
                             "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
-                            "The convention defines one-way transmit or receive beamwidth (beamwidth_receive_major and beamwidth_transmit_major), but Simrad echosounders record two-way beamwidth in the data." # noqa
+                            "The convention defines one-way transmit or receive beamwidth (beamwidth_receive_major and beamwidth_transmit_major), but Simrad echosounders record two-way beamwidth in the data."  # noqa
                         ),
                     },
                 ),

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -429,14 +429,13 @@ class SetGroupsEK80(SetGroupsBase):
                     ["channel"],
                     beam_params["beam_width_alongship"],
                     {
-                        "long_name": "Half power two-way beam width along "
-                        "alongship axis of beam",
+                        "long_name": "Half power two-way beam width along alongship axis of beam", # noqa
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
                         "comment": (
                             "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. "  # noqa
-                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
-                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data."  # noqa
+                            "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
+                            "The convention defines one-way transmit or receive beamwidth (beamwidth_receive_minor and beamwidth_transmit_minor), but Simrad echosounders record two-way beamwidth in the data." # noqa
                         ),
                     },
                 ),
@@ -444,14 +443,13 @@ class SetGroupsEK80(SetGroupsBase):
                     ["channel"],
                     beam_params["beam_width_athwartship"],
                     {
-                        "long_name": "Half power two-way beam width along "
-                        "athwartship axis of beam",
+                        "long_name": "Half power two-way beam width along athwartship axis of beam", # noqa
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
                         "comment": (
                             "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. "  # noqa
-                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
-                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data."  # noqa
+                            "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
+                            "The convention defines one-way transmit or receive beamwidth (beamwidth_receive_major and beamwidth_transmit_major), but Simrad echosounders record two-way beamwidth in the data." # noqa
                         ),
                     },
                 ),
@@ -492,10 +490,10 @@ class SetGroupsEK80(SetGroupsBase):
                     ["channel"],
                     beam_params["angle_offset_alongship"],
                     {
-                        "long_name": "electrical alongship angle of the transducer",
+                        "long_name": "electrical alongship angle offset of the transducer",
                         "comment": (
                             "Introduced in echopype for Simrad echosounders. "  # noqa
-                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
+                            "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
                         ),
                     },
                 ),
@@ -503,10 +501,10 @@ class SetGroupsEK80(SetGroupsBase):
                     ["channel"],
                     beam_params["angle_offset_athwartship"],
                     {
-                        "long_name": "electrical athwartship angle of the transducer",
+                        "long_name": "electrical athwartship angle offset of the transducer",
                         "comment": (
                             "Introduced in echopype for Simrad echosounders. "  # noqa
-                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
+                            "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
                         ),
                     },
                 ),
@@ -517,7 +515,7 @@ class SetGroupsEK80(SetGroupsBase):
                         "long_name": "alongship sensitivity of the transducer",
                         "comment": (
                             "Introduced in echopype for Simrad echosounders. "  # noqa
-                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
+                            "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
                         ),
                     },
                 ),
@@ -528,7 +526,7 @@ class SetGroupsEK80(SetGroupsBase):
                         "long_name": "athwartship sensitivity of the transducer",
                         "comment": (
                             "Introduced in echopype for Simrad echosounders. "  # noqa
-                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
+                            "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
                         ),
                     },
                 ),

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -429,13 +429,13 @@ class SetGroupsEK80(SetGroupsBase):
                     ["channel"],
                     beam_params["beam_width_alongship"],
                     {
-                        "long_name": "Half power two-way beam width along alongship axis of beam", # noqa
+                        "long_name": "Half power two-way beam width along alongship axis of beam",  # noqa
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
                         "comment": (
                             "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. "  # noqa
                             "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
-                            "The convention defines one-way transmit or receive beamwidth (beamwidth_receive_minor and beamwidth_transmit_minor), but Simrad echosounders record two-way beamwidth in the data." # noqa
+                            "The convention defines one-way transmit or receive beamwidth (beamwidth_receive_minor and beamwidth_transmit_minor), but Simrad echosounders record two-way beamwidth in the data."  # noqa
                         ),
                     },
                 ),
@@ -443,13 +443,13 @@ class SetGroupsEK80(SetGroupsBase):
                     ["channel"],
                     beam_params["beam_width_athwartship"],
                     {
-                        "long_name": "Half power two-way beam width along athwartship axis of beam", # noqa
+                        "long_name": "Half power two-way beam width along athwartship axis of beam",  # noqa
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
                         "comment": (
                             "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. "  # noqa
                             "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
-                            "The convention defines one-way transmit or receive beamwidth (beamwidth_receive_major and beamwidth_transmit_major), but Simrad echosounders record two-way beamwidth in the data." # noqa
+                            "The convention defines one-way transmit or receive beamwidth (beamwidth_receive_major and beamwidth_transmit_major), but Simrad echosounders record two-way beamwidth in the data."  # noqa
                         ),
                     },
                 ),

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -433,6 +433,11 @@ class SetGroupsEK80(SetGroupsBase):
                         "alongship axis of beam",
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
+                        "comment": (
+                            "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. " # noqa
+                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
+                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data." # noqa
+                        )
                     },
                 ),
                 "beamwidth_twoway_athwartship": (
@@ -443,6 +448,11 @@ class SetGroupsEK80(SetGroupsBase):
                         "athwartship axis of beam",
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
+                        "comment": (
+                            "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. " # noqa
+                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
+                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data." # noqa
+                        )
                     },
                 ),
                 "beam_direction_x": (
@@ -481,22 +491,46 @@ class SetGroupsEK80(SetGroupsBase):
                 "angle_offset_alongship": (
                     ["channel"],
                     beam_params["angle_offset_alongship"],
-                    {"long_name": "electrical alongship angle of the transducer"},
+                    {
+                        "long_name": "electrical alongship angle of the transducer",
+                        "comment": (
+                            "Introduced in echopype for Simrad echosounders. " # noqa
+                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
+                        )
+                    },
                 ),
                 "angle_offset_athwartship": (
                     ["channel"],
                     beam_params["angle_offset_athwartship"],
-                    {"long_name": "electrical athwartship angle of the transducer"},
+                    {
+                        "long_name": "electrical athwartship angle of the transducer",
+                        "comment": (
+                            "Introduced in echopype for Simrad echosounders. " # noqa
+                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
+                        )
+                    },
                 ),
                 "angle_sensitivity_alongship": (
                     ["channel"],
                     beam_params["angle_sensitivity_alongship"],
-                    {"long_name": "alongship sensitivity of the transducer"},
+                    {
+                        "long_name": "alongship sensitivity of the transducer",
+                        "comment": (
+                            "Introduced in echopype for Simrad echosounders. " # noqa
+                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
+                        )
+                    },
                 ),
                 "angle_sensitivity_athwartship": (
                     ["channel"],
                     beam_params["angle_sensitivity_athwartship"],
-                    {"long_name": "athwartship sensitivity of the transducer"},
+                    {
+                        "long_name": "athwartship sensitivity of the transducer",
+                        "comment": (
+                            "Introduced in echopype for Simrad echosounders. " # noqa
+                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
+                        )
+                    },
                 ),
                 "equivalent_beam_angle": (
                     ["channel"],
@@ -650,12 +684,24 @@ class SetGroupsEK80(SetGroupsBase):
                     "angle_athwartship": (
                         ["ping_time", "range_sample"],
                         self.parser_obj.ping_data_dict["angle"][ch][:, :, 0],
-                        {"long_name": "electrical athwartship angle"},
+                        {
+                            "long_name": "electrical athwartship angle",
+                            "comment": (
+                                "Introduced in echopype for Simrad echosounders. " # noqa
+                                + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
+                            )
+                        },
                     ),
                     "angle_alongship": (
                         ["ping_time", "range_sample"],
                         self.parser_obj.ping_data_dict["angle"][ch][:, :, 1],
-                        {"long_name": "electrical alongship angle"},
+                        {
+                            "long_name": "electrical alongship angle",
+                            "comment": (
+                                "Introduced in echopype for Simrad echosounders. " # noqa
+                                + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
+                            )
+                        },
                     ),
                 }
             )

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -434,10 +434,10 @@ class SetGroupsEK80(SetGroupsBase):
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
                         "comment": (
-                            "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. " # noqa
-                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
-                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data." # noqa
-                        )
+                            "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. "  # noqa
+                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
+                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data."  # noqa
+                        ),
                     },
                 ),
                 "beamwidth_twoway_athwartship": (
@@ -449,10 +449,10 @@ class SetGroupsEK80(SetGroupsBase):
                         "units": "arc_degree",
                         "valid_range": (0.0, 360.0),
                         "comment": (
-                            "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. " # noqa
-                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
-                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data." # noqa
-                        )
+                            "Introduced in echopype for Simrad echosounders to avoid potential confusion with convention definitions. "  # noqa
+                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
+                            + "The convention defines one-way transmit or receive beamwidth, but Simrad echosounders record two-way beamwidth in the data."  # noqa
+                        ),
                     },
                 ),
                 "beam_direction_x": (
@@ -494,9 +494,9 @@ class SetGroupsEK80(SetGroupsBase):
                     {
                         "long_name": "electrical alongship angle of the transducer",
                         "comment": (
-                            "Introduced in echopype for Simrad echosounders. " # noqa
-                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
-                        )
+                            "Introduced in echopype for Simrad echosounders. "  # noqa
+                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
+                        ),
                     },
                 ),
                 "angle_offset_athwartship": (
@@ -505,9 +505,9 @@ class SetGroupsEK80(SetGroupsBase):
                     {
                         "long_name": "electrical athwartship angle of the transducer",
                         "comment": (
-                            "Introduced in echopype for Simrad echosounders. " # noqa
-                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
-                        )
+                            "Introduced in echopype for Simrad echosounders. "  # noqa
+                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
+                        ),
                     },
                 ),
                 "angle_sensitivity_alongship": (
@@ -516,9 +516,9 @@ class SetGroupsEK80(SetGroupsBase):
                     {
                         "long_name": "alongship sensitivity of the transducer",
                         "comment": (
-                            "Introduced in echopype for Simrad echosounders. " # noqa
-                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
-                        )
+                            "Introduced in echopype for Simrad echosounders. "  # noqa
+                            + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
+                        ),
                     },
                 ),
                 "angle_sensitivity_athwartship": (
@@ -527,9 +527,9 @@ class SetGroupsEK80(SetGroupsBase):
                     {
                         "long_name": "athwartship sensitivity of the transducer",
                         "comment": (
-                            "Introduced in echopype for Simrad echosounders. " # noqa
-                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
-                        )
+                            "Introduced in echopype for Simrad echosounders. "  # noqa
+                            + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
+                        ),
                     },
                 ),
                 "equivalent_beam_angle": (
@@ -687,9 +687,9 @@ class SetGroupsEK80(SetGroupsBase):
                         {
                             "long_name": "electrical athwartship angle",
                             "comment": (
-                                "Introduced in echopype for Simrad echosounders. " # noqa
-                                + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. " # noqa
-                            )
+                                "Introduced in echopype for Simrad echosounders. "  # noqa
+                                + "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
+                            ),
                         },
                     ),
                     "angle_alongship": (
@@ -698,9 +698,9 @@ class SetGroupsEK80(SetGroupsBase):
                         {
                             "long_name": "electrical alongship angle",
                             "comment": (
-                                "Introduced in echopype for Simrad echosounders. " # noqa
-                                + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. " # noqa
-                            )
+                                "Introduced in echopype for Simrad echosounders. "  # noqa
+                                + "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
+                            ),
                         },
                     ),
                 }


### PR DESCRIPTION
This PR addresses #634.

I made some executive decisions on what echopype would do here to make sure there is no confusion on what the variables are and where they come from. 

In this PR:
- The beamdwidth variables are called `beamwidth_twoway_alongship/athwartship`: the convention defines 1-way beamwidth for transmit and receive separately. While I can split the two-way beamwidth into one-way beamwidth (by multiplying the value by 2), I think it is safer for users to see its original form without echopype altering the data.
- I've added a `comment` attribute to all `*_alongship`/`*_athwartship` variables, to say that we introduce this in echopype for Simrad echosounders, and the angle correspondence with [convention ver.2 definitions on p.72](http://nbviewer.org/github/ices-publications/SONAR-netCDF4/blob/v2.0/Formatted_docs/crr341.pdf). I know we are _not_ going to ver.2 any time soon, but since the angle definitions in ver.1  can be confusing, I think it is better to just include the correspondence with ver.2 where the angle definitions for split-beam echosounders are clearly stated.
