### PR TITLE
Improve selection of calibration parameters in Vender group

### DIFF
--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -79,11 +79,10 @@ class CalibrateEK(CalibrateBase):
         idxmin = np.abs(
             beam["transmit_duration_nominal"] - ds_vend["pulse_length"][relevant_indexes]
         ).idxmin(dim="pulse_length_bin")
-        idxmin = idxmin.where(
-            ~transmit_isnull, 0
-        ).astype(  # fill nan position with 0, remove before return
-            int
-        )  # convert to int for indexing
+
+        # fill nan position with 0 (witll remove before return)
+        # and convert to int for indexing
+        idxmin = idxmin.where(~transmit_isnull, 0).astype(int)
 
         # Get param dataarray into correct shape
         da_param = (

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -1,6 +1,5 @@
 import numpy as np
 import xarray as xr
-from dask.array.core import Array
 from scipy import signal
 
 from ..utils import uwa

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -78,13 +78,13 @@ class CalibrateEK(CalibrateBase):
         # by matching beam["transmit_duration_nominal"] with ds_vend["pulse_length"]
         transmit_isnull = beam["transmit_duration_nominal"].isnull()
         idxmin = np.abs(
-            beam["transmit_duration_nominal"]
-            - ds_vend["pulse_length"][relevant_indexes]
+            beam["transmit_duration_nominal"] - ds_vend["pulse_length"][relevant_indexes]
         ).idxmin(dim="pulse_length_bin")
-        idxmin = (
-            idxmin.where(~transmit_isnull, 0)  # fill nan position with 0, remove before return
-            .astype(int)  # convert to int for indexing
-        )
+        idxmin = idxmin.where(
+            ~transmit_isnull, 0
+        ).astype(  # fill nan position with 0, remove before return
+            int
+        )  # convert to int for indexing
 
         # Get param dataarray into correct shape
         da_param = (

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -51,7 +51,7 @@ class CalibrateEK(CalibrateBase):
 
         Parameters
         ----------
-        param : str
+        param : str {"sa_correction", "gain_correction"}
             name of parameter to retrieve
         """
         # TODO: need to test with EK80 power/angle data
@@ -64,22 +64,6 @@ class CalibrateEK(CalibrateBase):
         if param not in ["sa_correction", "gain_correction"]:
             raise ValueError(f"Unknown parameter {param}")
 
-        # Drop NaN ping_time for transmit_duration_nominal
-        if np.any(np.isnan(self.echodata.beam["transmit_duration_nominal"])):
-            # TODO: resolve performance warning:
-            #  /Users/wu-jung/miniconda3/envs/echopype_jan2021/lib/python3.8/site-packages/xarray/core/indexing.py:1369:
-            #  PerformanceWarning: Slicing is producing a large chunk. To accept the large
-            #  chunk and silence this warning, set the option
-            #      >>> with dask.config.set(**{'array.slicing.split_large_chunks': False}):
-            #      ...     array[indexer]
-            #  To avoid creating the large chunks, set the option
-            #      >>> with dask.config.set(**{'array.slicing.split_large_chunks': True}):
-            #      ...     array[indexer]
-            #    return self.array[key]
-            self.echodata.beam = self.echodata.beam.dropna(
-                dim="ping_time", how="any", subset=["transmit_duration_nominal"]
-            )
-
         if waveform_mode == "CW" and self.echodata.beam_power is not None:
             beam = self.echodata.beam_power
         else:
@@ -90,22 +74,18 @@ class CalibrateEK(CalibrateBase):
             np.isin(ds_vend["frequency_nominal"], beam["frequency_nominal"])
         )[0]
 
-        unique_pulse_length = np.unique(beam["transmit_duration_nominal"], axis=1)
+        # Find idx to select the corresponding param value
+        # by matching beam["transmit_duration_nominal"] with ds_vend["pulse_length"]
+        idxmin = np.abs(
+            beam["transmit_duration_nominal"]  # .isel(ping_time=slice(None,5))
+            - ds_vend["pulse_length"][relevant_indexes]
+        ).idxmin(dim="pulse_length_bin").astype(int)
 
-        pulse_length = ds_vend["pulse_length"][relevant_indexes]
-
-        # Find index with correct pulse length
-        idx_wanted = np.abs(pulse_length - unique_pulse_length).argmin(dim="pulse_length_bin")
-
-        # Checks for dask array and compute first
-        if isinstance(idx_wanted.data, Array):
-            idx_wanted = idx_wanted.data.compute()
-
-        return (
-            ds_vend[param]
-            .isel(pulse_length_bin=idx_wanted, channel=relevant_indexes)
-            .drop("pulse_length_bin")
-        )
+        da_param = ds_vend[param][relevant_indexes].expand_dims(
+            dim={"ping_time": idxmin["ping_time"]}
+        ).sortby(idxmin.channel)  # sortby in case channel sequence different in vendor and beam
+        
+        return da_param.isel(pulse_length_bin=idxmin).drop("pulse_length_bin")
 
     def get_cal_params(self, cal_params, waveform_mode, encode_mode):
         """Get cal params using user inputs or values from data file.
@@ -642,8 +622,8 @@ class CalibrateEK80(CalibrateEK):
                     else:
                         gain_temp = (
                             gain_single.sel(channel=ch_id)
-                            .assign_coords(ping_time=np.datetime64(0, "ns"))
-                            .expand_dims("ping_time")
+                            # .assign_coords(ping_time=np.datetime64(0, "ns"))
+                            # .expand_dims("ping_time")
                             .reindex_like(self.echodata.beam.backscatter_r, method="nearest")
                             .expand_dims("channel")
                         )

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -74,18 +74,27 @@ class CalibrateEK(CalibrateBase):
             np.isin(ds_vend["frequency_nominal"], beam["frequency_nominal"])
         )[0]
 
+        transmit_isnull = beam["transmit_duration_nominal"].isnull()
+
         # Find idx to select the corresponding param value
         # by matching beam["transmit_duration_nominal"] with ds_vend["pulse_length"]
         idxmin = np.abs(
             beam["transmit_duration_nominal"]  # .isel(ping_time=slice(None,5))
             - ds_vend["pulse_length"][relevant_indexes]
-        ).idxmin(dim="pulse_length_bin").astype(int)
+        ).idxmin(dim="pulse_length_bin")
+        idxmin = (
+            idxmin.where(~idxmin.isnull(), 0)  # fill nan position with 0, remove before return
+            .astype(int)  # convert to int for indexing
+        )
 
