### PR TITLE
Improve selection of calibration parameters from `Vendor` group

### DIFF
--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -53,8 +53,6 @@ class CalibrateEK(CalibrateBase):
         param : str {"sa_correction", "gain_correction"}
             name of parameter to retrieve
         """
-        # TODO: need to test with EK80 power/angle data
-        #  currently this has only been tested with EK60 data
         ds_vend = self.echodata.vendor
 
         if ds_vend is None or param not in ds_vend:

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -1,6 +1,5 @@
 import numpy as np
 import xarray as xr
-from dask.array.core import Array
 from scipy import signal
 
 from ..utils import uwa
@@ -51,7 +50,7 @@ class CalibrateEK(CalibrateBase):
 
         Parameters
         ----------
-        param : str
+        param : str {"sa_correction", "gain_correction"}
             name of parameter to retrieve
         """
         # TODO: need to test with EK80 power/angle data
@@ -64,22 +63,6 @@ class CalibrateEK(CalibrateBase):
         if param not in ["sa_correction", "gain_correction"]:
             raise ValueError(f"Unknown parameter {param}")
 
-        # Drop NaN ping_time for transmit_duration_nominal
-        if np.any(np.isnan(self.echodata.beam["transmit_duration_nominal"])):
-            # TODO: resolve performance warning:
-            #  /Users/wu-jung/miniconda3/envs/echopype_jan2021/lib/python3.8/site-packages/xarray/core/indexing.py:1369:
-            #  PerformanceWarning: Slicing is producing a large chunk. To accept the large
-            #  chunk and silence this warning, set the option
-            #      >>> with dask.config.set(**{'array.slicing.split_large_chunks': False}):
-            #      ...     array[indexer]
-            #  To avoid creating the large chunks, set the option
-            #      >>> with dask.config.set(**{'array.slicing.split_large_chunks': True}):
-            #      ...     array[indexer]
-            #    return self.array[key]
-            self.echodata.beam = self.echodata.beam.dropna(
-                dim="ping_time", how="any", subset=["transmit_duration_nominal"]
-            )
-
         if waveform_mode == "CW" and self.echodata.beam_power is not None:
             beam = self.echodata.beam_power
         else:
@@ -90,22 +73,27 @@ class CalibrateEK(CalibrateBase):
             np.isin(ds_vend["frequency_nominal"], beam["frequency_nominal"])
         )[0]
 
-        unique_pulse_length = np.unique(beam["transmit_duration_nominal"], axis=1)
+        # Find idx to select the corresponding param value
+        # by matching beam["transmit_duration_nominal"] with ds_vend["pulse_length"]
+        transmit_isnull = beam["transmit_duration_nominal"].isnull()
+        idxmin = np.abs(
+            beam["transmit_duration_nominal"] - ds_vend["pulse_length"][relevant_indexes]
+        ).idxmin(dim="pulse_length_bin")
 
-        pulse_length = ds_vend["pulse_length"][relevant_indexes]
+        # fill nan position with 0 (witll remove before return)
+        # and convert to int for indexing
+        idxmin = idxmin.where(~transmit_isnull, 0).astype(int)
 
-        # Find index with correct pulse length
-        idx_wanted = np.abs(pulse_length - unique_pulse_length).argmin(dim="pulse_length_bin")
-
-        # Checks for dask array and compute first
-        if isinstance(idx_wanted.data, Array):
-            idx_wanted = idx_wanted.data.compute()
-
-        return (
-            ds_vend[param]
-            .isel(pulse_length_bin=idx_wanted, channel=relevant_indexes)
-            .drop("pulse_length_bin")
+        # Get param dataarray into correct shape
+        da_param = (
+            ds_vend[param][relevant_indexes]
+            .expand_dims(dim={"ping_time": idxmin["ping_time"]})  # expand dims for direct indexing
+            .sortby(idxmin.channel)  # sortby in case channel sequence different in vendor and beam
         )
+
+        # Select corresponding index and clean up the original nan elements
+        da_param = da_param.isel(pulse_length_bin=idxmin, drop=True)
+        return da_param.where(~transmit_isnull, np.nan)  # set the nan elements back to nan
 
     def get_cal_params(self, cal_params, waveform_mode, encode_mode):
         """Get cal params using user inputs or values from data file.
@@ -658,8 +646,6 @@ class CalibrateEK80(CalibrateEK):
                     else:
                         gain_temp = (
                             gain_single.sel(channel=ch_id)
-                            .assign_coords(ping_time=np.datetime64(0, "ns"))
-                            .expand_dims("ping_time")
                             .reindex_like(self.echodata.beam.backscatter_r, method="nearest")
                             .expand_dims("channel")
                         )

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -291,7 +291,7 @@ def test_compute_Sv_ek80_BB_complex(ek80_path):
 def test_compute_Sv_ek80_CW_power_BB_complex(ek80_path):
     """
     Tests calibration in CW mode data encoded as power samples
-    and calibration in BB mode data encoded as complex seamples,
+    and calibration in BB mode data encoded as complex samples,
     while the file contains both CW power and BB complex samples.
     """
     ek80_raw_path = ek80_path / "Summer2018--D20180905-T033113.raw"

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -113,6 +113,22 @@ def test_compute_Sv_ek60_matlab(ek60_path):
     check_output(ds_TS['TS'], 'Sp')
 
 
+def test_compute_Sv_ek60_duplicated_freq(ek60_path):
+    ek60_raw_path = str(
+        ek60_path.joinpath('DY1002_EK60-D20100318-T023008_rep_freq.raw')
+    )
+
+    # Convert file
+    echodata = ep.open_raw(ek60_raw_path, sonar_model='EK60')
+
+    # Calibrate to get Sv
+    ds_Sv = ep.calibrate.compute_Sv(echodata)
+    ds_TS = ep.calibrate.compute_TS(echodata)
+
+    assert isinstance(ds_Sv, xr.Dataset)
+    assert isinstance(ds_TS, xr.Dataset)
+
+
 def test_compute_Sv_azfp(azfp_path):
     azfp_01a_path = str(azfp_path.joinpath('17082117.01A'))
     azfp_xml_path = str(azfp_path.joinpath('17041823.XML'))


### PR DESCRIPTION
This PR improves the selection operation of EK60 and EK80 CW mode calibration parameters in the `Vendor` group (`sa_correction`, `gain_correction`) as the current implementation is inefficient and inflexible.

This PR has an additional goal to allow calibrating the test file with duplicated frequency channels that alternates in `ping_time` (pinging sequence: ch3 - ch4 - ch3 -ch4 -...), which fails in the current implementation, like below:

<img width="560" alt="Screen Shot 2022-05-19 at 7 06 44 PM" src="https://user-images.githubusercontent.com/15334215/169544961-5a32e9c2-5c6b-458b-a129-84efdce30f95.png">

I also added a test in test_calibrate.py to run `compute_Sv/TS` on the duplicated frequency file.

The changes here should allow the test that's being xfailed at the moment in #660 to be run.
