### PR TITLE
Make time coordinate attributes consistent

### DIFF
--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -129,7 +129,7 @@ class SetGroupsAZFP(SetGroupsBase):
                         "long_name": "Timestamps for platform motion and orientation data",
                         "standard_name": "time",
                         "comment": "Time coordinate corresponding to platform motion and "
-                        "orientation sensors.",
+                        "orientation data.",
                     },
                 ),
             },

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -125,8 +125,11 @@ class SetGroupsAZFP(SetGroupsBase):
                     ["time2"],
                     time2,
                     {
-                        **self._varattrs["beam_coord_default"]["ping_time"],
-                        "comment": "Time coordinate corresponding to platform sensors.",
+                        "axis": "T",
+                        "long_name": "Timestamps for platform motion and orientation data",
+                        "standard_name": "time",
+                        "comment": "Time coordinate corresponding to platform motion and "
+                        "orientation sensors.",
                     },
                 ),
             },

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -128,7 +128,7 @@ class SetGroupsBase(abc.ABC):
                         "axis": "T",
                         "long_name": "Timestamps for NMEA datagrams",
                         "standard_name": "time",
-                        "comment": "Time coordinate corresponding to GPS location.",
+                        "comment": "Time coordinate corresponding to NMEA sensor data.",
                     },
                 )
             },

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -236,7 +236,7 @@ class SetGroupsEK60(SetGroupsBase):
                     time1,
                     {
                         **self._varattrs["platform_coord_default"]["time1"],
-                        "comment": "Time coordinate corresponding to GPS location.",
+                        "comment": "Time coordinate corresponding to NMEA position data.",
                     },
                 )
             },
@@ -321,9 +321,10 @@ class SetGroupsEK60(SetGroupsBase):
                             self.parser_obj.ping_time[ch],
                             {
                                 "axis": "T",
-                                "long_name": "Timestamps for position datagrams",
+                                "long_name": "Timestamps for platform motion and orientation data",
                                 "standard_name": "time",
-                                "comment": "Time coordinate corresponding to platform sensors.",
+                                "comment": "Time coordinate corresponding to platform motion and "
+                                "orientation sensors.",
                             },
                         ),
                         "time3": (
@@ -331,7 +332,7 @@ class SetGroupsEK60(SetGroupsBase):
                             self.parser_obj.ping_time[ch],
                             {
                                 "axis": "T",
-                                "long_name": "Timestamps for position datagrams",
+                                "long_name": "Timestamps for environmental data",
                                 "standard_name": "time",
                                 "comment": "Time coordinate corresponding to "
                                 "environmental variables.",

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -324,7 +324,7 @@ class SetGroupsEK60(SetGroupsBase):
                                 "long_name": "Timestamps for platform motion and orientation data",
                                 "standard_name": "time",
                                 "comment": "Time coordinate corresponding to platform motion and "
-                                "orientation sensors.",
+                                "orientation data.",
                             },
                         ),
                         "time3": (
@@ -332,10 +332,10 @@ class SetGroupsEK60(SetGroupsBase):
                             self.parser_obj.ping_time[ch],
                             {
                                 "axis": "T",
-                                "long_name": "Timestamps for environmental data",
+                                "long_name": "Timestamps for platform-related sampling environment",
                                 "standard_name": "time",
-                                "comment": "Time coordinate corresponding to "
-                                "environmental variables.",
+                                "comment": "Time coordinate corresponding to platform-related "
+                                "sampling environment.",
                             },
                         ),
                     },

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -117,7 +117,7 @@ class SetGroupsEK80(SetGroupsBase):
                     time1,
                     {
                         "axis": "T",
-                        "long_name": "Timestamp of each ping",
+                        "long_name": "Timestamps for NMEA position datagrams",
                         "standard_name": "time",
                         "comment": "Time coordinate corresponding to environmental "
                         "variables. Note that Platform.time3 is the same "
@@ -334,7 +334,7 @@ class SetGroupsEK80(SetGroupsBase):
                         "long_name": "Timestamps for platform motion and orientation data",
                         "standard_name": "time",
                         "comment": "Time coordinate corresponding to platform motion and "
-                        "orientation sensors.",
+                        "orientation data.",
                     },
                 ),
                 "time3": (
@@ -344,10 +344,11 @@ class SetGroupsEK80(SetGroupsBase):
                     else np.datetime64("NaT"),
                     {
                         "axis": "T",
-                        "long_name": "Timestamps for environmental data",
+                        "long_name": "Timestamps for platform-related sampling environment",
                         "standard_name": "time",
-                        "comment": "Time coordinate corresponding to environmental variables. "
-                        "Note that Platform.time3 is the same as Environment.time1.",
+                        "comment": "Time coordinate corresponding to platform-related "
+                        "sampling environment. Note that Platform.time3 is "
+                        "the same as Environment.time1.",
                     },
                 ),
                 "time1": (

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -331,9 +331,10 @@ class SetGroupsEK80(SetGroupsBase):
                     time2,
                     {
                         "axis": "T",
-                        "long_name": "Timestamps for MRU datagrams",
+                        "long_name": "Timestamps for platform motion and orientation data",
                         "standard_name": "time",
-                        "comment": "Time coordinate corresponding to platform sensors.",
+                        "comment": "Time coordinate corresponding to platform motion and "
+                        "orientation sensors.",
                     },
                 ),
                 "time3": (
@@ -343,7 +344,7 @@ class SetGroupsEK80(SetGroupsBase):
                     else np.datetime64("NaT"),
                     {
                         "axis": "T",
-                        "long_name": "Timestamps for Environment XML datagrams",
+                        "long_name": "Timestamps for environmental data",
                         "standard_name": "time",
                         "comment": "Time coordinate corresponding to environmental variables. "
                         "Note that Platform.time3 is the same as Environment.time1.",
@@ -354,7 +355,7 @@ class SetGroupsEK80(SetGroupsBase):
                     time1,
                     {
                         **self._varattrs["platform_coord_default"]["time1"],
-                        "comment": "Time coordinate corresponding to GPS location.",
+                        "comment": "Time coordinate corresponding to NMEA position data.",
                     },
                 ),
             },


### PR DESCRIPTION
This PR addresses #682. All changes made followed issue [682 (comment)](https://github.com/OSOceanAcoustics/echopype/issues/682#issuecomment-1133116826). 

As noted at the end of #682, `Platform.time3` is the same as `Environment.time1` for EK80. So, should we  also change the `long_name` for `Environment.time1` to `"Timestamps for environmental data"`? @leewujung for EK60, is `Platform.time3` the same as `Environment.time1`? I know that in the code they use the same value, but I am unsure if we should also make their attributes consistent with one another. 