### PR TITLE
Add EK80 RAW4 support

### DIFF
--- a/echopype/convert/utils/ek_raw_parsers.py
+++ b/echopype/convert/utils/ek_raw_parsers.py
@@ -1557,6 +1557,16 @@ class SimradRawParser(_SimradDatagramParser):
                 ("offset", "l"),
                 ("count", "l"),
             ],
+            4: [
+                ("type", "4s"),
+                ("low_date", "L"),
+                ("high_date", "L"),
+                ("channel_id", "128s"),
+                ("data_type", "h"),
+                ("spare", "2s"),
+                ("offset", "l"),
+                ("count", "l"),
+            ],
         }
         _SimradDatagramParser.__init__(self, "RAW", headers)
 
@@ -1602,7 +1612,8 @@ class SimradRawParser(_SimradDatagramParser):
                 data["power"] = np.empty((0,), dtype="int16")
                 data["angle"] = np.empty((0, 2), dtype="int8")
 
-        elif version == 3:
+        # RAW3 and RAW4 have the same format, only Datatype Bit 0-1 not used in RAW4
+        elif version == 3 or version == 4:
 
             # result = 1j*Data[...,1]; result += Data[...,0]
 

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -194,7 +194,7 @@ def test_compute_Sv_ek80_matlab(ek80_path):
 
     Unresolved: there is a discrepancy between the range vector due to minRange=0.02 m set in Matlab.
     """
-    ek80_raw_path = str(ek80_path.joinpath('D20170912-T234910.raw'))
+    ek80_raw_path = str(ek80_path.joinpath('raw4-D20220514-T172704.raw'))
     ek80_matlab_path = str(
         ek80_path.joinpath('from_matlab/D20170912-T234910_data.mat')
     )

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -194,7 +194,7 @@ def test_compute_Sv_ek80_matlab(ek80_path):
 
     Unresolved: there is a discrepancy between the range vector due to minRange=0.02 m set in Matlab.
     """
-    ek80_raw_path = str(ek80_path.joinpath('raw4-D20220514-T172704.raw'))
+    ek80_raw_path = str(ek80_path.joinpath('D20170912-T234910.raw'))
     ek80_matlab_path = str(
         ek80_path.joinpath('from_matlab/D20170912-T234910_data.mat')
     )


### PR DESCRIPTION
This PR adds support for RAW4 datagram for EK80 echosounder.

## Tasks
- [ ] add RAW4 to `convert.utils.ek_raw_parsers.SimradRawParser._unpack_contents`
- [ ] add RAW4 handler to `convert.parse_base.ParseEK._read_datagrams` so parsed RAW4 data are in parser object
- [ ] determine where RAW4 data sit in EchoData object and add it