-        da_param = ds_vend[param][relevant_indexes].expand_dims(
+        # Get param dataarray into correct shape
+        da_param = ds_vend[param][relevant_indexes].expand_dims(  # expand dims for direct indexing
             dim={"ping_time": idxmin["ping_time"]}
         ).sortby(idxmin.channel)  # sortby in case channel sequence different in vendor and beam
-        
-        return da_param.isel(pulse_length_bin=idxmin).drop("pulse_length_bin")
+
+        # Select corresponding index and clean up the original nan elements
+        da_param = da_param.isel(pulse_length_bin=idxmin, drop=True)
+        return da_param.where(~transmit_isnull, np.nan)  # set the nan elements back to nan
 
     def get_cal_params(self, cal_params, waveform_mode, encode_mode):
         """Get cal params using user inputs or values from data file.

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -291,7 +291,7 @@ def test_compute_Sv_ek80_BB_complex(ek80_path):
 def test_compute_Sv_ek80_CW_power_BB_complex(ek80_path):
     """
     Tests calibration in CW mode data encoded as power samples
-    and calibration in BB mode data encoded as complex seamples,
+    and calibration in BB mode data encoded as complex samples,
     while the file contains both CW power and BB complex samples.
     """
     ek80_raw_path = ek80_path / "Summer2018--D20180905-T033113.raw"

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -188,7 +188,7 @@ def test_plot_mvbs(
         plots = echopype.visualize.create_echogram(mvbs)
     except Exception as e:
         assert isinstance(e, ValueError)
-        assert str(e) == "Ping time must be greater or equal to 2 data points."  # noqa
+        assert str(e) == "Ping time must have a length that is greater or equal to 2"  # noqa
 
     if len(plots) > 0:
         assert all(isinstance(plot, FacetGrid) for plot in plots) is True

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -21,11 +21,15 @@ param_testdata = [
         None,
         {},
     ),
-    (
+    pytest.param(
         ek60_path / "DY1002_EK60-D20100318-T023008_rep_freq.raw",
         "EK60",
         None,
-        {}
+        {},
+        marks=pytest.mark.xfail(
+            run=False,
+            reason="Repeated frequencies not supported at the moment.",
+        ),
     ),
     (
         ek80_path / "echopype-test-D20211004-T235930.raw",

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -22,6 +22,12 @@ param_testdata = [
         {},
     ),
     (
+        ek60_path / "DY1002_EK60-D20100318-T023008_rep_freq.raw",
+        "EK60",
+        None,
+        {}
+    ),
+    (
         ek80_path / "echopype-test-D20211004-T235930.raw",
         "EK80",
         None,

--- a/echopype/visualize/api.py
+++ b/echopype/visualize/api.py
@@ -10,6 +10,7 @@ from ..echodata import EchoData
 def create_echogram(
     data: Union[EchoData, xr.Dataset],
     channel: Union[str, List[str], None] = None,
+    frequency: Union[str, List[str], None] = None,
     get_range: Optional[bool] = None,
     range_kwargs: dict = {},
     water_level: Union[int, float, xr.DataArray, bool, None] = None,
@@ -24,6 +25,9 @@ def create_echogram(
     channel : str or list of str, optional
         The channel to be plotted.
         Otherwise all channels will be plotted.
+    frequency : int, float, or list of float or ints, optional
+        The frequency to be plotted.
+        Otherwise all frequency will be plotted.
     get_range : bool, optional
         Flag as to whether range (``echo_range``) should be computed or not,
         by default it will just plot `range_sample`` as the yaxis.
@@ -63,8 +67,15 @@ def create_echogram(
         'units': 'm',
     }
 
+    if channel and frequency:
+        warnings.warn(
+            "Both channel and frequency are specified. Channel filtering will be used."
+        )
+
     if isinstance(channel, list) and len(channel) == 1:
         channel = channel[0]
+    elif isinstance(frequency, list) and len(frequency) == 1:
+        frequency = frequency[0]
 
     if isinstance(data, EchoData):
         if data.sonar_model.lower() == 'ad2cp':
@@ -169,6 +180,7 @@ def create_echogram(
         yaxis=yaxis,
         variable=variable,
         channel=channel,
+        frequency=frequency,
         **kwargs,
     )
 

--- a/echopype/visualize/api.py
+++ b/echopype/visualize/api.py
@@ -74,6 +74,8 @@ def create_echogram(
         yaxis = 'range_sample'
         variable = 'backscatter_r'
         ds = data.beam
+        if 'ping_time' in ds:
+            _check_ping_time(ds.ping_time)
         if get_range is True:
             yaxis = 'echo_range'
 
@@ -140,8 +142,8 @@ def create_echogram(
             ds.echo_range.attrs = range_attrs
 
     elif isinstance(data, xr.Dataset):
-        if 'ping_time' in data and data.ping_time.shape[0] < 2:
-            raise ValueError("Ping time must be greater or equal to 2 data points.")
+        if 'ping_time' in data:
+            _check_ping_time(data.ping_time)
         variable = 'Sv'
         ds = data
         yaxis = 'echo_range'
@@ -169,6 +171,11 @@ def create_echogram(
         channel=channel,
         **kwargs,
     )
+
+
+def _check_ping_time(ping_time):
+    if ping_time.shape[0] < 2:
+        raise ValueError("Ping time must have a length that is greater or equal to 2")
 
 
 def _add_water_level(

--- a/echopype/visualize/plot.py
+++ b/echopype/visualize/plot.py
@@ -1,8 +1,6 @@
-import sys
 import warnings
 import matplotlib.pyplot as plt
 import matplotlib.cm
-import math
 import xarray as xr
 import numpy as np
 from xarray.plot.facetgrid import FacetGrid
@@ -180,11 +178,7 @@ def _plot_echogram(
         ):
             # Handle the nans for echodata and Sv
             filtered_ds = filtered_ds.sel(
-                range_sample=filtered_ds.range_sample.where(
-                    ~filtered_ds.echo_range.isel(ping_time=0).isnull()
-                )
-                .dropna(dim='range_sample')
-                .data
+                range_sample=filtered_ds.echo_range.dropna(dim='range_sample').range_sample
             )
         plot = filtered_ds.plot.pcolormesh(
             x=xaxis,
@@ -220,13 +214,7 @@ def _plot_echogram(
             ):
                 # Handle the nans for echodata and Sv
                 d = d.sel(
-                    range_sample=d.range_sample.where(
-                        ~d.echo_range.sel(channel=f.values)
-                        .isel(ping_time=0)
-                        .isnull()
-                    )
-                    .dropna(dim='range_sample')
-                    .data
+                    range_sample=d.echo_range.dropna(dim='range_sample').range_sample
                 )
 
             plot = d.plot.pcolormesh(

--- a/echopype/visualize/plot.py
+++ b/echopype/visualize/plot.py
@@ -125,6 +125,9 @@ def _plot_echogram(
 
     row = None
     col = None
+    # perform frequency filtering
+    # if (frequency is not None) and ('channel' in ds.dims):
+    #     ds = ds.where(ds.frequency_nominal.isin(frequency), drop=True)
 
     if 'backscatter_i' in ds.variables:
         col = 'beam'


### PR DESCRIPTION
This PR improves the selection of EK CW mode calibration parameters in the `Vendor` group (`sa_correction`, `gain_correction`) as the current implementation is inefficient and not flexible.

There is an added goal to allow calibrating the example file with duplicated frequency channels that alternates in `ping_time`, which fails in the current implementation.

This PR builds on top of #660 as one of the plotting test uses this example file and is currently marked to not run.

Not ready for review yet.