### PR TITLE
Fix regression bug in computing MVBS in selecting `echo_range` for specific frequency

### DIFF
--- a/echopype/calibrate/calibrate_azfp.py
+++ b/echopype/calibrate/calibrate_azfp.py
@@ -154,6 +154,9 @@ class CalibrateAZFP(CalibrateBase):
         # Add env and cal parameters
         out = self._add_params_to_output(out)
 
+        # Order the dimensions
+        out["echo_range"] = out["echo_range"].transpose("channel", "ping_time", "range_sample")
+
         # Squeeze out the beam dim
         # doing it here because both out and self.cal_params["equivalent_beam_angle"] has beam dim
         return out.squeeze("beam", drop=True)

--- a/echopype/preprocess/api.py
+++ b/echopype/preprocess/api.py
@@ -86,9 +86,8 @@ def compute_MVBS(ds_Sv, range_meter_bin=20, ping_time_bin="20S"):
             .mean()
         )
         sv_groupby_bins.coords["echo_range"] = (["echo_range_bins"], rint[:-1])
-        sv_groupby_bins = (
-            sv_groupby_bins.swap_dims({"echo_range_bins": "echo_range"})
-            .drop_vars("echo_range_bins")
+        sv_groupby_bins = sv_groupby_bins.swap_dims({"echo_range_bins": "echo_range"}).drop_vars(
+            "echo_range_bins"
         )
         return 10 * np.log10(sv_groupby_bins)
 

--- a/echopype/preprocess/api.py
+++ b/echopype/preprocess/api.py
@@ -10,7 +10,9 @@ from .noise_est import NoiseEst
 
 
 def _check_range_uniqueness(ds):
-    """Check if range (``echo_range``) changes across ping in a given frequency channel."""
+    """
+    Check if range (``echo_range``) changes across ping in a given frequency channel.
+    """
     return (
         ds["echo_range"].isel(ping_time=0).dropna(dim="range_sample")
         == ds["echo_range"].dropna(dim="range_sample")
@@ -18,7 +20,8 @@ def _check_range_uniqueness(ds):
 
 
 def _set_MVBS_attrs(ds):
-    """Attach common attributes
+    """
+    Attach common attributes.
 
     Parameters
     ----------
@@ -42,7 +45,8 @@ def _set_MVBS_attrs(ds):
 
 
 def compute_MVBS(ds_Sv, range_meter_bin=20, ping_time_bin="20S"):
-    """Compute Mean Volume Backscattering Strength (MVBS)
+    """
+    Compute Mean Volume Backscattering Strength (MVBS)
     based on intervals of range (``echo_range``) and ``ping_time`` specified in physical units.
 
     Output of this function differs from that of ``compute_MVBS_index_binning``, which computes
@@ -161,7 +165,8 @@ def compute_MVBS(ds_Sv, range_meter_bin=20, ping_time_bin="20S"):
 
 
 def compute_MVBS_index_binning(ds_Sv, range_sample_num=100, ping_num=100):
-    """Compute Mean Volume Backscattering Strength (MVBS)
+    """
+    Compute Mean Volume Backscattering Strength (MVBS)
     based on intervals of ``range_sample`` and ping number (``ping_num``) specified in index number.
 
     Output of this function differs from that of ``compute_MVBS``, which computes


### PR DESCRIPTION
This PR fixes a few small things in related to `compute_MVBS` operation. Does _not_ address #662 😕

### Tasks
- [x] fix error that use `echo_range` from the first channel for all channels: this is a bug from the process of converting the data to be aligned with dimension `frequency` to `channel` in v0.6.0
- [x] re-orders the dimensions for `echo_range` in the AZFP Sv output to be consistent with data variable `Sv`
- [x] fix typing error: input `range_meter_bin` currently listed as int, but should be general as float