### PR TITLE
Proposed reorganization of AD2CP data format

### DIFF
--- a/docs/source/ad2cp_reorg.md
+++ b/docs/source/ad2cp_reorg.md
@@ -16,7 +16,7 @@
 # The original `Beam` group
 
 ## Which mode goes to which group
-Proposal/question: 
+Proposal/question:
 - use specific group name for different mode
 - this means that then some groups may not exist all together, i.e., there won't always be `Beam_group1` in the converted data file
 - this conflicts with what we have for EK80, where there will always be `Beam_group1` but the content changes depending on what are in the file (power/angle samples only, complex samples only, or both)
@@ -170,7 +170,3 @@ Coordinates:
 
 Data variable:
 - `magnetometer_raw`
-
-
-
-

--- a/docs/source/ad2cp_reorg.md
+++ b/docs/source/ad2cp_reorg.md
@@ -9,6 +9,8 @@
     - https://github.com/OSOceanAcoustics/echopype/blob/16a574dda792a61f6f7ae0583b70b4b87d787f12/echopype/convert/set_groups_ad2cp.py#L10-L14
     - Chose to keep coordinate value logic in set_groups
 - the `beam` coordinate is missing in `rawtest.090.00015.nc`?
+    - Beam is currently not included because no variables in the beam group are indexed by beam
+    - It should be included anyway
 
 
 

