### PR TITLE
Add calibrator mappings for ES70, ES80, EA640

### DIFF
--- a/docs/source/whats-new.md
+++ b/docs/source/whats-new.md
@@ -23,6 +23,7 @@ This is a minor release that includes important bug fixes, a number of new featu
 - Enhance `update_platform` to support a new use case (location data from fixed location) and add more consistency (#741)
 - Ability to parse and store RAW4 datagram for EK80 data (#714)
 - Add utility function for swapping `channel` coordinate with `frequency_nominal` (#710)
+- Add ES70, ES80, EA640 to allowed data type for calibration (#759)
 
 ## Changes of netCDF data model
 - Reorganize AD2CP data variables into different `Sonar/Beam_groupX`s and different first-level groups in a form consistent with v0.6.0 changes for all other sonar models (#731); some variables remain to be discussed and may change in future releases (#719)

--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -7,7 +7,14 @@ from ..utils.prov import echopype_prov_attrs, source_files_vars
 from .calibrate_azfp import CalibrateAZFP
 from .calibrate_ek import CalibrateEK60, CalibrateEK80
 
-CALIBRATOR = {"EK60": CalibrateEK60, "EK80": CalibrateEK80, "AZFP": CalibrateAZFP}
+CALIBRATOR = {
+    "EK60": CalibrateEK60, 
+    "EK80": CalibrateEK80, 
+    "AZFP": CalibrateAZFP,
+    "ES70": CalibrateEK60, 
+    "ES80": CalibrateEK80, 
+    "EA640": CalibrateEK80, 
+    }
 
 
 def _compute_cal(

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -29,7 +29,10 @@ XARRAY_ENGINE_MAP: Dict["FileFormatHint", "EngineHint"] = {
 
 TVG_CORRECTION_FACTOR = {
     "EK60": 2,
+    "ES70": 2,
     "EK80": 0,
+    "ES80": 0,
+    "EA640": 0,
 }
 
 
@@ -454,7 +457,7 @@ class EchoData:
             return range_meter
 
         # EK
-        elif self.sonar_model in ("EK60", "EK80"):
+        elif self.sonar_model in ("EK60", "EK80", "ES70", "ES80", "EA640"):
             waveform_mode = ek_waveform_mode
             encode_mode = ek_encode_mode
 


### PR DESCRIPTION
See https://github.com/OSOceanAcoustics/echopype/issues/750#issuecomment-1177018909

I didn't run tests locally, so I'll cross fingers that there aren't any surprises in the CI.