### PR TITLE
Pinning CI s3fs version to latest

### DIFF
--- a/.ci_helpers/py3.10.yaml
+++ b/.ci_helpers/py3.10.yaml
@@ -11,7 +11,7 @@ dependencies:
   - xarray
   - zarr
   - fsspec
-  - s3fs
+  - s3fs==2022.5.0
   - matplotlib-base
   - cmocean
   - mamba=0.20.0

--- a/.ci_helpers/py3.8.yaml
+++ b/.ci_helpers/py3.8.yaml
@@ -11,7 +11,7 @@ dependencies:
   - xarray
   - zarr
   - fsspec
-  - s3fs
+  - s3fs==2022.5.0
   - matplotlib-base
   - cmocean
   - mamba=0.20.0

--- a/.ci_helpers/py3.9.yaml
+++ b/.ci_helpers/py3.9.yaml
@@ -11,7 +11,7 @@ dependencies:
   - xarray
   - zarr
   - fsspec
-  - s3fs
+  - s3fs==2022.5.0
   - matplotlib-base
   - cmocean
   - mamba=0.20.0


### PR DESCRIPTION
This PR pins the s3fs for the CI runs since there seems to be some weird conda dependency bug where randomly the version 0.6.0 gets installed for s3fs.