### PR TITLE
Add "angle" in EK80 `long_name` and put underscore in function name

### DIFF
--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -250,7 +250,7 @@ class SetGroupsAZFP(SetGroupsBase):
         )
 
         # Manipulate some Dataset dimensions to adhere to convention
-        self.beamgroups_to_convention(
+        self.beam_groups_to_convention(
             ds, self.beam_only_names, self.beam_ping_time_names, self.ping_time_only_names
         )
 

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -282,7 +282,7 @@ class SetGroupsBase(abc.ABC):
                 .copy()
             )
 
-    def beamgroups_to_convention(
+    def beam_groups_to_convention(
         self,
         ds: xr.Dataset,
         beam_only_names: Set[str],

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -708,7 +708,7 @@ class SetGroupsEK60(SetGroupsBase):
         )  # override keeps the Dataset attributes
 
         # Manipulate some Dataset dimensions to adhere to convention
-        self.beamgroups_to_convention(
+        self.beam_groups_to_convention(
             ds, self.beam_only_names, self.beam_ping_time_names, self.ping_time_only_names
         )
 

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -500,7 +500,7 @@ class SetGroupsEK80(SetGroupsBase):
                     ["channel"],
                     beam_params["angle_sensitivity_alongship"],
                     {
-                        "long_name": "alongship sensitivity of the transducer",
+                        "long_name": "alongship angle sensitivity of the transducer",
                         "comment": (
                             "Introduced in echopype for Simrad echosounders. "  # noqa
                             "The alongship angle corresponds to the minor angle in SONAR-netCDF4 vers 2. "  # noqa
@@ -511,7 +511,7 @@ class SetGroupsEK80(SetGroupsBase):
                     ["channel"],
                     beam_params["angle_sensitivity_athwartship"],
                     {
-                        "long_name": "athwartship sensitivity of the transducer",
+                        "long_name": "athwartship angle sensitivity of the transducer",
                         "comment": (
                             "Introduced in echopype for Simrad echosounders. "  # noqa
                             "The athwartship angle corresponds to the major angle in SONAR-netCDF4 vers 2. "  # noqa
@@ -841,14 +841,14 @@ class SetGroupsEK80(SetGroupsBase):
 
         # Manipulate some Dataset dimensions to adhere to convention
         if isinstance(ds_beam_power, xr.Dataset):
-            self.beamgroups_to_convention(
+            self.beam_groups_to_convention(
                 ds_beam_power,
                 self.beam_only_names,
                 self.beam_ping_time_names,
                 self.ping_time_only_names,
             )
 
-        self.beamgroups_to_convention(
+        self.beam_groups_to_convention(
             ds_beam, self.beam_only_names, self.beam_ping_time_names, self.ping_time_only_names
         )
 


### PR DESCRIPTION
In PR #685 @leewujung requested that I add "angle" in EK80's `long_name` attribute for the variables `angle_sensitivity_alongship` and `angle_sensitivity_athwartship`, so that we are consistent with EK60. Additionally, it was requested that I put an underscore in the function `beamgroups_to_convention` in the file `set_groups_base.py`. I agreed with these changes. This PR implements these changes. 