--- a/docs/source/ad2cp_reorg.md
+++ b/docs/source/ad2cp_reorg.md
@@ -1,0 +1,176 @@
+## Questions/comments:
+- why check the version again?
+    - https://github.com/OSOceanAcoustics/echopype/blob/16a574dda792a61f6f7ae0583b70b4b87d787f12/echopype/convert/parse_ad2cp.py#L589-L593
+    - https://github.com/OSOceanAcoustics/echopype/blob/16a574dda792a61f6f7ae0583b70b4b87d787f12/echopype/convert/parse_ad2cp.py#L630-L634
+- Move `AHRS_COORDS` def to `parse_ad2cp`?
+    - https://github.com/OSOceanAcoustics/echopype/blob/16a574dda792a61f6f7ae0583b70b4b87d787f12/echopype/convert/set_groups_ad2cp.py#L10-L14
+- the `beam` coordinate is missing in `rawtest.090.00015.nc`?
+- `echosounder_raw_beam`, `echosounder_raw_echogram`: not sure what these correspond to
+- `status`, `status0`: need additional parsing
+
+
+
+
+
+
+# The original `Beam` group
+
+## Which mode goes to which group
+Proposal/question: 
+- use specific group name for different mode
+- this means that then some groups may not exist all together, i.e., there won't always be `Beam_group1` in the converted data file
+- this conflicts with what we have for EK80, where there will always be `Beam_group1` but the content changes depending on what are in the file (power/angle samples only, complex samples only, or both)
+- if we go with this approach, we can use the following:
+    - `Beam_group1`: average
+    - `Beam_group2`: burst
+    - `Beam_group3`: echosounder
+    - `Beam_group4`: echosounder raw samples
+        - the first ping is the raw transmit signal
+        - the rest of pings are the receive raw echoes
+
+## Variables common to all modes
+Coordinates:
+- `ping_time`: use the original `ping_time_average`, `ping_time_burst` and `ping_time_echosounder` in each of their own `Beam_groupX` but with the same name `ping_time`
+- `range_sample`: use the original `range_sample_average`, `range_sample_burst` and `range_sample_echosounder` in each of their own `Beam_groupX` but with the same name `range_sample`
+- `beam`:
+    - the actual physical beam activated in the setting (1, 2, 3, 4, 5)
+    - parsed from the data variable `data_set_description` using `parse_ad2cp._postprocess_beams` for the following packets: `BURST_AVERAGE_VERSION3_DATA_RECORD_FORMAT`, `BURST_AVERAGE_VERSION2_DATA_RECORD_FORMAT`, `BOTTOM_TRACK_DATA_RECORD_FORMAT`
+    - this is missing in `rawtest.090.00008.nc`??
+
+Data variables:
+- `number_of_beams`
+- `coordinate_system`
+- `number_of_cells`
+- `blanking`
+- `cell_size`
+- `velocity_range`
+- `echosounder_frequency`
+- `ambiguity_velocity`
+- `data_set_description`
+- `transmit_energy`
+- `velocity_scaling`
+- `velocity`: separate `velocity_burst` and `velocity_average` into different `Beam_groupX` and use the name `velocity`
+- `amplitude`: separate `amplitude_burst`, `amplitude_average` and `amplitude_echosounder` into different `Beam_groupX` and use the name `amplitude`
+- `correlation`: separate `correlation_burst`, `correlation_average` and `correlation_echosounder` into different `Beam_groupX` and use the name `correlation`
+
+Attributes:
+- `pulse_compressed`
+    - this probably should be a variable?
+    - should go to `Beam_group3` that stores the echosounder mode data
+    - can have a max length of 3 since there can be 3 echograms in the echosounder mode (aligned with `beam`): is this supported currently?
+
+
+## Move from `Beam` to `Platform` group
+- `figure_of_merit`: for bottom tracking
+- `altimeter_distance`
+- `altimeter_quality`
+- `altimeter_spare`
+- `altimeter_raw_data_num_samples`
+- `altimeter_raw_data_sample_distance`
+- `altimeter_raw_data_samples`
+- `ast_distance`
+- `ast_quality`
+- `ast_offset_100us`
+- `ast_pressure`
+
+
+
+
+
+
+
+# `Vendor_specific` group
+## Remove
+- `pulse_compressed`: this already is/will be in `Beam_group3` (echosounder mode data)
+
+## Move from `Vendor_specific` to `Platform` group
+- `ahrs_rotation_matrix_mij`
+- `ahrs_quaternions_wxyz`
+- `ahrs_gyro_xyz`
+- `std_dev_pitch`
+- `std_dev_roll`
+- `std_dev_heading`
+- `std_dev_pressure`
+- `compass_sensor_valid`
+- `tilt_sensor_valid`
+
+## Move from `Vendor_specific` to `Environment` group
+Coordinates:
+- `time1`: this will be the combined ping_time from all modes
+
+Data variables:
+- `temperature_of_pressure_sensor`: rename to "temperature_pressure_sensor"
+- `magnetometer_temperature`: rename to "temperature_magnetometer"
+- `real_ping_time_clock_temperature`: rename to "temperature_real_ping_time_clock"
+- `pressure_sensor_valid`
+- `temperature_sensor_valid`
+
+## Move from `Vendor_specific` to each of the `Beam_groupX` groups
+Coordinates: `ping_time` for that group (not the combined one)
+
+Data variables:
+- `data_record_version`
+- `error`
+- `status`: need additional parsing
+- `status0`: need additional parsing
+- `power_level`
+- `nominal_correlation`
+- `percentage_good_data`
+- `battery_voltage`
+- `ensemble_counter`
+
+## Move from `Vendor_specific` to `Beam_group4` group
+Coordinates:
+- `ping_time` for that group (not the combined one)
+- `sample`: rename to `range_sample`; this is sample number along range for raw echosounder data
+- `sample_transmit`: rename to `transmit_sample` (to be consistent with what's used for Simrad RAW4)
+
+Data variables:
+- `echosounder_raw_samples_i`
+- `echosounder_raw_samples_q`
+- `echosounder_raw_transmit_samples_i`
+- `echosounder_raw_transmit_samples_q`
+- `echosounder_raw_beam`: not sure what this corresponds to, but couldn't find a variable that correpsonds to `beam` which is the physical beam used in transmission
+- `echosounder_raw_echogram`: not sure what this corresponds to
+
+
+
+
+
+
+
+# The original `Environment` group
+Coordinates:
+- `time1`: this will be the combined ping_time from all modes
+
+Data variables:
+- `sound_speed_indicative`
+- `temperature`
+- `pressure`
+
+
+
+
+
+
+
+# The original `Platform` group
+Coordinates
+- `time1`: this will be the combined ping_time from all modes
+
+Data variables:
+- `heading`
+- `pitch`
+- `roll`
+
+## Move from `Platform` group to `Vendor_specific` group
+Coordinates:
+- `time1`: this will be the combined ping_time from all modes
+- `xyz`: coordinate for `magnetometer_raw`
+
+Data variable:
+- `magnetometer_raw`
+
+
+
+

--- a/docs/source/ad2cp_reorg.md
+++ b/docs/source/ad2cp_reorg.md
@@ -15,7 +15,7 @@
     - `comment`: Description in spec sheet
     - `units`: following spec sheet and the units convention in [CF convention](https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html)
     - for those that are already converted to the actual units, put "but already converted to actual units here."
-    - for example: for the field `Temperature`, put 
+    - for example: for the field `Temperature`, put
         ```
         {
             "long_name": "Field "Temperature" in the data specification. "
@@ -57,7 +57,7 @@ Coordinates:
     - the actual physical beam activated in the setting (1, 2, 3, 4, 5): @imranmaj please double check this
     - parsed from the data variable `data_set_description` using `parse_ad2cp._postprocess_beams` for the following packets:
       - `BURST_AVERAGE_VERSION3_DATA_RECORD_FORMAT`
-      - `BURST_AVERAGE_VERSION2_DATA_RECORD_FORMAT` 
+      - `BURST_AVERAGE_VERSION2_DATA_RECORD_FORMAT`
       - `BOTTOM_TRACK_DATA_RECORD_FORMAT`
 
 Data variables:
@@ -110,9 +110,9 @@ Attributes:
 - `pulse_compressed`: this already is/will be in `Beam_group3` (echosounder mode data)
 
 ## Keep in `Vendor_specific` group
-- Questions: 
+- Questions:
   - flag for whether these data will be collected?
-  - when collected, what their expected dimensions are? 
+  - when collected, what their expected dimensions are?
 - `ahrs_rotation_matrix_mij`
 - `ahrs_quaternions_wxyz`
 - `ahrs_gyro_xyz`
@@ -124,7 +124,7 @@ Attributes:
 - `tilt_sensor_valid`
 
 ### Data collected for every ping in all modes
-- Coordinate `time1`: 
+- Coordinate `time1`:
   - this will be the combined `ping_time` from all modes
 - `temperature_of_pressure_sensor`: rename to `temperature_pressure_sensor`
 - `magnetometer_temperature`: rename to `temperature_magnetometer`

--- a/docs/source/ad2cp_reorg.md
+++ b/docs/source/ad2cp_reorg.md
@@ -10,6 +10,7 @@
 
 ## Overarching action items:
 - Double check all raw to actual units conversion
+- Move the sequence of variable handling to following the sequence of the data specification, for easier reference
 - For all variables, put
     - `long_name`: Field in spec sheet
     - `comment`: Description in spec sheet
@@ -82,8 +83,10 @@
 
 ## Variables common to all modes
 Coordinates:
-- `ping_time`: use the original `ping_time_average`, `ping_time_burst` and `ping_time_echosounder` in each of their own `Beam_groupX` but with the same name `ping_time`
-- `range_sample`: use the original `range_sample_average`, `range_sample_burst` and `range_sample_echosounder` in each of their own `Beam_groupX` but with the same name `range_sample`
+- `ping_time`
+    - use the original `ping_time_average`, `ping_time_burst` and `ping_time_echosounder` in each of their own `Beam_groupX` but with the same name `ping_time`
+- `range_sample`
+    - use the original `range_sample_average`, `range_sample_burst` and `range_sample_echosounder` in each of their own `Beam_groupX` but with the same name `range_sample`
 - `beam`:
     - the actual physical beam activated in the setting (1, 2, 3, 4, 5): @imranmaj please double check this
     - parsed from the data variable `data_set_description` using `parse_ad2cp._postprocess_beams` for the following packets:
@@ -96,9 +99,11 @@ Data variables:
 - `coordinate_system`
 - `number_of_cells`
 - `blanking`
-- `cell_size`: this is conceptually equivalent to `sample_interval` for the other echosounders, just that `sample_interval` is defined in time (second) and `cell_size` is defined in space (meter)
+- `cell_size`
+    - this is conceptually equivalent to `sample_interval` for the other echosounders, just that `sample_interval` is defined in time (second) and `cell_size` is defined in space (meter)
 - `velocity_range`
 - `echosounder_frequency`
+    - the parsed values seem wrong: right now it shows as either 0 (these are probably for pings from other modes and not echosounder -- please verify) or 10000, but should be 1000000 (1 MHz)  @imranmaj
 - `ambiguity_velocity`
 - `data_set_description`
 - `transmit_energy`
@@ -106,7 +111,7 @@ Data variables:
 - `velocity`
     - separate `velocity_burst` and `velocity_average` into different `Beam_groupX` and use the name `velocity`
 - `amplitude`
-    - separate `amplitude_burst`, `amplitude_average` and `amplitude_echosounder` into different `Beam_groupX` and use the name `amplitude`
+    - separate `amplitude_burst`, `amplitude_average` and `amplitude_echosounder` into different `Beam_groupX` and use the name `backscatter_r` (since this "amplitude" is equivalent to what we have from EK60, AZFP and EK80 power data)
 - `correlation`
     - separate `correlation_burst`, `correlation_average` and `correlation_echosounder` into different `Beam_groupX` and use the name `correlation`
 

--- a/docs/source/ad2cp_reorg.md
+++ b/docs/source/ad2cp_reorg.md
@@ -2,8 +2,12 @@
 - why check the version again?
     - https://github.com/OSOceanAcoustics/echopype/blob/16a574dda792a61f6f7ae0583b70b4b87d787f12/echopype/convert/parse_ad2cp.py#L589-L593
     - https://github.com/OSOceanAcoustics/echopype/blob/16a574dda792a61f6f7ae0583b70b4b87d787f12/echopype/convert/parse_ad2cp.py#L630-L634
+    - Safety check to make sure the version is correct
+    - Maybe there are multiple versions in 1 file?
+    - Default is to interpret as version 3, maybe the version is 2?
 - Move `AHRS_COORDS` def to `parse_ad2cp`?
     - https://github.com/OSOceanAcoustics/echopype/blob/16a574dda792a61f6f7ae0583b70b4b87d787f12/echopype/convert/set_groups_ad2cp.py#L10-L14
+    - Chose to keep coordinate value logic in set_groups
 - the `beam` coordinate is missing in `rawtest.090.00015.nc`?
 
 

--- a/docs/source/ad2cp_reorg.md
+++ b/docs/source/ad2cp_reorg.md
@@ -19,8 +19,11 @@
         ```
         {
             "long_name": "Field "Temperature" in the data specification. "
-            "comment": "Reading from the temperature sensor. "
-                       "Raw data given as 0.01 °C but already converted to actual units here."
+            "comment": (
+                "Reading from the temperature sensor. "
+                "Raw data given as 0.01 °C "
+                "but already converted to actual units here."
+            )
             "units": "degree_C"
         }
         ```
@@ -31,10 +34,38 @@
 
 ## Which mode goes to which group
 - following SONAR-netCDF4 and our implementation of EK80 groups, we will use the following sequence when determining where data from each mode goes in `Beam_groupX`:
-    1. average
+    1. average:
+        ```
+        "descr": (
+            "contains echo intensity, velocity and correlation data "
+            "as well as other configuration parameters from the Average mode."
+        )
+        ```
     2. burst
+        ```
+        "descr": (
+            "contains echo intensity, velocity and correlation data "
+            "as well as other configuration parameters from the Burst mode."
+        )
+        ```
     3. echosounder
+        ```
+        "descr": (
+            "contains backscatter echo intensity and other configuration parameters from the Echosounder mode. "
+            "Data can be pulse compressed or raw intensity."
+        )
+        ```
     4. echosounder raw samples
+        ```
+        "descr": (
+            "contains complex backscatter raw samples and other configuration parameters from the Echosounder mode, "
+            "including complex data from the transmit pulse."
+        )
+        ```
+    - we need a trickier implementation than what's used for EK80, since for EK80 the max number group is 2, and depending on if complex or power data exist, where they show up may be different:
+        - if complex data exists, it is always stored in `Beam_group1`
+        - if ONLY power data exists, it is stored in `Beam_group1`
+        - if BOTH complex and power data exist, complex data in `Beam_group1` and power data in `Beam_group2`
 - examples:
     - example 1: file with average and burst mode:
         - `Beam_group1`: average


### PR DESCRIPTION
In v0.6.0 we left out AD2CP data because it takes quite a different flavor from all the other sonar models. Now we are in the position to reorganize the data format based on the previous experience.

In this PR I put in a markdown file that details my proposed changes of the data format. The file is put under `docs/source` but my intension is _not_ to merge this file but use this PR as a place where we can do line by line exchanges/discussions if needed.

@emiliom @imranmaj : I think it may work better if @emiliom and I meet first to settle down the proposed changes (which will be become new commits to this PR), and then @imranmaj and I meet to go through the required changes.

@emiliom: I can give you an overview of how this instrument operations and the main differences from the other sonar models. The variables are in such a way that can be grouped into a few conceptual groups, so even though there are a large number of them I think it won't be too hard for us to make decisions.

@imranmaj: There are a few questions that are independent of the format changes. We can discuss those in parallel.