### PR TITLE
Modify `combine_echodata` check for reversed time coordinates

### DIFF
--- a/echopype/core.py
+++ b/echopype/core.py
@@ -45,7 +45,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "parser": ParseAZFP,
         "set_groups": SetGroupsAZFP,
         "concat_dims": {
-            "platform": None,
+            "platform": "time2",
             "nmea": "time1",
             "vendor": ["ping_time", "channel"],
             "default": "ping_time",
@@ -61,7 +61,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "parser": ParseEK60,
         "set_groups": SetGroupsEK60,
         "concat_dims": {
-            "platform": ["time1", "ping_time"],
+            "platform": ["time1", "time2", "time3"],
             "nmea": "time1",
             "vendor": None,
             "default": "ping_time",
@@ -76,7 +76,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "parser": ParseEK60,
         "set_groups": SetGroupsEK60,
         "concat_dims": {
-            "platform": ["time1", "ping_time"],
+            "platform": ["time1", "time2", "time3"],
             "nmea": "time1",
             "vendor": None,
             "default": "ping_time",
@@ -91,7 +91,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "parser": ParseEK80,
         "set_groups": SetGroupsEK80,
         "concat_dims": {
-            "platform": ["time1", "time2"],
+            "platform": ["time1", "time2", "time3"],
             "nmea": "time1",
             "vendor": None,
             "default": "ping_time",
@@ -106,7 +106,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "parser": ParseEK80,
         "set_groups": SetGroupsEK80,
         "concat_dims": {
-            "platform": ["time1", "time2"],
+            "platform": ["time1", "time2", "time3"],
             "nmea": "time1",
             "vendor": None,
             "default": "ping_time",
@@ -121,7 +121,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "parser": ParseEK80,
         "set_groups": SetGroupsEK80,
         "concat_dims": {
-            "platform": ["time1", "time2"],
+            "platform": ["time1", "time2", "time3"],
             "nmea": "time1",
             "vendor": None,
             "default": "ping_time",

--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -225,7 +225,7 @@ def combine_echodata(echodatas: List[EchoData], combine_attrs="override") -> Ech
                     # TODO: investigate further why we need to do .astype("<U50")
                     combined_group["channel"] = combined_group["channel"].astype("<U50")
 
-            if sonar_model in ("EK60", "EK80", "AZFP"):
+            if sonar_model != "AD2CP":
 
                 combined_group, old_ping_time, new_ping_time = check_and_correct_reversed_time(
                     combined_group, old_ping_time, new_ping_time, "ping_time", sonar_model

--- a/echopype/tests/echodata/test_echodata_combine.py
+++ b/echopype/tests/echodata/test_echodata_combine.py
@@ -144,6 +144,8 @@ def test_combine_echodata(raw_datasets):
                 "ping_time",
                 "old_time1",
                 "time1",
+                "old_time2",
+                "time2",
             ],
             errors="ignore",
         ).drop_dims(
@@ -156,6 +158,8 @@ def test_combine_echodata(raw_datasets):
                     "ping_time",
                     "old_time1",
                     "time1",
+                    "old_time2",
+                    "time2",
                 ],
                 errors="ignore",
             )


### PR DESCRIPTION
While looking into `ep.combine_echodata`, I noticed that we do not test for reversed time coordinates for all sensors and all times. This PR solves this. Specifically, the following items were completed. 

- For EK80, EK60, and AZFP I make it so that we check for reversed time coordinates for all groups (besides `Top-level`, `Sonar`, `Provenance`, and `Platform/NMEA`) and correct them if necessary. 
- Additionally, I made slight modifications to the `concat_dims` in `core.py` for each sensor. While creating consistent time coordinates, these were not modified, but they should have been. The modifications include: 
    - For AZFP
        - added `time2` to the `platform` key
    - For EK60/ES70
        - changed `ping_time` to `time2` for the `platform` key
        - added `time3` to the `platform` key
    - For EK80/ES80/EA640
        - added `time3` to the `platform` key
