### PR TITLE
Fix bug in calibration that results in empty Sv

### DIFF
--- a/echopype/calibrate/calibrate_azfp.py
+++ b/echopype/calibrate/calibrate_azfp.py
@@ -1,12 +1,14 @@
 import numpy as np
 
+from ..echodata import EchoData
+
 from ..utils import uwa
 from .calibrate_base import CAL_PARAMS
 from .calibrate_ek import CalibrateBase
 
 
 class CalibrateAZFP(CalibrateBase):
-    def __init__(self, echodata, env_params, cal_params, **kwargs):
+    def __init__(self, echodata: EchoData, env_params, cal_params, **kwargs):
         super().__init__(echodata, env_params)
 
         # initialize cal params

--- a/echopype/calibrate/calibrate_base.py
+++ b/echopype/calibrate/calibrate_base.py
@@ -6,6 +6,8 @@ import scipy.interpolate
 import xarray as xr
 from typing_extensions import Literal
 
+from ..echodata import EchoData
+
 CAL_PARAMS = {
     "EK": ("sa_correction", "gain_correction", "equivalent_beam_angle"),
     "AZFP": ("EL", "DS", "TVR", "VTX", "equivalent_beam_angle", "Sv_offset"),
@@ -208,7 +210,7 @@ class EnvParams:
 class CalibrateBase(abc.ABC):
     """Class to handle calibration for all sonar models."""
 
-    def __init__(self, echodata, env_params=None):
+    def __init__(self, echodata: EchoData, env_params=None):
         self.echodata = echodata
         if isinstance(env_params, EnvParams):
             env_params = env_params._apply(echodata)

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -730,7 +730,7 @@ class CalibrateEK80(CalibrateEK):
             prx.name = "received_power"
             prx = prx.to_dataset()
 
-        # Derived params
+        # Compute derived params
 
         # Harmonize time coordinate between Beam_groupX data and env_params
         # Use self.echodata.beam because complex sample is always in Beam_group1

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -146,7 +146,7 @@ class CalibrateEK(CalibrateBase):
             for p in self.env_params.keys():
                 if isinstance(self.env_params[p], xr.DataArray):
                     if self.env_params[p]["time1"].size == 1:
-                        self.env_params[p] = self.env_params[p].squeeze().drop("time1")
+                        self.env_params[p] = self.env_params[p].squeeze(dim="time1").drop("time1")
                     else:
                         self.env_params[p] = self.env_params[p].interp(time1=ping_time)
 
@@ -758,8 +758,8 @@ class CalibrateEK80(CalibrateEK):
         # Use self.echodata.beam because complex sample is always in Beam_group1
         self._harmonize_env_param_time(ping_time=self.echodata.beam.ping_time)
 
-        sound_speed = self.env_params["sound_speed"].squeeze(drop=True)
-        absorption = self.env_params["sound_absorption"].sel(channel=chan_sel).squeeze(drop=True)
+        sound_speed = self.env_params["sound_speed"]
+        absorption = self.env_params["sound_absorption"].sel(channel=chan_sel)
         range_meter = self.range_meter.sel(channel=chan_sel)
         if waveform_mode == "BB":
             # use true center frequency for BB pulse

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -387,15 +387,6 @@ class EchoData:
         if isinstance(env_params, EnvParams):
             env_params = env_params._apply(self)
 
-        # TODO:
-        # Right now this only works with Environment.time1 with length=1
-        # If length>1 then requires interpolation
-        # See CalibrateEK._harmonize_env_param_time for implementation
-        def squeeze_non_scalar(n):
-            if not np.isscalar(n):
-                n = n.squeeze()
-            return n
-
         if "sound_speed" in env_params:
             sound_speed = self._harmonize_env_param_time(env_params["sound_speed"])
             # sound_speed = squeeze_non_scalar(env_params["sound_speed"])


### PR DESCRIPTION
The renaming of time coordinate in the `Environment` group (now called `time1` according to the convention) results in discrepancy in broadcasting the environment parameters during calibration, since the backscatter data is aligned with `ping_time`. In v0.6.0 `time1` was directly renamed to `ping_time`, which resulted in all non-matching timestamps in the backscatter data to be broadcasted to NaN. 

I think this is related to some parts of the problems seen in a number of recent issues #720 #743 #750. 

This is high priority and let's get the fix out in v0.6.1.

### Tasks
- [x] fix bugs related to time coordinate broadcasting
- [ ] add unit tests for the new function `EchoData._harmonize_env_param_time`
- [ ] add tests for catching unexpected NaN in calibrated data