### PR TITLE
Change src_filenames string attribute to source_filenames list-of-strings variable

### DIFF
--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -3,7 +3,7 @@ import warnings
 import xarray as xr
 
 from ..echodata import EchoData
-from ..utils.prov import echopype_prov_attrs
+from ..utils.prov import echopype_prov_attrs, source_files_vars
 from .calibrate_azfp import CalibrateAZFP
 from .calibrate_ek import CalibrateEK60, CalibrateEK80
 
@@ -91,7 +91,9 @@ def _compute_cal(
         source_file = echodata.converted_raw_path
     else:
         source_file = "SOURCE FILE NOT IDENTIFIED"
-    prov_dict = echopype_prov_attrs(process_type="processing", source_files=source_file)
+
+    cal_ds["source_filenames"] = source_files_vars(source_file)["source_filenames"]
+    prov_dict = echopype_prov_attrs(process_type="processing")
     prov_dict["processing_function"] = f"calibrate.compute_{cal_type}"
     cal_ds = cal_ds.assign_attrs(prov_dict)
 

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -7,7 +7,7 @@ import xarray as xr
 
 from ..echodata.convention import sonarnetcdf_1
 from ..utils.coding import COMPRESSION_SETTINGS, set_encodings
-from ..utils.prov import echopype_prov_attrs
+from ..utils.prov import echopype_prov_attrs, source_files_vars
 
 DEFAULT_CHUNK_SIZE = {"range_sample": 25000, "ping_time": 2500}
 
@@ -73,8 +73,8 @@ class SetGroupsBase(abc.ABC):
 
     def set_provenance(self) -> xr.Dataset:
         """Set the Provenance group."""
-        prov_dict = echopype_prov_attrs(process_type="conversion", source_files=self.input_file)
-        ds = xr.Dataset()
+        prov_dict = echopype_prov_attrs(process_type="conversion")
+        ds = xr.Dataset(source_files_vars(self.input_file))
         ds = ds.assign_attrs(prov_dict)
         return ds
 

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -5,7 +5,7 @@ import numpy as np
 import xarray as xr
 
 from ..utils.coding import set_encodings
-from ..utils.prov import echopype_prov_attrs
+from ..utils.prov import echopype_prov_attrs, source_files_vars
 
 # fmt: off
 from .set_groups_base import DEFAULT_CHUNK_SIZE, SetGroupsBase
@@ -108,12 +108,18 @@ class SetGroupsEK60(SetGroupsBase):
 
     def set_provenance(self) -> xr.Dataset:
         """Set the Provenance group."""
-        prov_dict = echopype_prov_attrs(process_type="conversion", source_files=self.input_file)
+        prov_dict = echopype_prov_attrs(process_type="conversion")
         prov_dict["duplicate_ping_times"] = 1 if self.old_ping_time is not None else 0
+        source_files = source_files_vars(self.input_file)
         if self.old_ping_time is not None:
-            ds = xr.Dataset(data_vars={"old_ping_time": self.old_ping_time})
+            ds = xr.Dataset(
+                data_vars={
+                    "old_ping_time": self.old_ping_time,
+                    **source_files,
+                }
+            )
         else:
-            ds = xr.Dataset()
+            ds = xr.Dataset(data_vars=source_files)
         ds = ds.assign_attrs(prov_dict)
         return ds
 

--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -7,7 +7,7 @@ import xarray as xr
 from ..core import SONAR_MODELS
 from ..qc import coerce_increasing_time, exist_reversed_time
 from ..utils.coding import set_encodings
-from ..utils.prov import echopype_prov_attrs
+from ..utils.prov import echopype_prov_attrs, source_files_vars
 from .echodata import EchoData
 
 
@@ -24,11 +24,8 @@ def union_attrs(datasets: List[xr.Dataset]) -> Dict[str, Any]:
 
 
 def assemble_combined_provenance(input_paths):
-    input_paths = [str(p) for p in input_paths]
     return xr.Dataset(
-        data_vars={
-            "src_filenames": ("file", input_paths),
-        },
+        data_vars=source_files_vars(input_paths),
         attrs=echopype_prov_attrs(process_type="conversion"),
     )
 

--- a/echopype/preprocess/api.py
+++ b/echopype/preprocess/api.py
@@ -148,7 +148,7 @@ def compute_MVBS(ds_Sv, range_meter_bin=20, ping_time_bin="20S"):
         }
     )
 
-    prov_dict = echopype_prov_attrs(process_type="processing", source_files=None)
+    prov_dict = echopype_prov_attrs(process_type="processing")
     prov_dict["processing_function"] = "preprocess.compute_MVBS"
     ds_MVBS = ds_MVBS.assign_attrs(prov_dict)
 
@@ -218,7 +218,7 @@ def compute_MVBS_index_binning(ds_Sv, range_sample_num=100, ping_num=100):
         }
     )
 
-    prov_dict = echopype_prov_attrs(process_type="processing", source_files=None)
+    prov_dict = echopype_prov_attrs(process_type="processing")
     prov_dict["processing_function"] = "preprocess.compute_MVBS_index_binning"
     ds_MVBS = ds_MVBS.assign_attrs(prov_dict)
 
