### PR TITLE
Fix python version requirements in docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx_rtd_theme
 sphinx-automodapi
+sphinx-panels
 sphinxcontrib-mermaid
 jupyter-book
 numpydoc

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,7 +5,7 @@ Installation and Examples
 Installation
 ------------
 
-Echopype is available and tested for Python>=3.7. The latest release
+Echopype is available and tested for Python>=3.8. The latest release
 can be installed from `PyPI <https://pypi.org/project/echopype/>`_:
 
 .. code-block:: console


### PR DESCRIPTION
This PR addresses the python version requirement discrepancy reported in #743 .

I also took this chance to address #717 for the `stable` branch. (Both `dev` and `main` have been updated.)