### PR TITLE
🛠️ Fix `combine_echodata` to result in a working echodata object

### DIFF
--- a/echopype/tests/echodata/test_echodata_combine.py
+++ b/echopype/tests/echodata/test_echodata_combine.py
@@ -1,4 +1,5 @@
 from typing import Any, List, Dict
+from textwrap import dedent
 from pathlib import Path
 
 import numpy as np
@@ -280,3 +281,25 @@ def test_combined_encodings(ek60_test_data):
         all_messages = ['Encoding mismatch found!'] + group_checks
         message_text = '\n'.join(all_messages)
         raise AssertionError(message_text)
+
+
+def test_combined_echodata_repr(ek60_test_data):
+    eds = [echopype.open_raw(file, "EK60") for file in ek60_test_data]
+    combined = echopype.combine_echodata(eds, "overwrite_conflicts")  # type: ignore
+    expected_repr = dedent(
+        """\
+        <EchoData: standardized raw data from Internal Memory>
+        Top-level: contains metadata about the SONAR-netCDF4 file format.
+        ├── Environment: contains information relevant to acoustic propagation through water.
+        ├── Platform: contains information about the platform on which the sonar is installed.
+        │   └── NMEA: contains information specific to the NMEA protocol.
+        ├── Provenance: contains metadata about how the SONAR-netCDF4 version of the data were obtained.
+        ├── Sonar: contains sonar system metadata and sonar beam groups.
+        │   └── Beam_group1: contains backscatter data (either complex samples or uncalibrated power samples) and other beam or channel-specific data, including split-beam angle data when they exist.
+        └── Vendor_specific: contains vendor-specific information about the sonar and the data."""
+    )
+
+    assert isinstance(repr(combined), str) is True
+
+    actual = "\n".join(x.rstrip() for x in repr(combined).split("\n"))
+    assert actual == expected_repr


### PR DESCRIPTION
This PR fixes #676. `combine_echodata` will now create the proper echodata object with an internal DataTree object.