@@ -284,7 +284,7 @@ def remove_noise(ds_Sv, ping_num, range_sample_num, noise_max=None, SNR_threshol
     noise_obj.remove_noise(noise_max=noise_max, SNR_threshold=SNR_threshold)
     ds_Sv = noise_obj.ds_Sv
 
-    prov_dict = echopype_prov_attrs(process_type="processing", source_files=None)
+    prov_dict = echopype_prov_attrs(process_type="processing")
     prov_dict["processing_function"] = "preprocess.remove_noise"
     ds_Sv = ds_Sv.assign_attrs(prov_dict)
 

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -250,7 +250,7 @@ class TestEchoData:
             ├── Platform: contains information about the platform on which the sonar is installed.
             │   └── NMEA: contains information specific to the NMEA protocol.
             ├── Provenance: contains metadata about how the SONAR-netCDF4 version of the data were obtained.
-            ├── Sonar: contains specific metadata for the sonar system.
+            ├── Sonar: contains sonar system metadata and sonar beam groups.
             │   └── Beam_group1: contains backscatter data (either complex samples or uncalibrated power samples) and other beam or channel-specific data, including split-beam angle data when they exist.
             └── Vendor specific: contains vendor-specific information about the sonar and the data."""
         )

--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -1,5 +1,5 @@
 from datetime import datetime as dt
-from typing import Dict, List, Tuple, Any, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from _echopype_version import version as ECHOPYPE_VERSION
 from typing_extensions import Literal

--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -1,5 +1,5 @@
 from datetime import datetime as dt
-from typing import Dict
+from typing import Dict, List, Any
 
 from _echopype_version import version as ECHOPYPE_VERSION
 from typing_extensions import Literal
@@ -29,3 +29,29 @@ def echopype_prov_attrs(process_type: ProcessType, source_files: str = None) -> 
         prov_dict["src_filenames"] = source_files
 
     return prov_dict
+
+
+def source_files_vars(source_paths: List[str]) -> Dict[str, Any]:
+    """
+    Create source_filenames provenance variable dict to be used for creating
+    xarray dataarray.
+
+    Parameters
+    ----------
+    source_paths: List[str]
+        (explain what this is)
+
+    Returns
+    -------
+    source_files_var
+        (explain what this is)
+    """
+    source_files_var = {
+        "source_filenames": (
+            "filenames",
+            [str(p) for p in source_paths],
+            {"long_name": "Source filenames"},
+        ),
+    }
+
+    return source_files_var

--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -1,5 +1,5 @@
 from datetime import datetime as dt
-from typing import Dict, List, Any
+from typing import Dict, List, Tuple, Any, Union
 
 from _echopype_version import version as ECHOPYPE_VERSION
 from typing_extensions import Literal
@@ -7,7 +7,7 @@ from typing_extensions import Literal
 ProcessType = Literal["conversion", "processing"]
 
 
-def echopype_prov_attrs(process_type: ProcessType, source_files: str = None) -> Dict[str, str]:
+def echopype_prov_attrs(process_type: ProcessType) -> Dict[str, str]:
     """
     Standard echopype software attributes for provenance
 
@@ -15,41 +15,43 @@ def echopype_prov_attrs(process_type: ProcessType, source_files: str = None) -> 
     ----------
     process_type : ProcessType
         Echopype process function type
-    source_files: str
-        Source file path. A list of files is not currently supported
     """
     prov_dict = {
         f"{process_type}_software_name": "echopype",
         f"{process_type}_software_version": ECHOPYPE_VERSION,
         f"{process_type}_time": dt.utcnow().isoformat(timespec="seconds") + "Z",  # use UTC time
     }
-    if source_files:
-        # TODO: src_filenames will be replaced with a new variable, source_filenames
-        #   Also, come to think of it, source files is not "echopype provenance" info per se
-        prov_dict["src_filenames"] = source_files
 
     return prov_dict
 
 
-def source_files_vars(source_paths: List[str]) -> Dict[str, Any]:
+def source_files_vars(source_paths: Union[str, List[Any]]) -> Dict[str, Tuple]:
     """
     Create source_filenames provenance variable dict to be used for creating
     xarray dataarray.
 
     Parameters
     ----------
-    source_paths: List[str]
-        (explain what this is)
+    source_paths: Union[str, List[Any]]
+        Source file paths as either a single path string or a list of Path-type paths
 
     Returns
     -------
-    source_files_var
-        (explain what this is)
+    source_files_var: Dict[str, Tuple]
+        Single-element dict containing a tuple for creating the
+        source_filenames xarray dataarray with filenames dimension
     """
+
+    # Handle both a list of pathlib paths and a plain string containing a single path
+    if type(source_paths) is str:
+        source_files = [source_paths]
+    else:
+        source_files = [str(p) for p in source_paths]
+
     source_files_var = {
         "source_filenames": (
             "filenames",
-            [str(p) for p in source_paths],
+            source_files,
             {"long_name": "Source filenames"},
         ),
     }


### PR DESCRIPTION
Closes #620. Implemented using a new prov.py function, `source_files_vars`, that is reused wherever the `source_filenames` variable is needed, including in `assemble_combined_provenance` where it already existed. Addresses convention adherence.