### PR TITLE
Add standard name attribute to `frequency_nominal`

### DIFF
--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -205,8 +205,12 @@ class SetGroupsAZFP(SetGroupsBase):
                 "frequency_nominal": (
                     ["channel"],
                     freq,
-                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
-                     "standard_name": "sound_frequency"},
+                    {
+                        "units": "Hz",
+                        "long_name": "Transducer frequency",
+                        "valid_min": 0.0,
+                        "standard_name": "sound_frequency",
+                    },
                 ),
                 "backscatter_r": (["channel", "ping_time", "range_sample"], N),
                 "equivalent_beam_angle": (["channel"], parameters["BP"]),
@@ -275,8 +279,12 @@ class SetGroupsAZFP(SetGroupsBase):
                 "frequency_nominal": (
                     ["channel"],
                     freq,
-                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
-                     "standard_name": "sound_frequency"},
+                    {
+                        "units": "Hz",
+                        "long_name": "Transducer frequency",
+                        "valid_min": 0.0,
+                        "standard_name": "sound_frequency",
+                    },
                 ),
                 "XML_transmit_duration_nominal": (["channel"], tdn),
                 "XML_gain_correction": (["channel"], parameters["gain"]),

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -205,7 +205,8 @@ class SetGroupsAZFP(SetGroupsBase):
                 "frequency_nominal": (
                     ["channel"],
                     freq,
-                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0},
+                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
+                     "standard_name": "sound_frequency"},
                 ),
                 "backscatter_r": (["channel", "ping_time", "range_sample"], N),
                 "equivalent_beam_angle": (["channel"], parameters["BP"]),
@@ -274,7 +275,8 @@ class SetGroupsAZFP(SetGroupsBase):
                 "frequency_nominal": (
                     ["channel"],
                     freq,
-                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0},
+                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
+                     "standard_name": "sound_frequency"},
                 ),
                 "XML_transmit_duration_nominal": (["channel"], tdn),
                 "XML_gain_correction": (["channel"], parameters["gain"]),

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -174,7 +174,8 @@ class SetGroupsEK60(SetGroupsBase):
             ds_tmp["frequency_nominal"] = (
                 ["channel"],
                 [self.parser_obj.config_datagram["transceivers"][ch]["frequency"]],
-                {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0},
+                {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
+                 "standard_name": "sound_frequency"},
             )
 
             ds_env.append(ds_tmp)
@@ -356,7 +357,8 @@ class SetGroupsEK60(SetGroupsBase):
                 ds_tmp["frequency_nominal"] = (
                     ["channel"],
                     [self.parser_obj.config_datagram["transceivers"][ch]["frequency"]],
-                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0},
+                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
+                     "standard_name": "sound_frequency"},
                 )
 
                 ds_plat.append(ds_tmp)
@@ -420,7 +422,8 @@ class SetGroupsEK60(SetGroupsBase):
                 "frequency_nominal": (
                     ["channel"],
                     freq,
-                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0},
+                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
+                     "standard_name": "sound_frequency"},
                 ),
                 "beam_type": (
                     "channel",
@@ -721,6 +724,7 @@ class SetGroupsEK60(SetGroupsBase):
                         "units": "Hz",
                         "long_name": "Transducer frequency",
                         "valid_min": 0.0,
+                        "standard_name": "sound_frequency"
                     },
                 ),
                 "sa_correction": (["channel", "pulse_length_bin"], sa_correction),

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -174,8 +174,12 @@ class SetGroupsEK60(SetGroupsBase):
             ds_tmp["frequency_nominal"] = (
                 ["channel"],
                 [self.parser_obj.config_datagram["transceivers"][ch]["frequency"]],
-                {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
-                 "standard_name": "sound_frequency"},
+                {
+                    "units": "Hz",
+                    "long_name": "Transducer frequency",
+                    "valid_min": 0.0,
+                    "standard_name": "sound_frequency",
+                },
             )
 
             ds_env.append(ds_tmp)
@@ -357,8 +361,12 @@ class SetGroupsEK60(SetGroupsBase):
                 ds_tmp["frequency_nominal"] = (
                     ["channel"],
                     [self.parser_obj.config_datagram["transceivers"][ch]["frequency"]],
-                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
-                     "standard_name": "sound_frequency"},
+                    {
+                        "units": "Hz",
+                        "long_name": "Transducer frequency",
+                        "valid_min": 0.0,
+                        "standard_name": "sound_frequency",
+                    },
                 )
 
                 ds_plat.append(ds_tmp)
