### PR TITLE
Squeeze and drop the redundant `beam` dimension in calibration outputs

### DIFF
--- a/echopype/calibrate/calibrate_azfp.py
+++ b/echopype/calibrate/calibrate_azfp.py
@@ -117,7 +117,7 @@ class CalibrateAZFP(CalibrateBase):
         a = self.cal_params["DS"]
         EL = (
             self.cal_params["EL"] - 2.5 / a + self.echodata.beam.backscatter_r / (26214 * a)
-        )  # eq.(5)
+        )  # eq.(5)  # has beam dim due to backscatter_r
 
         if cal_type == "Sv":
             # eq.(9)
@@ -154,7 +154,9 @@ class CalibrateAZFP(CalibrateBase):
         # Add env and cal parameters
         out = self._add_params_to_output(out)
 
-        return out
+        # Squeeze out the beam dim
+        # doing it here because both out and self.cal_params["equivalent_beam_angle"] has beam dim
+        return out.squeeze("beam", drop=True)
 
     def compute_Sv(self, **kwargs):
         return self._cal_power(cal_type="Sv")

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -752,7 +752,12 @@ class CalibrateEK80(CalibrateEK):
 
         # Derived params
         # TODO: right now squeeze out the single ping_time dimension
-        #       need to properly align based on actual time
+        #  Need to properly align based on actual time
+        #  This ping_time is actually renamed from time1 in Environment group,
+        #  so that in the computation of range_meter it can be aligned with echo data easily.
+        #  This however makes this part of code less traceable,
+        #  since the ping_time here does not come from the "pings"
+        #  Will resolve later.
         sound_speed = self.env_params["sound_speed"].squeeze(drop=True)
         absorption = self.env_params["sound_absorption"].sel(channel=chan_sel).squeeze(drop=True)
         range_meter = self.range_meter.sel(channel=chan_sel)

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -181,7 +181,7 @@ class CalibrateEK(CalibrateBase):
             CSv = (
                 10 * np.log10(beam["transmit_power"])
                 + 2 * self.cal_params["gain_correction"]
-                + self.cal_params["equivalent_beam_angle"]
+                + self.cal_params["equivalent_beam_angle"]  # has beam dim
                 + 10
                 * np.log10(
                     wavelength**2
@@ -193,10 +193,10 @@ class CalibrateEK(CalibrateBase):
 
             # Calibration and echo integration
             out = (
-                beam["backscatter_r"]
+                beam["backscatter_r"]  # has beam dim
                 + spreading_loss
                 + absorption_loss
-                - CSv
+                - CSv  # has beam dim
                 - 2 * self.cal_params["sa_correction"]
             )
             out.name = "Sv"
@@ -223,7 +223,9 @@ class CalibrateEK(CalibrateBase):
         # Add env and cal parameters
         out = self._add_params_to_output(out)
 
-        return out
+        # Squeeze out the beam dim
+        # doing it here because both out and self.cal_params["equivalent_beam_angle"] has beam dim
+        return out.squeeze("beam", drop=True)
 
 
 class CalibrateEK60(CalibrateEK):

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -160,8 +160,7 @@ def test_compute_Sv_azfp(azfp_path):
                 == ds_base['Output'][0]['Range'][fidx]
             )
             assert np.allclose(
-                ds_cmp[cal_type_in_ds_cmp[cal_type]]
-                .isel(channel=fidx, beam=0).drop('beam').values,
+                ds_cmp[cal_type_in_ds_cmp[cal_type]].isel(channel=fidx).values,
                 ds_base['Output'][0][cal_type][fidx],
                 atol=1e-13,
                 rtol=0,

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -68,9 +68,10 @@ def test_compute_Sv_ek60_echoview(ek60_path):
     test_Sv = np.stack(channels)
 
     # Echoview data is shifted by 1 sample along range (missing the first sample)
+    # TODO: resolve: pydevd warning: Computing repr of channels (list) was slow (took 0.29s)
     assert np.allclose(
         test_Sv[:, :, 7:],
-        ds_Sv.Sv.isel(ping_time=slice(None, 10), range_sample=slice(8, None), beam=0),
+        ds_Sv.Sv.isel(ping_time=slice(None, 10), range_sample=slice(8, None)),
         atol=1e-8
     )
 


### PR DESCRIPTION
This PR closes #644.

I'm taking the approach to just squeeze and drop the redundant `beam` dimension at the end of the calibration operations. There may be efficiency advantage to take care of this extra dimension earlier in the computation, but let's delay this part to post-v0.6.0.

I've also noted the variables that have the redundant `beam` dimension (as comments) as I go through to make this change.

## Tasks
- [x] Squeeze out `beam` from `CalibrateEK._cal_power()`
- [x] Squeeze out `beam` from `CalibrateEK._cal_complex()`
- [x] Squeeze out `beam` from `CalibrateAZFP._cal_power()`
- [x] Fix all calibration tests