### PR TITLE
Bring consistency to the time coordinate names

### DIFF
--- a/echopype/calibrate/calibrate_azfp.py
+++ b/echopype/calibrate/calibrate_azfp.py
@@ -52,7 +52,9 @@ class CalibrateAZFP(CalibrateBase):
         self.env_params["temperature"] = (
             self.env_params["temperature"]
             if "temperature" in self.env_params
-            else self.echodata.environment["temperature"]
+            # renaming time1 to ping_time is necessary because we are performing
+            # calculations with the beam groups that use ping_time
+            else self.echodata.environment["temperature"].rename({"time1": "ping_time"})
         )
 
         # Salinity and pressure always come from user input

--- a/echopype/calibrate/calibrate_azfp.py
+++ b/echopype/calibrate/calibrate_azfp.py
@@ -49,11 +49,11 @@ class CalibrateAZFP(CalibrateBase):
         env_params : dict
         """
         # Temperature comes from either user input or data file
+        # Below, renaming time1 to ping_time is necessary because we are performing
+        # calculations with the beam groups that use ping_time
         self.env_params["temperature"] = (
             self.env_params["temperature"]
             if "temperature" in self.env_params
-            # renaming time1 to ping_time is necessary because we are performing
-            # calculations with the beam groups that use ping_time
             else self.echodata.environment["temperature"].rename({"time1": "ping_time"})
         )
 

--- a/echopype/calibrate/calibrate_base.py
+++ b/echopype/calibrate/calibrate_base.py
@@ -195,8 +195,8 @@ class EnvParams:
         #     )
 
         if self.data_kind == "stationary":
-            # renaming time2 to ping_time is necessary because we are performing
-            # calculations with the beam groups that use ping_time
+            # renaming time3 (from Platform group) to ping_time is necessary because 
+            # we are performing calculations with the beam groups that use ping_time
             return {
                 var: env_params[var].rename({"time3": "ping_time"})
                 for var in ("temperature", "salinity", "pressure")

--- a/echopype/calibrate/calibrate_base.py
+++ b/echopype/calibrate/calibrate_base.py
@@ -194,7 +194,15 @@ class EnvParams:
         #         }
         #     )
 
-        return {var: env_params[var] for var in ("temperature", "salinity", "pressure")}
+        if self.data_kind == "stationary":
+            # renaming time2 to ping_time is necessary because we are performing
+            # calculations with the beam groups that use ping_time
+            return {
+                var: env_params[var].rename({"time2": "ping_time"})
+                for var in ("temperature", "salinity", "pressure")
+            }
+        else:
+            return {var: env_params[var] for var in ("temperature", "salinity", "pressure")}
 
 
 class CalibrateBase(abc.ABC):

--- a/echopype/calibrate/calibrate_base.py
+++ b/echopype/calibrate/calibrate_base.py
@@ -43,7 +43,7 @@ class EnvParams:
             The environmental parameters to use for calibration. This data will be interpolated with
             a provided `EchoData` object.
 
-            When `data_kind` is `"stationary"`, env_params must have a coordinate `"ping_time"`.
+            When `data_kind` is `"stationary"`, env_params must have a coordinate `"time2"`.
             When `data_kind` is `"mobile"`, env_params must have coordinates `"latitude"`
             and `"longitude"`.
             When `data_kind` is `"organized"`, env_params must have coordinates `"time"`,
@@ -92,7 +92,7 @@ class EnvParams:
 
     def _apply(self, echodata) -> Dict[str, xr.DataArray]:
         if self.data_kind == "stationary":
-            dims = ["ping_time"]
+            dims = ["time2"]
         elif self.data_kind == "mobile":
             dims = ["latitude", "longitude"]
         elif self.data_kind == "organized":

--- a/echopype/calibrate/calibrate_base.py
+++ b/echopype/calibrate/calibrate_base.py
@@ -43,7 +43,7 @@ class EnvParams:
             The environmental parameters to use for calibration. This data will be interpolated with
             a provided `EchoData` object.
 
-            When `data_kind` is `"stationary"`, env_params must have a coordinate `"time2"`.
+            When `data_kind` is `"stationary"`, env_params must have a coordinate `"time3"`.
             When `data_kind` is `"mobile"`, env_params must have coordinates `"latitude"`
             and `"longitude"`.
             When `data_kind` is `"organized"`, env_params must have coordinates `"time"`,
@@ -92,7 +92,7 @@ class EnvParams:
 
     def _apply(self, echodata) -> Dict[str, xr.DataArray]:
         if self.data_kind == "stationary":
-            dims = ["time2"]
+            dims = ["time3"]
         elif self.data_kind == "mobile":
             dims = ["latitude", "longitude"]
         elif self.data_kind == "organized":
@@ -198,7 +198,7 @@ class EnvParams:
             # renaming time2 to ping_time is necessary because we are performing
             # calculations with the beam groups that use ping_time
             return {
-                var: env_params[var].rename({"time2": "ping_time"})
+                var: env_params[var].rename({"time3": "ping_time"})
                 for var in ("temperature", "salinity", "pressure")
             }
         else:

--- a/echopype/calibrate/calibrate_base.py
+++ b/echopype/calibrate/calibrate_base.py
@@ -195,7 +195,7 @@ class EnvParams:
         #     )
 
         if self.data_kind == "stationary":
-            # renaming time3 (from Platform group) to ping_time is necessary because 
+            # renaming time3 (from Platform group) to ping_time is necessary because
             # we are performing calculations with the beam groups that use ping_time
             return {
                 var: env_params[var].rename({"time3": "ping_time"})

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -269,11 +269,12 @@ class CalibrateEK60(CalibrateEK):
             )
         # Otherwise get sound speed and absorption from user inputs or raw data file
         else:
+            # Below, renaming time1 to ping_time is necessary because
+            # we are performing calculations with the beam groups that use ping_time
+
             self.env_params["sound_speed"] = (
                 self.env_params["sound_speed"]
                 if "sound_speed" in self.env_params
-                # renaming time1 to ping_time is necessary because we are performing
-                # calculations with the beam groups that use ping_time
                 else self.echodata.environment["sound_speed_indicative"].rename(
                     {"time1": "ping_time"}
                 )
@@ -281,8 +282,6 @@ class CalibrateEK60(CalibrateEK):
             self.env_params["sound_absorption"] = (
                 self.env_params["sound_absorption"]
                 if "sound_absorption" in self.env_params
-                # renaming time1 to ping_time is necessary because we are performing
-                # calculations with the beam groups that use ping_time
                 else self.echodata.environment["absorption_indicative"].rename(
                     {"time1": "ping_time"}
                 )
@@ -383,14 +382,15 @@ class CalibrateEK80(CalibrateEK):
         #  get sound speed from user inputs or raw data file
         #  get absorption from user inputs or computing from env params stored in raw data file
         else:
+            # Below, renaming time1 to ping_time is necessary because
+            # we are performing calculations with the beam groups that use ping_time
+
             # pressure is encoded as "depth" in EK80  # TODO: change depth to pressure in EK80 file?
             for p1, p2 in zip(
                 ["temperature", "salinity", "pressure"],
                 ["temperature", "salinity", "depth"],
             ):
                 self.env_params[p1] = (
-                    # renaming time1 to ping_time is necessary because we are performing
-                    # calculations with the beam groups that use ping_time
                     self.env_params[p1]
                     if p1 in self.env_params
                     else self.echodata.environment[p2].rename({"time1": "ping_time"})
@@ -398,8 +398,6 @@ class CalibrateEK80(CalibrateEK):
             self.env_params["sound_speed"] = (
                 self.env_params["sound_speed"]
                 if "sound_speed" in self.env_params
-                # renaming time1 to ping_time is necessary because we are performing
-                # calculations with the beam groups that use ping_time
                 else self.echodata.environment["sound_speed_indicative"].rename(
                     {"time1": "ping_time"}
                 )

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -272,12 +272,20 @@ class CalibrateEK60(CalibrateEK):
             self.env_params["sound_speed"] = (
                 self.env_params["sound_speed"]
                 if "sound_speed" in self.env_params
-                else self.echodata.environment["sound_speed_indicative"]
+                # renaming time1 to ping_time is necessary because we are performing
+                # calculations with the beam groups that use ping_time
+                else self.echodata.environment["sound_speed_indicative"].rename(
+                    {"time1": "ping_time"}
+                )
             )
             self.env_params["sound_absorption"] = (
                 self.env_params["sound_absorption"]
                 if "sound_absorption" in self.env_params
-                else self.echodata.environment["absorption_indicative"]
+                # renaming time1 to ping_time is necessary because we are performing
+                # calculations with the beam groups that use ping_time
+                else self.echodata.environment["absorption_indicative"].rename(
+                    {"time1": "ping_time"}
+                )
             )
 
     def compute_Sv(self, **kwargs):
@@ -381,12 +389,20 @@ class CalibrateEK80(CalibrateEK):
                 ["temperature", "salinity", "depth"],
             ):
                 self.env_params[p1] = (
-                    self.env_params[p1] if p1 in self.env_params else self.echodata.environment[p2]
+                    # renaming time1 to ping_time is necessary because we are performing
+                    # calculations with the beam groups that use ping_time
+                    self.env_params[p1]
+                    if p1 in self.env_params
+                    else self.echodata.environment[p2].rename({"time1": "ping_time"})
                 )
             self.env_params["sound_speed"] = (
                 self.env_params["sound_speed"]
                 if "sound_speed" in self.env_params
-                else self.echodata.environment["sound_speed_indicative"]
+                # renaming time1 to ping_time is necessary because we are performing
+                # calculations with the beam groups that use ping_time
+                else self.echodata.environment["sound_speed_indicative"].rename(
+                    {"time1": "ping_time"}
+                )
             )
             self.env_params["sound_absorption"] = (
                 self.env_params["sound_absorption"]

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -119,7 +119,11 @@ def _save_groups_to_file(echodata, output_path, engine, compress=True):
     # Environment group
     io.save_file(
         echodata.environment.chunk(
-            {"ping_time": DEFAULT_CHUNK_SIZE["ping_time"]}
+            # Making chunking w.r.t. ping_time for AD2CP
+            # and w.r.t. time1 for the rest of the sensors
+            {"time1": DEFAULT_CHUNK_SIZE["ping_time"]}
+            if echodata.top.attrs["keywords"] != "AD2CP"
+            else {"ping_time": DEFAULT_CHUNK_SIZE["ping_time"]}
         ),  # TODO: chunking necessary?
         path=output_path,
         mode="a",

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -43,18 +43,19 @@ class SetGroupsAZFP(SetGroupsBase):
         ds = xr.Dataset(
             {
                 "temperature": (
-                    ["ping_time"],
+                    ["time1"],
                     self.parser_obj.unpacked_data["temperature"],
                 )
             },
             coords={
-                "ping_time": (
-                    ["ping_time"],
+                "time1": (
+                    ["time1"],
                     ping_time,
                     {
                         "axis": "T",
                         "long_name": "Timestamp of each ping",
                         "standard_name": "time",
+                        "comment": "Time coordinate corresponding to environmental variables.",
                     },
                 )
             },

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -94,12 +94,12 @@ class SetGroupsAZFP(SetGroupsBase):
             "platform_code_ICES": self.ui_param["platform_code_ICES"],
         }
         unpacked_data = self.parser_obj.unpacked_data
-        ping_time = self.parser_obj.ping_time
+        time2 = self.parser_obj.ping_time
 
         ds = xr.Dataset(
             {
-                "tilt_x": (["ping_time"], unpacked_data["tilt_x"]),
-                "tilt_y": (["ping_time"], unpacked_data["tilt_y"]),
+                "tilt_x": (["time2"], unpacked_data["tilt_x"]),
+                "tilt_y": (["time2"], unpacked_data["tilt_y"]),
                 **{
                     var: ([], np.nan, self._varattrs["platform_var_default"][var])
                     for var in [
@@ -121,10 +121,13 @@ class SetGroupsAZFP(SetGroupsBase):
                 },
             },
             coords={
-                "ping_time": (
-                    ["ping_time"],
-                    ping_time,
-                    self._varattrs["beam_coord_default"]["ping_time"],
+                "time2": (
+                    ["time2"],
+                    time2,
+                    {
+                        **self._varattrs["beam_coord_default"]["ping_time"],
+                        "comment": "Time coordinate corresponding to platform sensors.",
+                    },
                 ),
             },
         )

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -128,6 +128,7 @@ class SetGroupsBase(abc.ABC):
                         "axis": "T",
                         "long_name": "Timestamps for NMEA datagrams",
                         "standard_name": "time",
+                        "comment": "Time coordinate corresponding to GPS location.",
                     },
                 )
             },

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -127,7 +127,7 @@ class SetGroupsEK60(SetGroupsBase):
             ds_tmp = xr.Dataset(
                 {
                     "absorption_indicative": (
-                        ["ping_time"],
+                        ["time1"],
                         self.parser_obj.ping_data_dict["absorption_coefficient"][ch],
                         {
                             "long_name": "Indicative acoustic absorption",
@@ -136,7 +136,7 @@ class SetGroupsEK60(SetGroupsBase):
                         },
                     ),
                     "sound_speed_indicative": (
-                        ["ping_time"],
+                        ["time1"],
                         self.parser_obj.ping_data_dict["sound_velocity"][ch],
                         {
                             "long_name": "Indicative sound speed",
@@ -147,13 +147,14 @@ class SetGroupsEK60(SetGroupsBase):
                     ),
                 },
                 coords={
-                    "ping_time": (
-                        ["ping_time"],
+                    "time1": (
+                        ["time1"],
                         self.parser_obj.ping_time[ch],
                         {
                             "axis": "T",
                             "long_name": "Timestamps for NMEA position datagrams",
                             "standard_name": "time",
+                            "comment": "Time coordinate corresponding to environmental variables.",
                         },
                     )
                 },
@@ -227,7 +228,10 @@ class SetGroupsEK60(SetGroupsBase):
                 "time1": (
                     ["time1"],
                     time1,
-                    self._varattrs["platform_coord_default"]["time1"],
+                    {
+                        **self._varattrs["platform_coord_default"]["time1"],
+                        "comment": "Time coordinate corresponding to GPS location.",
+                    },
                 )
             },
         )
@@ -250,22 +254,22 @@ class SetGroupsEK60(SetGroupsBase):
                 ds_tmp = xr.Dataset(
                     {
                         "pitch": (
-                            ["ping_time"],
+                            ["time2"],
                             self.parser_obj.ping_data_dict["pitch"][ch],
                             self._varattrs["platform_var_default"]["pitch"],
                         ),
                         "roll": (
-                            ["ping_time"],
+                            ["time2"],
                             self.parser_obj.ping_data_dict["roll"][ch],
                             self._varattrs["platform_var_default"]["roll"],
                         ),
                         "vertical_offset": (
-                            ["ping_time"],
+                            ["time2"],
                             self.parser_obj.ping_data_dict["heave"][ch],
                             self._varattrs["platform_var_default"]["vertical_offset"],
                         ),
                         "water_level": (
-                            ["ping_time"],
+                            ["time3"],
                             self.parser_obj.ping_data_dict["transducer_depth"][ch],
                             self._varattrs["platform_var_default"]["water_level"],
                         ),
@@ -306,15 +310,27 @@ class SetGroupsEK60(SetGroupsBase):
                         },
                     },
                     coords={
-                        "ping_time": (
-                            ["ping_time"],
+                        "time2": (
+                            ["time2"],
                             self.parser_obj.ping_time[ch],
                             {
                                 "axis": "T",
                                 "long_name": "Timestamps for position datagrams",
                                 "standard_name": "time",
+                                "comment": "Time coordinate corresponding to platform sensors.",
                             },
-                        )
+                        ),
+                        "time3": (
+                            ["time3"],
+                            self.parser_obj.ping_time[ch],
+                            {
+                                "axis": "T",
+                                "long_name": "Timestamps for position datagrams",
+                                "standard_name": "time",
+                                "comment": "Time coordinate corresponding to "
+                                "environmental variables.",
+                            },
+                        ),
                     },
                     attrs={
                         "platform_code_ICES": self.ui_param["platform_code_ICES"],
@@ -348,7 +364,7 @@ class SetGroupsEK60(SetGroupsBase):
             # Merge with NMEA data
             ds = xr.merge([ds, ds_plat], combine_attrs="override")
 
-            ds = ds.chunk({"ping_time": DEFAULT_CHUNK_SIZE["ping_time"]})
+            ds = ds.chunk({"time2": DEFAULT_CHUNK_SIZE["ping_time"]})
 
         return set_encodings(ds)
 

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -63,7 +63,7 @@ class SetGroupsEK80(SetGroupsBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def set_env(self, env_only=False) -> xr.Dataset:
+    def set_env(self) -> xr.Dataset:
         """Set the Environment group."""
 
         # set time1 if it exists

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -62,20 +62,18 @@ class SetGroupsEK80(SetGroupsBase):
 
     def set_env(self, env_only=False) -> xr.Dataset:
         """Set the Environment group."""
-        # If only saving environment group,
-        # there is no ping_time so use timestamp of environment datagram
-        if env_only:
-            ping_time = self.parser_obj.environment["timestamp"]
+
+        # set time1 if it exists
+        if "timestamp" in self.parser_obj.environment:
+            time1 = np.array([self.parser_obj.environment["timestamp"]])
         else:
-            ping_time = list(self.parser_obj.ping_time.values())[0][0]
-        # Select the first available ping_time
-        ping_time = np.array([ping_time.astype("datetime64[ns]")])
+            time1 = np.array([np.datetime64("NaT")])
 
         # Collect variables
         dict_env = dict()
         for k, v in self.parser_obj.environment.items():
             if k in ["temperature", "depth", "acidity", "salinity", "sound_speed"]:
-                dict_env[k] = (["ping_time"], [v])
+                dict_env[k] = (["time1"], [v])
 
         # Rename to conform with those defined in convention
         if "sound_speed" in dict_env:
@@ -89,7 +87,7 @@ class SetGroupsEK80(SetGroupsBase):
 
         if "sound_velocity_profile" in self.parser_obj.environment:
             dict_env["sound_velocity_profile"] = (
-                ["environment_time", "sound_velocity_profile_depth"],
+                ["time1", "sound_velocity_profile_depth"],
                 [self.parser_obj.environment["sound_velocity_profile"][1::2]],
                 {
                     "long_name": "sound velocity profile",
@@ -104,33 +102,23 @@ class SetGroupsEK80(SetGroupsBase):
         for var_name in vars:
             if var_name in self.parser_obj.environment:
                 dict_env[var_name] = (
-                    ["environment_time"],
+                    ["time1"],
                     [self.parser_obj.environment[var_name]],
                 )
 
         ds = xr.Dataset(
             dict_env,
             coords={
-                "ping_time": (
-                    ["ping_time"],
-                    ping_time,
+                "time1": (
+                    ["time1"],
+                    time1,
                     {
                         "axis": "T",
                         "long_name": "Timestamp of each ping",
                         "standard_name": "time",
-                    },
-                ),
-                "environment_time": (
-                    ["environment_time"],
-                    [self.parser_obj.environment["timestamp"]]
-                    if "timestamp" in self.parser_obj.environment
-                    else np.datetime64("NaT"),
-                    {
-                        "axis": "T",
-                        "long_name": "Timestamps for Environment XML datagrams",
-                        "standard_name": "time",
-                        "comment": "Platform.time3 and Environment.environment_time are "
-                        "identical time coordinates from the same datagrams",
+                        "comment": "Time coordinate corresponding to environmental "
+                        "variables. Note that Platform.time3 is the same "
+                        "as Environment.time1",
                     },
                 ),
                 "sound_velocity_profile_depth": (

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -360,6 +360,7 @@ class SetGroupsEK80(SetGroupsBase):
                         "axis": "T",
                         "long_name": "Timestamps for MRU datagrams",
                         "standard_name": "time",
+                        "comment": "Time coordinate corresponding to platform sensors.",
                     },
                 ),
                 "time3": (
@@ -371,8 +372,8 @@ class SetGroupsEK80(SetGroupsBase):
                         "axis": "T",
                         "long_name": "Timestamps for Environment XML datagrams",
                         "standard_name": "time",
-                        "comment": "Platform.time3 and Environment.environment_time are "
-                        "identical time coordinates from the same datagrams",
+                        "comment": "Time coordinate corresponding to environmental variables. "
+                        "Note that Platform.time3 is the same as Environment.time1",
                     },
                 ),
                 "time1": (
@@ -382,6 +383,7 @@ class SetGroupsEK80(SetGroupsBase):
                         "axis": "T",
                         "long_name": "Timestamps for NMEA datagrams",
                         "standard_name": "time",
+                        "comment": "Time coordinate corresponding to GPS location.",
                     },
                 ),
             },

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -374,9 +374,7 @@ class SetGroupsEK80(SetGroupsBase):
                     ["time1"],
                     time1,
                     {
-                        "axis": "T",
-                        "long_name": "Timestamps for NMEA datagrams",
-                        "standard_name": "time",
+                        **self._varattrs["platform_coord_default"]["time1"],
                         "comment": "Time coordinate corresponding to GPS location.",
                     },
                 ),

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -364,7 +364,9 @@ class EchoData:
                 formula_source="AZFP" if self.sonar_model == "AZFP" else "Mackenzie",
             )
         elif self.sonar_model in ("EK60", "EK80") and "sound_speed_indicative" in self.environment:
-            sound_speed = squeeze_non_scalar(self.environment["sound_speed_indicative"])
+            sound_speed = squeeze_non_scalar(
+                self.environment["sound_speed_indicative"].rename({"time1": "ping_time"})
+            )
         else:
             raise ValueError(
                 "sound speed must be specified in env_params, "

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -335,12 +335,12 @@ def test_env_params(ek60_path):
     # values after 1:25 will be extrapolated
     env_params_data = xr.Dataset(
         data_vars={
-            "pressure": ("time2", np.arange(50)),
-            "salinity": ("time2", np.arange(50)),
-            "temperature": ("time2", np.arange(50)),
+            "pressure": ("time3", np.arange(50)),
+            "salinity": ("time3", np.arange(50)),
+            "temperature": ("time3", np.arange(50)),
         },
         coords={
-            "time2": np.arange("2017-06-20T01:00", "2017-06-20T01:25", np.timedelta64(30, "s"), dtype="datetime64[ns]")
+            "time3": np.arange("2017-06-20T01:00", "2017-06-20T01:25", np.timedelta64(30, "s"), dtype="datetime64[ns]")
         }
     )
     env_params = EnvParams(env_params_data, "stationary")

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -391,7 +391,7 @@ def test_env_params(ek60_path):
     }
     for var, values in known_values.items():
         for time, value in values.items():
-            assert np.isclose(converted_env_params[var].sel(time2=time), value)
+            assert np.isclose(converted_env_params[var].sel(ping_time=time), value)
 
     # mobile
     rng = np.random.default_rng(0)

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -130,7 +130,7 @@ def test_compute_Sv_azfp(azfp_path):
     # Calibrate using identical env params as in Matlab ParametersAZFP.m
     # AZFP Matlab code uses average temperature
     avg_temperature = (
-        echodata.environment['temperature'].mean('ping_time').values
+        echodata.environment['temperature'].mean('time1').values
     )
     env_params = {
         'temperature': avg_temperature,
@@ -335,12 +335,12 @@ def test_env_params(ek60_path):
     # values after 1:25 will be extrapolated
     env_params_data = xr.Dataset(
         data_vars={
-            "pressure": ("ping_time", np.arange(50)),
-            "salinity": ("ping_time", np.arange(50)),
-            "temperature": ("ping_time", np.arange(50)),
+            "pressure": ("time2", np.arange(50)),
+            "salinity": ("time2", np.arange(50)),
+            "temperature": ("time2", np.arange(50)),
         },
         coords={
-            "ping_time": np.arange("2017-06-20T01:00", "2017-06-20T01:25", np.timedelta64(30, "s"), dtype="datetime64[ns]")
+            "time2": np.arange("2017-06-20T01:00", "2017-06-20T01:25", np.timedelta64(30, "s"), dtype="datetime64[ns]")
         }
     )
     env_params = EnvParams(env_params_data, "stationary")
@@ -391,7 +391,7 @@ def test_env_params(ek60_path):
     }
     for var, values in known_values.items():
         for time, value in values.items():
-            assert np.isclose(converted_env_params[var].sel(ping_time=time), value)
+            assert np.isclose(converted_env_params[var].sel(time2=time), value)
 
     # mobile
     rng = np.random.default_rng(0)

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -43,17 +43,17 @@ def check_env_xml(echodata):
     }
     for env_var, expected_env_var_values in env_vars.items():
         assert env_var in echodata["Environment"]
-        assert echodata["Environment"][env_var].dims == ("environment_time",)
+        assert echodata["Environment"][env_var].dims == ("time1",)
         assert all([env_var_value in expected_env_var_values for env_var_value in echodata["Environment"][env_var]])
     assert "transducer_sound_speed" in echodata["Environment"]
-    assert echodata["Environment"]["transducer_sound_speed"].dims == ("environment_time",)
+    assert echodata["Environment"]["transducer_sound_speed"].dims == ("time1",)
     assert (1480 <= echodata["Environment"]["transducer_sound_speed"]).all() and (echodata["Environment"]["transducer_sound_speed"] <= 1500).all()
     assert "sound_velocity_profile" in echodata["Environment"]
-    assert echodata["Environment"]["sound_velocity_profile"].dims == ("environment_time", "sound_velocity_profile_depth")
+    assert echodata["Environment"]["sound_velocity_profile"].dims == ("time1", "sound_velocity_profile_depth")
     assert (1470 <= echodata["Environment"]["sound_velocity_profile"]).all() and (echodata["Environment"]["sound_velocity_profile"] <= 1500).all()
 
     # check env dims
-    assert "environment_time" in echodata["Environment"]
+    assert "time1" in echodata["Environment"]
     assert "sound_velocity_profile_depth"
     assert np.array_equal(echodata["Environment"]["sound_velocity_profile_depth"], [1, 1000])
 

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -384,17 +384,17 @@ def test_compute_range(compute_range_samples):
     stationary_env_params = EnvParams(
         xr.Dataset(
             data_vars={
-                "pressure": ("time2", np.arange(50)),
-                "salinity": ("time2", np.arange(50)),
-                "temperature": ("time2", np.arange(50)),
+                "pressure": ("time3", np.arange(50)),
+                "salinity": ("time3", np.arange(50)),
+                "temperature": ("time3", np.arange(50)),
             },
             coords={
-                "time2": np.arange("2017-06-20T01:00", "2017-06-20T01:25", np.timedelta64(30, "s"), dtype="datetime64[ns]")
+                "time3": np.arange("2017-06-20T01:00", "2017-06-20T01:25", np.timedelta64(30, "s"), dtype="datetime64[ns]")
             }
         ),
         data_kind="stationary"
     )
-    if "time2" in ed.platform and sonar_model != "AD2CP":
+    if "time3" in ed.platform and sonar_model != "AD2CP":
         ed.compute_range(stationary_env_params, azfp_cal_type, ek_waveform_mode)
     else:
         try:

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -250,7 +250,7 @@ class TestEchoData:
             ├── Platform: contains information about the platform on which the sonar is installed.
             │   └── NMEA: contains information specific to the NMEA protocol.
             ├── Provenance: contains metadata about how the SONAR-netCDF4 version of the data were obtained.
-            ├── Sonar: contains specific metadata for the sonar system.
+            ├── Sonar: contains sonar system metadata and sonar beam groups.
             │   └── Beam_group1: contains backscatter data (either complex samples or uncalibrated power samples) and other beam or channel-specific data, including split-beam angle data when they exist.
             └── Vendor specific: contains vendor-specific information about the sonar and the data."""
         )
