### PR TITLE
Change `long_name` attribute in `ds_power` for EK80

### DIFF
--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -648,7 +648,7 @@ class SetGroupsEK80(SetGroupsBase):
                 "backscatter_r": (
                     ["ping_time", "range_sample"],
                     self.parser_obj.ping_data_dict["power"][ch],
-                    {"long_name": "Backscattering power", "units": "dB"},
+                    {"long_name": "Backscatter power", "units": "dB"},
                 ),
             },
             coords={


### PR DESCRIPTION
In this PR I have changed the `long_name` attribute for the variable `backscatter_r` for EK80 from `"Backscattering power"` to `"Backscatter power"`. This makes this attribute consistent between EK60 and EK80. 