@@ -422,8 +430,12 @@ class SetGroupsEK60(SetGroupsBase):
                 "frequency_nominal": (
                     ["channel"],
                     freq,
-                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
-                     "standard_name": "sound_frequency"},
+                    {
+                        "units": "Hz",
+                        "long_name": "Transducer frequency",
+                        "valid_min": 0.0,
+                        "standard_name": "sound_frequency",
+                    },
                 ),
                 "beam_type": (
                     "channel",
@@ -724,7 +736,7 @@ class SetGroupsEK60(SetGroupsBase):
                         "units": "Hz",
                         "long_name": "Transducer frequency",
                         "valid_min": 0.0,
-                        "standard_name": "sound_frequency"
+                        "standard_name": "sound_frequency",
                     },
                 ),
                 "sa_correction": (["channel", "pulse_length_bin"], sa_correction),

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -166,7 +166,8 @@ class SetGroupsEK80(SetGroupsBase):
             "frequency_nominal": (
                 ["channel"],
                 var["transducer_frequency"],
-                {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0},
+                {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
+                 "standard_name": "sound_frequency"},
             ),
             "serial_number": (["channel"], var["serial_number"]),
             "transducer_name": (["channel"], var["transducer_name"]),
@@ -232,7 +233,8 @@ class SetGroupsEK80(SetGroupsBase):
                 "frequency_nominal": (
                     ["channel"],
                     freq,
-                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0},
+                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
+                     "standard_name": "sound_frequency"},
                 ),
                 "pitch": (
                     ["time2"],
@@ -395,7 +397,8 @@ class SetGroupsEK80(SetGroupsBase):
                 "frequency_nominal": (
                     ["channel"],
                     freq,
-                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0},
+                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
+                     "standard_name": "sound_frequency"},
                 ),
                 "beam_type": (["channel"], beam_params["transducer_beam_type"]),
                 "beamwidth_twoway_alongship": (
@@ -871,7 +874,8 @@ class SetGroupsEK80(SetGroupsBase):
                 "frequency_nominal": (
                     ["channel"],
                     param_dict["transducer_frequency"],
-                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0},
+                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
+                     "standard_name": "sound_frequency"},
                 ),
                 "sa_correction": (
                     ["channel", "pulse_length_bin"],

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -166,8 +166,12 @@ class SetGroupsEK80(SetGroupsBase):
             "frequency_nominal": (
                 ["channel"],
                 var["transducer_frequency"],
-                {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
-                 "standard_name": "sound_frequency"},
+                {
+                    "units": "Hz",
+                    "long_name": "Transducer frequency",
+                    "valid_min": 0.0,
+                    "standard_name": "sound_frequency",
+                },
             ),
             "serial_number": (["channel"], var["serial_number"]),
             "transducer_name": (["channel"], var["transducer_name"]),
@@ -233,8 +237,12 @@ class SetGroupsEK80(SetGroupsBase):
                 "frequency_nominal": (
                     ["channel"],
                     freq,
-                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
-                     "standard_name": "sound_frequency"},
+                    {
+                        "units": "Hz",
+                        "long_name": "Transducer frequency",
+                        "valid_min": 0.0,
+                        "standard_name": "sound_frequency",
+                    },
                 ),
                 "pitch": (
                     ["time2"],
@@ -397,8 +405,12 @@ class SetGroupsEK80(SetGroupsBase):
                 "frequency_nominal": (
                     ["channel"],
                     freq,
-                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
-                     "standard_name": "sound_frequency"},
+                    {
+                        "units": "Hz",
+                        "long_name": "Transducer frequency",
+                        "valid_min": 0.0,
+                        "standard_name": "sound_frequency",
+                    },
                 ),
                 "beam_type": (["channel"], beam_params["transducer_beam_type"]),
                 "beamwidth_twoway_alongship": (
@@ -874,8 +886,12 @@ class SetGroupsEK80(SetGroupsBase):
                 "frequency_nominal": (
                     ["channel"],
                     param_dict["transducer_frequency"],
-                    {"units": "Hz", "long_name": "Transducer frequency", "valid_min": 0.0,
-                     "standard_name": "sound_frequency"},
+                    {
+                        "units": "Hz",
+                        "long_name": "Transducer frequency",
+                        "valid_min": 0.0,
+                        "standard_name": "sound_frequency",
+                    },
                 ),
                 "sa_correction": (
                     ["channel", "pulse_length_bin"],


### PR DESCRIPTION
When `frequency_nominal` was added, the attribute `standard_name` was dropped. In this PR I add it back with the value of `"standard_name": "sound_frequency"`.