### PR TITLE
Consistent use of Sonar.sonar_model attribute, also consistent with echodata.sonar_model

### DIFF
--- a/echopype/convert/set_groups_ad2cp.py
+++ b/echopype/convert/set_groups_ad2cp.py
@@ -378,10 +378,10 @@ class SetGroupsAd2cp(SetGroupsBase):
         beam_groups_vars, beam_groups_coord = self._beam_groups_vars()
         ds = xr.Dataset(beam_groups_vars, coords=beam_groups_coord)
 
-        # Assemble sonar group dictionary
-        sonar_dict = {
+        # Assemble sonar group global attribute dictionary
+        sonar_attr_dict = {
             "sonar_manufacturer": "Nortek",
-            "sonar_model": "AD2CP",
+            "sonar_model": self.sonar_model,
             "sonar_serial_number": "",
             "sonar_software_name": "",
             "sonar_software_version": "",
@@ -389,13 +389,13 @@ class SetGroupsAd2cp(SetGroupsBase):
             "sonar_type": "acoustic Doppler current profiler (ADCP)",
         }
         if "serial_number" in self.ds:
-            sonar_dict["sonar_serial_number"] = int(self.ds["serial_number"].data[0])
+            sonar_attr_dict["sonar_serial_number"] = int(self.ds["serial_number"].data[0])
         firmware_version = self.parser_obj.get_firmware_version()
         if firmware_version is not None:
-            sonar_dict["sonar_firmware_version"] = ", ".join(
+            sonar_attr_dict["sonar_firmware_version"] = ", ".join(
                 [f"{k}:{v}" for k, v in firmware_version.items()]
             )
 
-        ds = ds.assign_attrs(sonar_dict)
+        ds = ds.assign_attrs(sonar_attr_dict)
 
         return ds

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -73,16 +73,16 @@ class SetGroupsAZFP(SetGroupsBase):
         beam_groups_vars, beam_groups_coord = self._beam_groups_vars()
         ds = xr.Dataset(beam_groups_vars, coords=beam_groups_coord)
 
-        # Assemble sonar group dictionary
-        sonar_dict = {
+        # Assemble sonar group global attribute dictionary
+        sonar_attr_dict = {
             "sonar_manufacturer": "ASL Environmental Sciences",
-            "sonar_model": "Acoustic Zooplankton Fish Profiler",
+            "sonar_model": self.sonar_model,
             "sonar_serial_number": int(self.parser_obj.unpacked_data["serial_number"]),
             "sonar_software_name": "Based on AZFP Matlab Toolbox",
             "sonar_software_version": "1.4",
             "sonar_type": "echosounder",
         }
-        ds = ds.assign_attrs(sonar_dict)
+        ds = ds.assign_attrs(sonar_attr_dict)
 
         return ds
 

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -193,18 +193,18 @@ class SetGroupsEK60(SetGroupsBase):
         beam_groups_vars, beam_groups_coord = self._beam_groups_vars()
         ds = xr.Dataset(beam_groups_vars, coords=beam_groups_coord)
 
-        # Assemble sonar group dictionary
-        sonar_dict = {
+        # Assemble sonar group global attribute dictionary
+        sonar_attr_dict = {
             "sonar_manufacturer": "Simrad",
-            "sonar_model": self.parser_obj.config_datagram["sounder_name"],
+            "sonar_model": self.sonar_model,
             # transducer (sonar) serial number is not stored in the EK60 raw data file,
             # so sonar_serial_number can't be populated from the raw datagrams
             "sonar_serial_number": "",
-            "sonar_software_name": "",
+            "sonar_software_name":  self.parser_obj.config_datagram["sounder_name"],
             "sonar_software_version": self.parser_obj.config_datagram["version"],
             "sonar_type": "echosounder",
         }
-        ds = ds.assign_attrs(sonar_dict)
+        ds = ds.assign_attrs(sonar_attr_dict)
 
         return ds
 

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -200,7 +200,7 @@ class SetGroupsEK60(SetGroupsBase):
             # transducer (sonar) serial number is not stored in the EK60 raw data file,
             # so sonar_serial_number can't be populated from the raw datagrams
             "sonar_serial_number": "",
-            "sonar_software_name":  self.parser_obj.config_datagram["sounder_name"],
+            "sonar_software_name": self.parser_obj.config_datagram["sounder_name"],
             "sonar_software_version": self.parser_obj.config_datagram["version"],
             "sonar_type": "echosounder",
         }

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -169,7 +169,7 @@ class SetGroupsEK80(SetGroupsBase):
                 {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0},
             ),
             "serial_number": (["channel"], var["serial_number"]),
-            "sonar_model": (["channel"], var["transducer_name"]),
+            "transducer_name": (["channel"], var["transducer_name"]),
             "sonar_serial_number": (["channel"], var["channel_id_short"]),
             "sonar_software_name": (
                 ["channel"],
@@ -190,8 +190,15 @@ class SetGroupsEK80(SetGroupsBase):
                 ),
                 **beam_groups_coord,
             },
-            attrs={"sonar_manufacturer": "Simrad", "sonar_type": "echosounder"},
         )
+
+        # Assemble sonar group global attribute dictionary
+        sonar_attr_dict = {
+            "sonar_manufacturer": "Simrad",
+            "sonar_model": self.sonar_model,
+            "sonar_type": "echosounder",
+        }
+        ds = ds.assign_attrs(sonar_attr_dict)
 
         return ds
 


### PR DESCRIPTION
Addresses #681, specifically https://github.com/OSOceanAcoustics/echopype/issues/681#issuecomment-1130581845. 

- `sonar_model` is now a `Sonar` attribute for all sensors, including EK80.
- The value of that attribute is now assigned based on the echodata `sonar_model` property.
- The EK80 `Sonar.sonar_model` variable was  to `Sonar.transducer_name` (not a convention variable or attribute).

This PR also addresses #571 by setting `sonar_software_name` to `self.parser_obj.config_datagram["sounder_name"]`. This value is typically (always?) "ER60", which [is in fact the Simar sonar software name.](https://support.echoview.com/WebHelp/Reference/File_formats/Simrad_data_files.htm)