### PR TITLE
Use `mode` to determine whether to save angle data for EK60

### DIFF
--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -580,7 +580,6 @@ class SetGroupsEK60(SetGroupsBase):
         # Construct Dataset with ping-by-ping data from all channels
         ds_backscatter = []
         for ch in ch_ids:
-            data_shape = self.parser_obj.ping_data_dict["power"][ch].shape
             ds_tmp = xr.Dataset(
                 {
                     "backscatter_r": (
@@ -655,7 +654,7 @@ class SetGroupsEK60(SetGroupsBase):
                     ),
                     "range_sample": (
                         ["range_sample"],
-                        np.arange(data_shape[1]),
+                        np.arange(self.parser_obj.ping_data_dict["power"][ch].shape[1]),
                         self._varattrs["beam_coord_default"]["range_sample"],
                     ),
                 },

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -661,12 +661,10 @@ class SetGroupsEK60(SetGroupsBase):
                 },
             )
 
-            # TODO: below needs to be changed to use
-            #  self.convert_obj.ping_data_dict['mode'][ch] == 3
-            #  1 = Power only, 2 = Angle only 3 = Power & Angle
-            # Set angle data if in split beam mode (beam_type == 1)
-            # because single beam mode (beam_type == 0) does not record angle data
-            if self.parser_obj.config_datagram["transceivers"][ch]["beam_type"] == 1:
+            # Save angle data if exist based on values in self.parser_obj.ping_data_dict['mode'][ch]
+            # Assume the mode of all pings are identical
+            # 1 = Power only, 2 = Angle only 3 = Power & Angle
+            if np.all(np.array(self.parser_obj.ping_data_dict["mode"][ch]) != 1):
                 ds_tmp = ds_tmp.assign(
                     {
                         "angle_athwartship": (

--- a/echopype/test_data/README.md
+++ b/echopype/test_data/README.md
@@ -22,6 +22,7 @@ Most of these files are stored on Git LFS but the ones that aren't (due to file 
 - Winter2017-D20170115-T150122.raw: Contains a change of recording length in the middle of the file
 - 2015843-D20151023-T190636.raw: Not used in tests but contains ranges are not constant across ping times
 - SH1701_consecutive_files_w_range_change: Not used in tests. [Folder](https://drive.google.com/drive/u/1/folders/1PaDtL-xnG5EK3N3P1kGlXa5ub16Yic0f) on shared drive that contains sequential files with ranges that are not constant across ping times.
+- NBP_B050N-D20180117-T215840.raw: split-beam setup without angle data
 
 
 ### AZFP

--- a/echopype/test_data/README.md
+++ b/echopype/test_data/README.md
@@ -22,7 +22,7 @@ Most of these files are stored on Git LFS but the ones that aren't (due to file 
 - Winter2017-D20170115-T150122.raw: Contains a change of recording length in the middle of the file
 - 2015843-D20151023-T190636.raw: Not used in tests but contains ranges are not constant across ping times
 - SH1701_consecutive_files_w_range_change: Not used in tests. [Folder](https://drive.google.com/drive/u/1/folders/1PaDtL-xnG5EK3N3P1kGlXa5ub16Yic0f) on shared drive that contains sequential files with ranges that are not constant across ping times.
-- NBP_B050N-D20180117-T215840.raw: split-beam setup without angle data (test function commented out due to large file size; file currently exist locally and not in Docker image)
+- NBP_B050N-D20180118-T090228.raw: split-beam setup without angle data
 
 
 ### AZFP

--- a/echopype/test_data/README.md
+++ b/echopype/test_data/README.md
@@ -22,7 +22,7 @@ Most of these files are stored on Git LFS but the ones that aren't (due to file 
 - Winter2017-D20170115-T150122.raw: Contains a change of recording length in the middle of the file
 - 2015843-D20151023-T190636.raw: Not used in tests but contains ranges are not constant across ping times
 - SH1701_consecutive_files_w_range_change: Not used in tests. [Folder](https://drive.google.com/drive/u/1/folders/1PaDtL-xnG5EK3N3P1kGlXa5ub16Yic0f) on shared drive that contains sequential files with ranges that are not constant across ping times.
-- NBP_B050N-D20180117-T215840.raw: split-beam setup without angle data
+- NBP_B050N-D20180117-T215840.raw: split-beam setup without angle data (test function commented out due to large file size; file currently exist locally and not in Docker image)
 
 
 ### AZFP

--- a/echopype/tests/convert/test_convert_ek60.py
+++ b/echopype/tests/convert/test_convert_ek60.py
@@ -196,7 +196,7 @@ def test_convert_ek60_duplicate_frequencies(ek60_path):
 
 
 def test_convert_ek60_splitbeam_no_angle(ek60_path):
-    """Convert a file from a split-beam setup but does not record angle data."""
+    """Convert a file from a split-beam setup that does not record angle data."""
 
     raw_path = (
         ek60_path

--- a/echopype/tests/convert/test_convert_ek60.py
+++ b/echopype/tests/convert/test_convert_ek60.py
@@ -193,3 +193,16 @@ def test_convert_ek60_duplicate_frequencies(ek60_path):
                        truth_freq_nom_vals, rtol=1e-05, atol=1e-08)
 
     assert np.all(ed['Sonar/Beam_group1'].channel.values == truth_chan_vals)
+
+
+# def test_convert_ek60_splitbeam_no_angle(ek60_path):
+#     """Convert a file from a split-beam setup but does not record angle data."""
+
+#     raw_path = (
+#         ek60_path
+#         / "NBP_B050N-D20180117-T215840.raw"
+#     )
+#     ed = open_raw(raw_path, "EK60")
+
+#     assert "angle_athwartship" not in ed["Sonar/Beam_group1"]
+#     assert "angle_alongship" not in ed["Sonar/Beam_group1"]

--- a/echopype/tests/convert/test_convert_ek60.py
+++ b/echopype/tests/convert/test_convert_ek60.py
@@ -195,14 +195,14 @@ def test_convert_ek60_duplicate_frequencies(ek60_path):
     assert np.all(ed['Sonar/Beam_group1'].channel.values == truth_chan_vals)
 
 
-# def test_convert_ek60_splitbeam_no_angle(ek60_path):
-#     """Convert a file from a split-beam setup but does not record angle data."""
+def test_convert_ek60_splitbeam_no_angle(ek60_path):
+    """Convert a file from a split-beam setup but does not record angle data."""
 
-#     raw_path = (
-#         ek60_path
-#         / "NBP_B050N-D20180117-T215840.raw"
-#     )
-#     ed = open_raw(raw_path, "EK60")
+    raw_path = (
+        ek60_path
+        / "NBP_B050N-D20180118-T090228.raw"
+    )
+    ed = open_raw(raw_path, "EK60")
 
-#     assert "angle_athwartship" not in ed["Sonar/Beam_group1"]
-#     assert "angle_alongship" not in ed["Sonar/Beam_group1"]
+    assert "angle_athwartship" not in ed["Sonar/Beam_group1"]
+    assert "angle_alongship" not in ed["Sonar/Beam_group1"]


### PR DESCRIPTION
This PR addresses #491 by using `mode` in the parsed data to determine whether to save angle data for EK60. Previously it was assumed that angle data are always collected for split-beam setup, but the test data file @lgarzio provided had a split-beam transducer but only collected power data.

Note the test function is commented out because the test file is too large (100 MB) to be included in regular test set. 
