### PR TITLE
Rearrange AZFP attributes/variables and remove a variable according to #642

### DIFF
--- a/echopype/calibrate/calibrate_azfp.py
+++ b/echopype/calibrate/calibrate_azfp.py
@@ -29,9 +29,15 @@ class CalibrateAZFP(CalibrateBase):
         cal_params : dict
         """
         # Params from the Beam group
-        for p in ["EL", "DS", "TVR", "VTX", "Sv_offset", "equivalent_beam_angle"]:
+        self.cal_params["equivalent_beam_angle"] = (
+            cal_params["equivalent_beam_angle"]
+            if "equivalent_beam_angle" in cal_params
+            else self.echodata.beam["equivalent_beam_angle"]
+        )
+
+        for p in ["EL", "DS", "TVR", "VTX", "Sv_offset"]:
             # substitute if None in user input
-            self.cal_params[p] = cal_params[p] if p in cal_params else self.echodata.beam[p]
+            self.cal_params[p] = cal_params[p] if p in cal_params else self.echodata.vendor[p]
 
     def get_env_params(self):
         """Get env params using user inputs or values from data file.

--- a/echopype/calibrate/calibrate_azfp.py
+++ b/echopype/calibrate/calibrate_azfp.py
@@ -28,13 +28,15 @@ class CalibrateAZFP(CalibrateBase):
         ----------
         cal_params : dict
         """
-        # Params from the Beam group
+
+        # Get params from Beam_group1
         self.cal_params["equivalent_beam_angle"] = (
             cal_params["equivalent_beam_angle"]
             if "equivalent_beam_angle" in cal_params
             else self.echodata.beam["equivalent_beam_angle"]
         )
 
+        # Get params from the Vendor group
         for p in ["EL", "DS", "TVR", "VTX", "Sv_offset"]:
             # substitute if None in user input
             self.cal_params[p] = cal_params[p] if p in cal_params else self.echodata.vendor[p]

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -254,7 +254,6 @@ class SetGroupsAZFP(SetGroupsBase):
         tdn = np.array(parameters["pulse_length"]) / 1e6
         channel_id = self._create_unique_channel_name(unpacked_data)
         anc = np.array(unpacked_data["ancillary"])  # convert to np array for easy slicing
-        range_samples_xml = np.array(parameters["range_samples"])  # from xml file
 
         # Build variables in the output xarray Dataset
         Sv_offset = np.zeros(freq.shape)
@@ -314,7 +313,7 @@ class SetGroupsAZFP(SetGroupsBase):
                 "Sv_offset": (["channel"], Sv_offset),
                 "number_of_samples_digitized_per_pings": (
                     ["channel"],
-                    range_samples_xml,
+                    np.array(parameters["range_samples"]),
                 ),
                 "number_of_digitized_samples_averaged_per_pings": (
                     ["channel"],

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -90,30 +90,43 @@ class SetGroupsAZFP(SetGroupsBase):
             "platform_type": self.ui_param["platform_type"],
             "platform_code_ICES": self.ui_param["platform_code_ICES"],
         }
-        # Save
+        unpacked_data = self.parser_obj.unpacked_data
+        ping_time = self.parser_obj.ping_time
+
         ds = xr.Dataset(
             {
-                var: ([], np.nan, self._varattrs["platform_var_default"][var])
-                for var in [
-                    "MRU_offset_x",
-                    "MRU_offset_y",
-                    "MRU_offset_z",
-                    "MRU_rotation_x",
-                    "MRU_rotation_y",
-                    "MRU_rotation_z",
-                    "position_offset_x",
-                    "position_offset_y",
-                    "position_offset_z",
-                    "transducer_offset_x",
-                    "transducer_offset_y",
-                    "transducer_offset_z",
-                    "vertical_offset",
-                    "water_level",
-                ]
-            }
+                "tilt_x": (["ping_time"], unpacked_data["tilt_x"]),
+                "tilt_y": (["ping_time"], unpacked_data["tilt_y"]),
+                **{
+                    var: ([], np.nan, self._varattrs["platform_var_default"][var])
+                    for var in [
+                        "MRU_offset_x",
+                        "MRU_offset_y",
+                        "MRU_offset_z",
+                        "MRU_rotation_x",
+                        "MRU_rotation_y",
+                        "MRU_rotation_z",
+                        "position_offset_x",
+                        "position_offset_y",
+                        "position_offset_z",
+                        "transducer_offset_x",
+                        "transducer_offset_y",
+                        "transducer_offset_z",
+                        "vertical_offset",
+                        "water_level",
+                    ]
+                },
+            },
+            coords={
+                "ping_time": (
+                    ["ping_time"],
+                    ping_time,
+                    self._varattrs["beam_coord_default"]["ping_time"],
+                ),
+            },
         )
         ds = ds.assign_attrs(platform_dict)
-        return ds
+        return set_encodings(ds)
 
     @staticmethod
     def _create_unique_channel_name(unpacked_data):
@@ -143,7 +156,6 @@ class SetGroupsAZFP(SetGroupsBase):
         """Set the Beam group."""
         unpacked_data = self.parser_obj.unpacked_data
         parameters = self.parser_obj.parameters
-        anc = np.array(unpacked_data["ancillary"])  # convert to np array for easy slicing
         dig_rate = unpacked_data["dig_rate"]  # dim: freq
         freq = np.array(unpacked_data["frequency"]) * 1000  # Frequency in Hz
         ping_time = self.parser_obj.ping_time
@@ -151,12 +163,7 @@ class SetGroupsAZFP(SetGroupsBase):
 
         # Build variables in the output xarray Dataset
         N = []  # for storing backscatter_r values for each frequency
-        Sv_offset = np.zeros(freq.shape)
         for ich in range(len(freq)):
-            # TODO: should not access the private function, better to compute Sv_offset in parser
-            Sv_offset[ich] = self.parser_obj._calc_Sv_offset(
-                freq[ich], unpacked_data["pulse_length"][ich]
-            )
             N.append(
                 np.array(
                     [unpacked_data["counts"][p][ich] for p in range(len(unpacked_data["year"]))]
@@ -176,7 +183,6 @@ class SetGroupsAZFP(SetGroupsBase):
             del N_tmp
 
         tdn = unpacked_data["pulse_length"] / 1e6  # Convert microseconds to seconds
-        range_samples_xml = np.array(parameters["range_samples"])  # from xml file
         range_samples_per_bin = unpacked_data["range_samples_per_bin"]  # from data header
 
         # Calculate sample interval in seconds
@@ -208,25 +214,6 @@ class SetGroupsAZFP(SetGroupsBase):
                         "valid_min": 0.0,
                     },
                 ),
-                "temperature_counts": (["ping_time"], anc[:, 4]),
-                "tilt_x_count": (["ping_time"], anc[:, 0]),
-                "tilt_y_count": (["ping_time"], anc[:, 1]),
-                "tilt_x": (["ping_time"], unpacked_data["tilt_x"]),
-                "tilt_y": (["ping_time"], unpacked_data["tilt_y"]),
-                "cos_tilt_mag": (["ping_time"], unpacked_data["cos_tilt_mag"]),
-                "DS": (["channel"], parameters["DS"]),
-                "EL": (["channel"], parameters["EL"]),
-                "TVR": (["channel"], parameters["TVR"]),
-                "VTX": (["channel"], parameters["VTX"]),
-                "Sv_offset": (["channel"], Sv_offset),
-                "number_of_samples_digitized_per_pings": (
-                    ["channel"],
-                    range_samples_xml,
-                ),
-                "number_of_digitized_samples_averaged_per_pings": (
-                    ["channel"],
-                    parameters["range_averaging_samples"],
-                ),
             },
             coords={
                 "channel": (
@@ -248,25 +235,6 @@ class SetGroupsAZFP(SetGroupsBase):
             attrs={
                 "beam_mode": "",
                 "conversion_equation_t": "type_4",
-                "number_of_frequency": parameters["num_freq"],
-                "number_of_pings_per_burst": parameters["pings_per_burst"],
-                "average_burst_pings_flag": parameters["average_burst_pings"],
-                # Temperature coefficients
-                "temperature_ka": parameters["ka"],
-                "temperature_kb": parameters["kb"],
-                "temperature_kc": parameters["kc"],
-                "temperature_A": parameters["A"],
-                "temperature_B": parameters["B"],
-                "temperature_C": parameters["C"],
-                # Tilt coefficients
-                "tilt_X_a": parameters["X_a"],
-                "tilt_X_b": parameters["X_b"],
-                "tilt_X_c": parameters["X_c"],
-                "tilt_X_d": parameters["X_d"],
-                "tilt_Y_a": parameters["Y_a"],
-                "tilt_Y_b": parameters["Y_b"],
-                "tilt_Y_c": parameters["Y_c"],
-                "tilt_Y_d": parameters["Y_d"],
             },
         )
 
@@ -285,6 +253,16 @@ class SetGroupsAZFP(SetGroupsBase):
         ping_time = self.parser_obj.ping_time
         tdn = np.array(parameters["pulse_length"]) / 1e6
         channel_id = self._create_unique_channel_name(unpacked_data)
+        anc = np.array(unpacked_data["ancillary"])  # convert to np array for easy slicing
+        range_samples_xml = np.array(parameters["range_samples"])  # from xml file
+
+        # Build variables in the output xarray Dataset
+        Sv_offset = np.zeros(freq.shape)
+        for ich in range(len(freq)):
+            # TODO: should not access the private function, better to compute Sv_offset in parser
+            Sv_offset[ich] = self.parser_obj._calc_Sv_offset(
+                freq[ich], unpacked_data["pulse_length"][ich]
+            )
 
         ds = xr.Dataset(
             {
@@ -326,6 +304,22 @@ class SetGroupsAZFP(SetGroupsBase):
                 "battery_main": (["ping_time"], unpacked_data["battery_main"]),
                 "battery_tx": (["ping_time"], unpacked_data["battery_tx"]),
                 "profile_number": (["ping_time"], unpacked_data["profile_number"]),
+                "temperature_counts": (["ping_time"], anc[:, 4]),
+                "tilt_x_count": (["ping_time"], anc[:, 0]),
+                "tilt_y_count": (["ping_time"], anc[:, 1]),
+                "DS": (["channel"], parameters["DS"]),
+                "EL": (["channel"], parameters["EL"]),
+                "TVR": (["channel"], parameters["TVR"]),
+                "VTX": (["channel"], parameters["VTX"]),
+                "Sv_offset": (["channel"], Sv_offset),
+                "number_of_samples_digitized_per_pings": (
+                    ["channel"],
+                    range_samples_xml,
+                ),
+                "number_of_digitized_samples_averaged_per_pings": (
+                    ["channel"],
+                    parameters["range_averaging_samples"],
+                ),
             },
             coords={
                 "channel": (
@@ -360,6 +354,25 @@ class SetGroupsAZFP(SetGroupsBase):
                 "ping_period": unpacked_data["ping_period"],
                 "phase": unpacked_data["phase"],
                 "number_of_channels": unpacked_data["num_chan"],
+                "number_of_frequency": parameters["num_freq"],
+                "number_of_pings_per_burst": parameters["pings_per_burst"],
+                "average_burst_pings_flag": parameters["average_burst_pings"],
+                # Temperature coefficients
+                "temperature_ka": parameters["ka"],
+                "temperature_kb": parameters["kb"],
+                "temperature_kc": parameters["kc"],
+                "temperature_A": parameters["A"],
+                "temperature_B": parameters["B"],
+                "temperature_C": parameters["C"],
+                # Tilt coefficients
+                "tilt_X_a": parameters["X_a"],
+                "tilt_X_b": parameters["X_b"],
+                "tilt_X_c": parameters["X_c"],
+                "tilt_X_d": parameters["X_d"],
+                "tilt_Y_a": parameters["Y_a"],
+                "tilt_Y_b": parameters["Y_b"],
+                "tilt_Y_c": parameters["Y_c"],
+                "tilt_Y_d": parameters["Y_d"],
             },
         )
         return set_encodings(ds)

--- a/echopype/tests/convert/test_convert_azfp.py
+++ b/echopype/tests/convert/test_convert_azfp.py
@@ -71,15 +71,6 @@ def test_convert_azfp_01a_matlab_raw(azfp_path):
         ),
         echodata.beam.backscatter_r.isel(beam=0).drop('beam').values,
     )
-    # tilt x-y
-    assert np.array_equal(
-        np.array([d[0] for d in ds_matlab['Data']['Ancillary'][0]]).squeeze(),
-        echodata.beam.tilt_x_count,
-    )
-    assert np.array_equal(
-        np.array([d[1] for d in ds_matlab['Data']['Ancillary'][0]]).squeeze(),
-        echodata.beam.tilt_y_count,
-    )
 
     # Test vendor group
     # Test temperature
@@ -96,6 +87,15 @@ def test_convert_azfp_01a_matlab_raw(azfp_path):
             [d[0] for d in ds_matlab['Data']['BatteryMain'][0]]
         ).squeeze(),
         echodata.vendor.battery_main,
+    )
+    # tilt x-y
+    assert np.array_equal(
+        np.array([d[0] for d in ds_matlab['Data']['Ancillary'][0]]).squeeze(),
+        echodata.vendor.tilt_x_count,
+    )
+    assert np.array_equal(
+        np.array([d[1] for d in ds_matlab['Data']['Ancillary'][0]]).squeeze(),
+        echodata.vendor.tilt_y_count,
     )
 
     # check convention-required variables in the Platform group


### PR DESCRIPTION
In this PR I address issue #642. More specifically, I have made the following changes for AZFP:

- Moved the following variables to the `Platform` group:
  - `tilt_x/y(ping_time)`
- Moved the following variables to the `Vendor` group: 
    - `temperature_counts(ping_time)`
    - `tilt_x/y_count(ping_time)`
    - `DS(channel)`
    - `EL(channel)`
    - `​​TVR(channel)`
    - `VTX(channel)`
    - `Sv_offset(channel)`
    - `number_of_samples_digitized_per_pings(channel)`
    - `number_of_digitized_samples_averaged_per_pings(channel)`
- Removed the variable `cos_tilt_mag(ping_time)`
- Moved the following attributes to the `Vendor` group: `tilt_X_a/b/c/d`, `tilt_Y_a/b/c/d`, `temperature_ka/kb/kc/A/B/C`, `number_of_frequency`, `number_of_pings_per_burst`, `average_burst_pings_flag`

Note that this PR is currently a draft. We need to decide if several attributes (corresponding to coefficients) that were moved to the `Vendor` group should instead be made into variables, see [#642 (comment)](https://github.com/OSOceanAcoustics/echopype/issues/642#issuecomment-1120032423).
 