@@ -384,17 +384,17 @@ def test_compute_range(compute_range_samples):
     stationary_env_params = EnvParams(
         xr.Dataset(
             data_vars={
-                "pressure": ("ping_time", np.arange(50)),
-                "salinity": ("ping_time", np.arange(50)),
-                "temperature": ("ping_time", np.arange(50)),
+                "pressure": ("time2", np.arange(50)),
+                "salinity": ("time2", np.arange(50)),
+                "temperature": ("time2", np.arange(50)),
             },
             coords={
-                "ping_time": np.arange("2017-06-20T01:00", "2017-06-20T01:25", np.timedelta64(30, "s"), dtype="datetime64[ns]")
+                "time2": np.arange("2017-06-20T01:00", "2017-06-20T01:25", np.timedelta64(30, "s"), dtype="datetime64[ns]")
             }
         ),
         data_kind="stationary"
     )
-    if "ping_time" in ed.platform and sonar_model != "AD2CP":
+    if "time2" in ed.platform and sonar_model != "AD2CP":
         ed.compute_range(stationary_env_params, azfp_cal_type, ek_waveform_mode)
     else:
         try:

--- a/echopype/tests/preprocess/test_preprocess.py
+++ b/echopype/tests/preprocess/test_preprocess.py
@@ -393,7 +393,7 @@ def test_preprocess_mvbs(test_data_samples):
     ed = ep.open_raw(filepath, sonar_model, azfp_xml_path)
     if ed.sonar_model.lower() == 'azfp':
         avg_temperature = (
-            ed.environment['temperature'].mean('ping_time').values
+            ed.environment['temperature'].mean('time1').values
         )
         env_params = {
             'temperature': avg_temperature,

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -105,7 +105,7 @@ def test_plot_multi_get_range(
     ed = echopype.open_raw(filepath, sonar_model, azfp_xml_path)
     if ed.sonar_model.lower() == 'azfp':
         avg_temperature = (
-            ed.environment['temperature'].mean('ping_time').values
+            ed.environment['temperature'].mean('time1').values
         )
         env_params = {
             'temperature': avg_temperature,
@@ -143,7 +143,7 @@ def test_plot_Sv(
     ed = echopype.open_raw(filepath, sonar_model, azfp_xml_path)
     if ed.sonar_model.lower() == 'azfp':
         avg_temperature = (
-            ed.environment['temperature'].mean('ping_time').values
+            ed.environment['temperature'].mean('time1').values
         )
         env_params = {
             'temperature': avg_temperature,
@@ -170,7 +170,7 @@ def test_plot_mvbs(
     ed = echopype.open_raw(filepath, sonar_model, azfp_xml_path)
     if ed.sonar_model.lower() == 'azfp':
         avg_temperature = (
-            ed.environment['temperature'].mean('ping_time').values
+            ed.environment['temperature'].mean('time1').values
         )
         env_params = {
             'temperature': avg_temperature,
@@ -242,7 +242,7 @@ def test_water_level_echodata(water_level, expect_warning):
             original_array = (
                 single_array
                 + echodata.platform.water_level.sel(channel='GPT  18 kHz 009072058c8d 1-1 ES18-11',
-                                                    ping_time='2017-07-19T21:13:47.984999936').values
+                                                    time3='2017-07-19T21:13:47.984999936').values
             )
         else:
             original_array = single_array
@@ -275,7 +275,8 @@ def test_water_level_echodata(water_level, expect_warning):
     if isinstance(results, xr.DataArray):
         final_array = results.sel(channel='GPT  18 kHz 009072058c8d 1-1 ES18-11',
                                   ping_time='2017-07-19T21:13:47.984999936').values
-
+        print(f"original_array = {original_array}")
+        print(f"results = {results}")
         assert np.array_equal(original_array, final_array)
 
 

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -27,6 +27,7 @@ DEFAULT_ENCODINGS = {
     "ping_time_echosounder_raw_transmit": DEFAULT_TIME_ENCODING,
     "time1": DEFAULT_TIME_ENCODING,
     "time2": DEFAULT_TIME_ENCODING,
+    "time3": DEFAULT_TIME_ENCODING,
 }
 
 

--- a/echopype/visualize/api.py
+++ b/echopype/visualize/api.py
@@ -196,7 +196,7 @@ def _add_water_level(
                     isinstance(platform_data, xr.Dataset)
                     and 'water_level' in platform_data
                 ):
-                    return range_in_meter + platform_data.water_level
+                    return range_in_meter + platform_data.water_level.rename({'time3': 'ping_time'})
                 else:
                     warnings.warn(
                         "Boolean type found for water level. Please provide platform data with water level in it or provide a separate water level data."  # noqa
@@ -206,6 +206,11 @@ def _add_water_level(
         return range_in_meter
     if isinstance(water_level, xr.DataArray):
         check_dims = range_in_meter.dims
+
+        # rename time3 to ping_time because range_in_meter is in ping_time
+        if 'time3' in water_level:
+            water_level = water_level.rename({'time3': 'ping_time'})
+
         if not any(
             True if d in water_level.dims else False for d in check_dims
         ):

--- a/echopype/visualize/api.py
+++ b/echopype/visualize/api.py
@@ -184,6 +184,7 @@ def _add_water_level(
     data_type: str,
     platform_data: Optional[xr.Dataset] = None,
 ) -> xr.DataArray:
+    # Below, we rename time3 to ping_time because range_in_meter is in ping_time
     if isinstance(water_level, bool):
         if water_level is True:
             if data_type == xr.Dataset:
@@ -206,8 +207,6 @@ def _add_water_level(
         return range_in_meter
     if isinstance(water_level, xr.DataArray):
         check_dims = range_in_meter.dims
-
-        # rename time3 to ping_time because range_in_meter is in ping_time
         if 'time3' in water_level:
             water_level = water_level.rename({'time3': 'ping_time'})
 


### PR DESCRIPTION
In this PR I address #656, which brings more consistency to the names of the time coordinates for the `Platform` and `Environment` groups. Specifically, the following changes were made. 

* Platform 
    * Let `time1.comment = "Time coordinate corresponding to GPS location."`
        * Note: AZFP does not have a `time1` 
    * Let `time2.comment = “Time coordinate corresponding to platform sensors.”`
    * Let `time3.comment = “Time coordinate corresponding to environmental variables.”`
        * For EK80 `time3.comment = “Time coordinate corresponding to environmental variables. Note that Platform.time3 is the same as Environment.time1”`
        * Note: AZFP does not have a `time3`
    * For EK60 `ping_time` was changed to `time2` for the variables `pitch/roll/vertical_offset`. The variable `time3` was created (the values are identical to `time2`) and `ping_time` was changed to `time3` for the variable `water_level`.
    * For AZFP `ping_time` was changed to `time2` 
* Environment
    * Let `time1.comment = “Time coordinate corresponding to environmental variables.”`
        * For EK80 `time1.comment = “Time coordinate corresponding to environmental variables. Note that Platform.time3 is the same as Environment.time1”`
    * For EK60 changed `ping_time` to `time1`
    * For EK80 defined time1 as `self.parser_obj.environment["timestamp"]`, if it exists and NaT, if it doesn’t. Then replaced `ping_time` and `environment_time` with `time1` 
    * For AZFP changed `ping_time` to `time1`
* Platform/NMEA 
    * Let `Platform/NMEA.time1.comment = "Time coordinate corresponding to GPS location."`
    * Note: the values of `Platform/NMEA.time1` will be changed in a different PR
* Added `"time3": DEFAULT_TIME_ENCODING` to `​​DEFAULT_ENCODINGS`
* Rename `time1` to `ping_time` in `get_env_params` for all calibration routines and modify associated tests. Additionally, renamed `time3` to `ping_time` at the end of the function `_apply` in `calibrate_base.py`. 


IMPORTANT NOTE: Since we changed some of the time names in the `Platform` and `Environment` groups, this caused some conflicts in the calibration routines, the `compute_range` function in `EchoData`, and the visualize api function `_add_water_level`. This is because in these routines we are often adding together variables from the beam groups (which use `ping_time`) and  variables from the `Platform`/`Environment` groups (which use either `time1` or `time3`). Since `ping_time` is a required dimension for the beam groups (in the convention), I thought it best to not change its name and rather account for this difference in downstream routines. 
