### PR TITLE
Check filter coeffs existence in `SetGroupsEK80.set_vendor`

### DIFF
--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -966,11 +966,14 @@ class SetGroupsEK80(SetGroupsBase):
         decimation_factors = dict()
         for ch in channels:
             # filter coeffs and decimation factor for wide band transceiver (WBT)
-            coeffs[f"{ch} WBT filter"] = self.parser_obj.fil_coeffs[ch][1]
-            decimation_factors[f"{ch} WBT decimation"] = self.parser_obj.fil_df[ch][1]
+            if self.parser_obj.fil_coeffs:
+                coeffs[f"{ch} WBT filter"] = self.parser_obj.fil_coeffs[ch][1]
+                decimation_factors[f"{ch} WBT decimation"] = self.parser_obj.fil_df[ch][1]
             # filter coeffs and decimation factor for pulse compression (PC)
-            coeffs[f"{ch} PC filter"] = self.parser_obj.fil_coeffs[ch][2]
-            decimation_factors[f"{ch} PC decimation"] = self.parser_obj.fil_df[ch][2]
+            if self.parser_obj.fil_df:
+
+                coeffs[f"{ch} PC filter"] = self.parser_obj.fil_coeffs[ch][2]
+                decimation_factors[f"{ch} PC decimation"] = self.parser_obj.fil_df[ch][2]
 
         # Assemble everything into a Dataset
         ds = xr.merge([ds_table, ds_cal])

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -971,7 +971,6 @@ class SetGroupsEK80(SetGroupsBase):
                 decimation_factors[f"{ch} WBT decimation"] = self.parser_obj.fil_df[ch][1]
             # filter coeffs and decimation factor for pulse compression (PC)
             if self.parser_obj.fil_df:
-
                 coeffs[f"{ch} PC filter"] = self.parser_obj.fil_coeffs[ch][2]
                 decimation_factors[f"{ch} PC decimation"] = self.parser_obj.fil_df[ch][2]
 

--- a/echopype/test_data/README.md
+++ b/echopype/test_data/README.md
@@ -11,6 +11,7 @@ Most of these files are stored on Git LFS but the ones that aren't (due to file 
 - 2019118 group2survey-D20191214-T081342.raw: Contains 6 channels but only 2 of those channels collect ping data
 - D20200528-T125932.raw: Data collected from WBT mini (instead of WBT), from @emlynjdavies
 - Green2.Survey2.FM.short.slow.-D20191004-T211557.raw: Contains 2-in-1 transducer, from @FletcherFT (reduced from 104.9 MB to 765 KB in test data updates)
+- D20210330-T123857.raw: do not contain filter coefficients
 
 
 ### EA640

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -395,3 +395,16 @@ def test_convert_ek80_freq_subset(ek80_path):
     assert (echodata["Platform"]["water_level"] == 0).all()
 
     check_env_xml(echodata)
+
+
+def test_convert_ek80_no_fil_coeff(ek80_path):
+    """Make sure we can convert EK80 file with empty filter coefficients."""
+    echodata = open_raw(raw_file=ek80_path.joinpath('D20210330-T123857.raw'), sonar_model='EK80')
+
+    ch_ids = list(echodata["Sonar/Beam_group1"]["channel"].values)
+
+    for ch_id in ch_ids:
+        assert f"{ch_id} WBT filter_r" not in echodata["Vendor_specific"].attrs.keys()
+        assert f"{ch_id} WBT filter_i" not in echodata["Vendor_specific"].attrs.keys()
+        assert f"{ch_id} PC filter_r" not in echodata["Vendor_specific"].attrs.keys()
+        assert f"{ch_id} PC filter_i" not in echodata["Vendor_specific"].attrs.keys()


### PR DESCRIPTION
This PR fixes the bug that `SetGroupsEK80.set_vendor` attempts to save potentially non-existing filter coefficients in EK80 file. Addresses #720.