### PR TITLE
Add logging and optional printouts

### DIFF
--- a/echopype/__init__.py
+++ b/echopype/__init__.py
@@ -6,6 +6,9 @@ from . import calibrate, consolidate, preprocess, utils
 from .convert.api import open_raw
 from .echodata.api import open_converted
 from .echodata.combine import combine_echodata
+from .utils.log import verbose
+
+verbose(override=False)
 
 __all__ = [
     "open_raw",
@@ -15,4 +18,5 @@ __all__ = [
     "consolidate",
     "preprocess",
     "utils",
+    "verbose",
 ]

--- a/echopype/__init__.py
+++ b/echopype/__init__.py
@@ -8,7 +8,7 @@ from .echodata.api import open_converted
 from .echodata.combine import combine_echodata
 from .utils.log import verbose
 
-verbose(override=False)
+verbose(override=True)
 
 __all__ = [
     "open_raw",

--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -1,8 +1,7 @@
-import warnings
-
 import xarray as xr
 
 from ..echodata import EchoData
+from ..utils.log import _init_logger
 from ..utils.prov import echopype_prov_attrs, source_files_vars
 from .calibrate_azfp import CalibrateAZFP
 from .calibrate_ek import CalibrateEK60, CalibrateEK80
@@ -15,6 +14,8 @@ CALIBRATOR = {
     "ES80": CalibrateEK80,
     "EA640": CalibrateEK80,
 }
+
+logger = _init_logger(__name__)
 
 
 def _compute_cal(
@@ -39,12 +40,12 @@ def _compute_cal(
             )
     elif echodata.sonar_model in ("EK60", "AZFP"):
         if waveform_mode is not None and waveform_mode != "CW":
-            warnings.warn(
+            logger.warning(
                 "This sonar model transmits only narrowband signals (waveform_mode='CW'). "
                 "Calibration will be in CW mode",
             )
         if encode_mode is not None and encode_mode != "power":
-            warnings.warn(
+            logger.warning(
                 "This sonar model only record data as power or power/angle samples "
                 "(encode_mode='power'). Calibration will be done on the power samples.",
             )

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -3,10 +3,11 @@ import xarray as xr
 from scipy import signal
 
 from ..echodata import EchoData
-from ..utils import log, uwa
+from ..utils import uwa
+from ..utils.log import _init_logger
 from .calibrate_base import CAL_PARAMS, CalibrateBase
 
-logger = log._init_logger(__name__)
+logger = _init_logger(__name__)
 
 
 class CalibrateEK(CalibrateBase):

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -3,8 +3,10 @@ import xarray as xr
 from scipy import signal
 
 from ..echodata import EchoData
-from ..utils import uwa
+from ..utils import log, uwa
 from .calibrate_base import CAL_PARAMS, CalibrateBase
+
+logger = log._init_logger(__name__)
 
 
 class CalibrateEK(CalibrateBase):
@@ -902,11 +904,11 @@ class CalibrateEK80(CalibrateEK):
 
             if encode_mode == "power":
                 use_beam_power = True  # switch source of backscatter data
-                print(
+                logger.info(
                     "Only power samples are calibrated, but complex samples also exist in the raw data file!"  # noqa
                 )
             else:
-                print(
+                logger.info(
                     "Only complex samples are calibrated, but power samples also exist in the raw data file!"  # noqa
                 )
         else:  # only power OR complex samples exist

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -1,5 +1,4 @@
 import warnings
-from datetime import datetime as dt
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional, Tuple
 
@@ -16,7 +15,7 @@ if TYPE_CHECKING:
     from ..core import EngineHint, PathHint, SonarModelsHint
 # fmt: on
 from ..echodata.echodata import XARRAY_ENGINE_MAP, EchoData
-from ..utils import io
+from ..utils import io, log
 
 COMPRESSION_SETTINGS = {
     "netcdf4": {"zlib": True, "complevel": 4},
@@ -28,6 +27,9 @@ DEFAULT_CHUNK_SIZE = {"range_sample": 25000, "ping_time": 2500}
 NMEA_SENTENCE_DEFAULT = ["GGA", "GLL", "RMC"]
 
 BEAM_SUBGROUP_DEFAULT = "Beam_group1"
+
+# Logging setup
+logger = log._init_logger(__name__)
 
 
 def to_file(
@@ -78,15 +80,15 @@ def to_file(
 
     # Sequential or parallel conversion
     if exists and not overwrite:
-        print(
-            f"{dt.now().strftime('%H:%M:%S')}  {echodata.source_file} has already been converted to {engine}. "  # noqa
+        logger.info(
+            f"{echodata.source_file} has already been converted to {engine}. "  # noqa
             f"File saving not executed."
         )
     else:
         if exists:
-            print(f"{dt.now().strftime('%H:%M:%S')}  overwriting {output_file}")
+            logger.info(f"overwriting {output_file}")
         else:
-            print(f"{dt.now().strftime('%H:%M:%S')}  saving {output_file}")
+            logger.info(f"saving {output_file}")
         _save_groups_to_file(
             echodata,
             output_path=io.sanitize_file_path(
@@ -367,7 +369,7 @@ def open_raw(
     EchoData object
     """
     if (sonar_model is None) and (raw_file is None):
-        print("Please specify the path to the raw data file and the sonar model.")
+        logger.warning("Please specify the path to the raw data file and the sonar model.")
         return
 
     # Check inputs
@@ -376,7 +378,7 @@ def open_raw(
     storage_options = storage_options if storage_options is not None else {}
 
     if sonar_model is None:
-        print("Please specify the sonar model.")
+        logger.warning("Please specify the sonar model.")
 
         if xml_path is None:
             sonar_model = "EK60"

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -15,7 +15,8 @@ if TYPE_CHECKING:
     from ..core import EngineHint, PathHint, SonarModelsHint
 # fmt: on
 from ..echodata.echodata import XARRAY_ENGINE_MAP, EchoData
-from ..utils import io, log
+from ..utils import io
+from ..utils.log import _init_logger
 
 COMPRESSION_SETTINGS = {
     "netcdf4": {"zlib": True, "complevel": 4},
@@ -29,7 +30,7 @@ NMEA_SENTENCE_DEFAULT = ["GGA", "GLL", "RMC"]
 BEAM_SUBGROUP_DEFAULT = "Beam_group1"
 
 # Logging setup
-logger = log._init_logger(__name__)
+logger = _init_logger(__name__)
 
 
 def to_file(

--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -8,12 +8,12 @@ from struct import unpack
 import fsspec
 import numpy as np
 
-from ..utils import log
+from ..utils.log import _init_logger
 from .parse_base import ParseBase
 
 FILENAME_DATETIME_AZFP = "\\w+.01A"
 
-logger = log._init_logger(__name__)
+logger = _init_logger(__name__)
 
 
 class ParseAZFP(ParseBase):

--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -8,9 +8,12 @@ from struct import unpack
 import fsspec
 import numpy as np
 
+from ..utils import log
 from .parse_base import ParseBase
 
 FILENAME_DATETIME_AZFP = "\\w+.01A"
+
+logger = log._init_logger(__name__)
 
 
 class ParseAZFP(ParseBase):
@@ -273,10 +276,7 @@ class ParseAZFP(ParseBase):
         )
         timestr = timestamp.strftime("%Y-%b-%d %H:%M:%S")
         pathstr, xml_name = os.path.split(self.xml_path)
-        print(
-            f"{dt.now().strftime('%H:%M:%S')}  parsing file {filename} with {xml_name}, "
-            f"time of first ping: {timestr}"
-        )
+        logger.info(f"parsing file {filename} with {xml_name}, " f"time of first ping: {timestr}")
 
     def _split_header(self, raw, header_unpacked):
         """Splits the header information into a dictionary.
@@ -300,7 +300,7 @@ class ParseAZFP(ParseBase):
         ):  # first field should match hard-coded FILE_TYPE from manufacturer
             check_eof = raw.read(1)
             if check_eof:
-                print("Error: Unknown file type")
+                logger.error("Unknown file type")
                 return False
         header_byte_cnt = 0
 

--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -4,11 +4,14 @@ from datetime import datetime as dt
 
 import numpy as np
 
+from ..utils import log
 from .utils.ek_raw_io import RawSimradFile, SimradEOF
 
 FILENAME_DATETIME_EK60 = (
     "(?P<survey>.+)?-?D(?P<date>\\w{1,8})-T(?P<time>\\w{1,6})-?(?P<postfix>\\w+)?.raw"
 )
+
+logger = log._init_logger(__name__)
 
 
 class ParseBase:
@@ -54,9 +57,8 @@ class ParseEK(ParseBase):
 
     def _print_status(self):
         time = self.config_datagram["timestamp"].astype(dt).strftime("%Y-%b-%d %H:%M:%S")
-        print(
-            f"{dt.now().strftime('%H:%M:%S')}  parsing file {os.path.basename(self.source_file)}, "
-            f"time of first ping: {time}"
+        logger.info(
+            f"parsing file {os.path.basename(self.source_file)}, " f"time of first ping: {time}"
         )
 
     def parse_raw(self):
@@ -80,7 +82,7 @@ class ParseEK(ParseBase):
                     xml_type = "environment"
                 elif "CONFIG" in self.data_type:
                     xml_type = "configuration"
-                print(f"{dt.now().strftime('%H:%M:%S')} exporting {xml_type} XML file")
+                logger.info(f"exporting {xml_type} XML file")
                 # Don't parse anything else if only the config xml is required.
                 if "CONFIG" in self.data_type:
                     return
@@ -314,18 +316,18 @@ class ParseEK(ParseBase):
 
             # TAG datagrams contain time-stamped annotations inserted via the recording software
             elif new_datagram["type"].startswith("TAG"):
-                print("TAG datagram encountered.")
+                logger.info("TAG datagram encountered.")
 
             # BOT datagrams contain sounder detected bottom depths from .bot files
             elif new_datagram["type"].startswith("BOT"):
-                print("BOT datagram encountered.")
+                logger.info("BOT datagram encountered.")
 
             # DEP datagrams contain sounder detected bottom depths from .out files
             # as well as reflectivity data
             elif new_datagram["type"].startswith("DEP"):
-                print("DEP datagram encountered.")
+                logger.info("DEP datagram encountered.")
             else:
-                print("Unknown datagram type: " + str(new_datagram["type"]))
+                logger.info("Unknown datagram type: " + str(new_datagram["type"]))
 
     def _append_channel_ping_data(self, datagram, rx=True):
         """

--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -4,14 +4,14 @@ from datetime import datetime as dt
 
 import numpy as np
 
-from ..utils import log
+from ..utils.log import _init_logger
 from .utils.ek_raw_io import RawSimradFile, SimradEOF
 
 FILENAME_DATETIME_EK60 = (
     "(?P<survey>.+)?-?D(?P<date>\\w{1,8})-T(?P<time>\\w{1,6})-?(?P<postfix>\\w+)?.raw"
 )
 
-logger = log._init_logger(__name__)
+logger = _init_logger(__name__)
 
 
 class ParseBase:

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -1,16 +1,18 @@
-import warnings
 from collections import defaultdict
 
 import numpy as np
 import xarray as xr
 
 from ..utils.coding import set_encodings
+from ..utils.log import _init_logger
 from ..utils.prov import echopype_prov_attrs, source_files_vars
 
 # fmt: off
 from .set_groups_base import DEFAULT_CHUNK_SIZE, SetGroupsBase
 
 # fmt: on
+
+logger = _init_logger(__name__)
 
 
 class SetGroupsEK60(SetGroupsBase):
@@ -84,7 +86,7 @@ class SetGroupsEK60(SetGroupsBase):
                     backscatter_r[all_duplicates_idx[0]],
                     backscatter_r[all_duplicates_idx[1]],
                 ):
-                    warnings.warn(
+                    logger.warning(
                         "duplicate pings with identical values detected; the duplicate pings will be removed"  # noqa
                     )
                     for v in self.parser_obj.ping_data_dict.values():
@@ -96,7 +98,7 @@ class SetGroupsEK60(SetGroupsBase):
                             v[ch] = [v[ch][i] for i in unique_idx]
                     self.parser_obj.ping_time[ch] = self.parser_obj.ping_time[ch][unique_idx]
                 else:
-                    warnings.warn(
+                    logger.warning(
                         "duplicate ping times detected; the duplicate times will be incremented by 1 nanosecond and remain in the ping_time coordinate. The original ping times will be preserved in the Provenance group"  # noqa
                     )
 

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -4,8 +4,11 @@ from typing import List
 import numpy as np
 import xarray as xr
 
+from ..utils import log
 from ..utils.coding import set_encodings
 from .set_groups_base import SetGroupsBase
+
+logger = log._init_logger(__name__)
 
 
 class SetGroupsEK80(SetGroupsBase):
@@ -226,7 +229,7 @@ class SetGroupsEK80(SetGroupsBase):
             water_level = self.parser_obj.environment["water_level_draft"]
         else:
             water_level = np.nan
-            print("WARNING: The water_level_draft was not in the file. " "Value set to NaN.")
+            logger.info("WARNING: The water_level_draft was not in the file. Value set to NaN.")
 
         time1, msg_type, lat, lon = self._parse_NMEA()
         time2 = self.parser_obj.mru.get("timestamp", None)

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -4,11 +4,11 @@ from typing import List
 import numpy as np
 import xarray as xr
 
-from ..utils import log
 from ..utils.coding import set_encodings
+from ..utils.log import _init_logger
 from .set_groups_base import SetGroupsBase
 
-logger = log._init_logger(__name__)
+logger = _init_logger(__name__)
 
 
 class SetGroupsEK80(SetGroupsBase):

--- a/echopype/convert/utils/ek_raw_io.py
+++ b/echopype/convert/utils/ek_raw_io.py
@@ -6,18 +6,18 @@ by Rick Towler <rick.towler@noaa.gov> at NOAA AFSC.
 Contains low-level functions called by ./ek_raw_parsers.py
 """
 
-import logging
 import struct
 from io import SEEK_CUR, SEEK_END, SEEK_SET, BufferedReader, FileIO
 
 import fsspec
 from fsspec.implementations.local import LocalFileSystem
 
+from ...utils.log import _init_logger
 from . import ek_raw_parsers as parsers
 
 __all__ = ["RawSimradFile"]
 
-log = logging.getLogger(__name__)
+log = _init_logger(__name__)
 
 
 class SimradEOF(Exception):
@@ -590,7 +590,7 @@ class RawSimradFile(BufferedReader):
             dgram_size = self._read_dgram_size()
 
         except DatagramSizeError:
-            print("Error reading the datagram")
+            log.info("Error reading the datagram")
             self._seek_bytes(old_file_pos, SEEK_SET)
             raise
 

--- a/echopype/convert/utils/ek_raw_io.py
+++ b/echopype/convert/utils/ek_raw_io.py
@@ -17,7 +17,7 @@ from . import ek_raw_parsers as parsers
 
 __all__ = ["RawSimradFile"]
 
-log = _init_logger(__name__)
+logger = _init_logger(__name__)
 
 
 class SimradEOF(Exception):
@@ -265,7 +265,7 @@ class RawSimradFile(BufferedReader):
 
         #  check for invalid time data
         if (header["low_date"], header["high_date"]) == (0, 0):
-            log.warning(
+            logger.warning(
                 "Skipping %s datagram w/ timestamp of (0, 0) at %sL:%d",
                 header["type"],
                 str(self._tell_bytes()),
@@ -277,7 +277,7 @@ class RawSimradFile(BufferedReader):
         #  basic sanity check on size
         if header["size"] < 16:
             #  size can't be smaller than the header size
-            log.warning(
+            logger.warning(
                 "Invalid datagram header: size: %d, type: %s, nt_date: %s.  dgram_size < 16",
                 header["size"],
                 header["type"],
@@ -303,7 +303,7 @@ class RawSimradFile(BufferedReader):
 
         #  and make sure it checks out
         if bytes_read < header["size"]:
-            log.warning(
+            logger.warning(
                 "Datagram %d (@%d) shorter than expected length:  %d < %d",
                 self.tell(),
                 old_file_pos,
@@ -324,14 +324,14 @@ class RawSimradFile(BufferedReader):
         #  make sure they match
         if header["size"] != dgram_size_check:
             # self._seek_bytes(old_file_pos, SEEK_SET)
-            log.warning(
+            logger.warning(
                 "Datagram failed size check:  %d != %d @ (%d, %d)",
                 header["size"],
                 dgram_size_check,
                 self._tell_bytes(),
                 self.tell(),
             )
-            log.warning("Skipping to next datagram...")
+            logger.warning("Skipping to next datagram...")
             self._find_next_datagram()
 
             return self._read_next_dgram()
@@ -473,17 +473,17 @@ class RawSimradFile(BufferedReader):
 
     def _find_next_datagram(self):
         old_file_pos = self._tell_bytes()
-        log.warning("Attempting to find next valid datagram...")
+        logger.warning("Attempting to find next valid datagram...")
 
         try:
             while self.peek()["type"][:3] not in list(self.DGRAM_TYPE_KEY.keys()):
                 self._seek_bytes(1, 1)
         except DatagramReadError:
-            log.warning("No next datagram found. Ending reading of file.")
+            logger.warning("No next datagram found. Ending reading of file.")
             raise SimradEOF()
         else:
-            log.warning("Found next datagram:  %s", self.peek())
-            log.warning("Skipped ahead %d bytes", self._tell_bytes() - old_file_pos)
+            logger.warning("Found next datagram:  %s", self.peek())
+            logger.warning("Skipped ahead %d bytes", self._tell_bytes() - old_file_pos)
 
     def tell(self):
         """
@@ -539,7 +539,7 @@ class RawSimradFile(BufferedReader):
         header = self.peek()
 
         if header["size"] < 16:
-            log.warning(
+            logger.warning(
                 "Invalid datagram header: size: %d, type: %s, nt_date: %s.  dgram_size < 16",
                 header["size"],
                 header["type"],
@@ -553,14 +553,14 @@ class RawSimradFile(BufferedReader):
             dgram_size_check = self._read_dgram_size()
 
             if header["size"] != dgram_size_check:
-                log.warning(
+                logger.warning(
                     "Datagram failed size check:  %d != %d @ (%d, %d)",
                     header["size"],
                     dgram_size_check,
                     self._tell_bytes(),
                     self.tell(),
                 )
-                log.warning("Skipping to next datagram... (in skip)")
+                logger.warning("Skipping to next datagram... (in skip)")
 
                 self._find_next_datagram()
 
@@ -590,7 +590,7 @@ class RawSimradFile(BufferedReader):
             dgram_size = self._read_dgram_size()
 
         except DatagramSizeError:
-            log.info("Error reading the datagram")
+            logger.info("Error reading the datagram")
             self._seek_bytes(old_file_pos, SEEK_SET)
             raise
 
@@ -615,7 +615,7 @@ class RawSimradFile(BufferedReader):
             try:
                 new_dgram = next(self)
             except Exception:
-                log.debug("Caught EOF?")
+                logger.debug("Caught EOF?")
                 raise StopIteration
 
             yield new_dgram

--- a/echopype/convert/utils/ek_raw_parsers.py
+++ b/echopype/convert/utils/ek_raw_parsers.py
@@ -7,7 +7,6 @@ The code has been modified to handle split-beam data and
 channel-transducer structure from different EK80 setups.
 """
 
-import logging
 import re
 import struct
 import sys
@@ -16,6 +15,7 @@ from collections import Counter
 
 import numpy as np
 
+from ...utils.log import _init_logger
 from .ek_date_conversion import nt_to_unix
 
 TCVR_CH_NUM_MATCHER = re.compile(r"\d{6}-\w{1,2}|\w{12}-\w{1,2}")
@@ -29,7 +29,7 @@ __all__ = [
     "SimradRawParser",
 ]
 
-log = logging.getLogger(__name__)
+logger = _init_logger(__name__)
 
 
 class _SimradDatagramParser(object):
@@ -189,8 +189,8 @@ class SimradDepthParser(_SimradDatagramParser):
 
             if len(set(lengths)) != 1:
                 min_indx = min(lengths)
-                log.warning("Data lengths mismatched:  d:%d, r:%d, u:%d, t:%d", *lengths)
-                log.warning("  Using minimum value:  %d", min_indx)
+                logger.warning("Data lengths mismatched:  d:%d, r:%d, u:%d, t:%d", *lengths)
+                logger.warning("  Using minimum value:  %d", min_indx)
                 data["transceiver_count"] = min_indx
 
             else:
@@ -280,7 +280,7 @@ class SimradBottomParser(_SimradDatagramParser):
         if version == 0:
 
             if len(data["depth"]) != data["transceiver_count"]:
-                log.warning(
+                logger.warning(
                     "# of depth values %d does not match transceiver count %d",
                     len(data["depth"]),
                     data["transceiver_count"],
@@ -1326,12 +1326,12 @@ class SimradConfigParser(_SimradDatagramParser):
                 transducer_header = self._transducer_headers[sounder_name]
                 _sounder_name_used = sounder_name
             except KeyError:
-                log.warning(
+                logger.warning(
                     "Unknown sounder_name:  %s, (no one of %s)",
                     sounder_name,
                     list(self._transducer_headers.keys()),
                 )
-                log.warning("Will use ER60 transducer config fields as default")
+                logger.warning("Will use ER60 transducer config fields as default")
 
                 transducer_header = self._transducer_headers["ER60"]
                 _sounder_name_used = "ER60"
@@ -1403,7 +1403,7 @@ class SimradConfigParser(_SimradDatagramParser):
         if version == 0:
 
             if data["transceiver_count"] != len(data["transceivers"]):
-                log.warning("Mismatch between 'transceiver_count' and actual # of transceivers")
+                logger.warning("Mismatch between 'transceiver_count' and actual # of transceivers")
                 data["transceiver_count"] = len(data["transceivers"])
 
             sounder_name = data["sounder_name"]
@@ -1424,12 +1424,12 @@ class SimradConfigParser(_SimradDatagramParser):
                 transducer_header = self._transducer_headers[sounder_name]
                 _sounder_name_used = sounder_name
             except KeyError:
-                log.warning(
+                logger.warning(
                     "Unknown sounder_name:  %s, (no one of %s)",
                     sounder_name,
                     list(self._transducer_headers.keys()),
                 )
-                log.warning("Will use ER60 transducer config fields as default")
+                logger.warning("Will use ER60 transducer config fields as default")
 
                 transducer_header = self._transducer_headers["ER60"]
                 _sounder_name_used = "ER60"
@@ -1685,19 +1685,19 @@ class SimradRawParser(_SimradDatagramParser):
 
             if data["count"] > 0:
                 if (int(data["mode"]) & 0x1) and (len(data.get("power", [])) != data["count"]):
-                    log.warning(
+                    logger.warning(
                         "Data 'count' = %d, but contains %d power samples.  Ignoring power."
                     )
                     data["mode"] &= ~(1 << 0)
 
                 if (int(data["mode"]) & 0x2) and (len(data.get("angle", [])) != data["count"]):
-                    log.warning(
+                    logger.warning(
                         "Data 'count' = %d, but contains %d angle samples.  Ignoring angle."
                     )
                     data["mode"] &= ~(1 << 1)
 
                 if data["mode"] == 0:
-                    log.warning(
+                    logger.warning(
                         "Data 'count' = %d, but mode == 0.  Setting count to 0",
                         data["count"],
                     )

--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -1,9 +1,9 @@
-import warnings
 from pathlib import Path
 from typing import Any, Dict, List
 
 import xarray as xr
 from datatree import DataTree
+from loguru import logger
 
 from ..core import SONAR_MODELS
 from ..qc import coerce_increasing_time, exist_reversed_time
@@ -59,7 +59,7 @@ def check_and_correct_reversed_time(combined_group, old_time, new_time, time_str
 
     if time_str in combined_group and exist_reversed_time(combined_group, time_str):
         if old_time is None:
-            warnings.warn(
+            logger.warning(
                 f"{sonar_model} {time_str} reversal detected; {time_str} will be corrected"  # noqa
                 " (see https://github.com/OSOceanAcoustics/echopype/pull/297)"
             )

--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -3,13 +3,15 @@ from typing import Any, Dict, List
 
 import xarray as xr
 from datatree import DataTree
-from loguru import logger
 
 from ..core import SONAR_MODELS
 from ..qc import coerce_increasing_time, exist_reversed_time
 from ..utils.coding import set_encodings
+from ..utils.log import _init_logger
 from ..utils.prov import echopype_prov_attrs, source_files_vars
 from .echodata import EchoData
+
+logger = _init_logger(__name__)
 
 
 def union_attrs(datasets: List[xr.Dataset]) -> Dict[str, Any]:

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 from ..calibrate.env_params import EnvParams
 from ..utils.coding import set_encodings
 from ..utils.io import check_file_existence, sanitize_file_path
+from ..utils.log import _init_logger
 from ..utils.uwa import calc_sound_speed
 from .convention import sonarnetcdf_1
 from .sensor_ep_version_mapping import ep_version_mapper
@@ -34,6 +35,8 @@ TVG_CORRECTION_FACTOR = {
     "ES80": 0,
     "EA640": 0,
 }
+
+logger = _init_logger(__name__)
 
 
 class EchoData:
@@ -671,7 +674,7 @@ class EchoData:
             if var in platform and (~platform[var].isnull()).all():
                 dropped_vars.append(var)
         if len(dropped_vars) > 0:
-            warnings.warn(
+            logger.warning(
                 f"Some variables in the original Platform group will be overwritten: {', '.join(dropped_vars)}"  # noqa
             )
         platform = platform.drop_vars(

--- a/echopype/echodata/sensor_ep_version_mapping/v05x_to_v06x.py
+++ b/echopype/echodata/sensor_ep_version_mapping/v05x_to_v06x.py
@@ -1,4 +1,3 @@
-import warnings
 import xml.etree.ElementTree as ET
 
 import numpy as np
@@ -6,9 +5,11 @@ import xarray as xr
 
 # TODO: turn this into an absolute import!
 from ...core import SONAR_MODELS
+from ...utils.log import _init_logger
 from ..convention import sonarnetcdf_1
 
 _varattrs = sonarnetcdf_1.yaml_dict["variable_and_varattributes"]
+logger = _init_logger(__name__)
 
 
 def _get_sensor(sensor_model):
@@ -1133,7 +1134,7 @@ def convert_v05x_to_v06x(echodata_obj):
     """
 
     # TODO: put in an appropriate link to the v5 to v6 conversion outline
-    warnings.warn(
+    logger.warning(
         "Converting echopype version 0.5.x file to 0.6.0."
         " For specific details on how items have been changed,"
         " please see the echopype documentation. It is recommended "

--- a/echopype/tests/utils/test_utils_log.py
+++ b/echopype/tests/utils/test_utils_log.py
@@ -1,0 +1,105 @@
+import logging
+import pytest
+
+EXPECTED_MESSAGE = "Testing log function"
+
+
+def logging_func(logger):
+    logger.info("Testing log function")
+
+
+@pytest.fixture(params=[False, True])
+def verbose(request):
+    return request.param
+
+
+def test_init_logger():
+    from echopype.utils import log
+    logger = log._init_logger('echopype.testing0')
+    handlers = [h.name for h in logger.handlers]
+
+    assert isinstance(logger, logging.Logger) is True
+    assert logger.name == 'echopype.testing0'
+    assert len(logger.handlers) == 2
+    assert log.STDERR_NAME in handlers
+    assert log.STDOUT_NAME in handlers
+
+
+def test_set_log_file():
+    from echopype.utils import log
+    logger = log._init_logger('echopype.testing1')
+    from tempfile import TemporaryDirectory
+    with TemporaryDirectory() as tmpdir:
+        tmpfile = tmpdir + "/testfile.log"
+        log._set_logfile(logger, tmpfile)
+        handlers = [h.name for h in logger.handlers]
+
+        assert log.LOGFILE_HANDLE_NAME in handlers
+
+
+def test_set_verbose(verbose, capsys):
+    from echopype.utils import log
+    logger = log._init_logger(f'echopype.testing_{str(verbose).lower()}')
+
+    # To pass through in caplog need to propagate
+    # logger.propagate = True
+
+    log._set_verbose(verbose)
+
+    logging_func(logger)
+
+    captured = capsys.readouterr()
+
+    if verbose:
+        assert EXPECTED_MESSAGE in captured.out
+    else:
+        assert "" in captured.out
+
+
+def test_get_all_loggers():
+    from echopype.utils import log
+    all_loggers = log._get_all_loggers()
+    loggers = [logging.getLogger()]  # get the root logger
+    loggers = loggers + [logging.getLogger(name) for name in logging.root.manager.loggerDict]
+
+    assert all_loggers == loggers
+
+
+def run_verbose_test(logger, override, logfile, capsys):
+    import echopype as ep
+    import os
+
+    ep.verbose(logfile=logfile, override=override)
+
+    logging_func(logger)
+
+    captured = capsys.readouterr()
+
+    if override is False:
+        assert captured.out == ""
+    else:
+        assert EXPECTED_MESSAGE in captured.out
+
+    if logfile is not None:
+        assert os.path.exists(logfile)
+        with open(logfile) as f:
+            assert EXPECTED_MESSAGE in f.read()
+
+
+@pytest.mark.parametrize(["id", "override", "logfile"], [
+    ("fn", False, None),
+    ("tn", True, None),
+    ("nn", None, None),
+    ("tf", True, 'test.log')
+])
+def test_verbose(id, override, logfile, capsys):
+    from echopype.utils import log
+    logger = log._init_logger(f'echopype.testing_{id}')
+
+    if logfile is not None:
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmpdir:
+            tmpfile = tmpdir + f'/{logfile}'
+            run_verbose_test(logger, override, tmpfile, capsys)
+    else:
+        run_verbose_test(logger, override, logfile, capsys)

--- a/echopype/tests/utils/test_utils_log.py
+++ b/echopype/tests/utils/test_utils_log.py
@@ -1,4 +1,3 @@
-import logging
 import pytest
 
 EXPECTED_MESSAGE = "Testing log function"
@@ -14,6 +13,7 @@ def verbose(request):
 
 
 def test_init_logger():
+    import logging
     from echopype.utils import log
     logger = log._init_logger('echopype.testing0')
     handlers = [h.name for h in logger.handlers]
@@ -57,6 +57,7 @@ def test_set_verbose(verbose, capsys):
 
 
 def test_get_all_loggers():
+    import logging
     from echopype.utils import log
     all_loggers = log._get_all_loggers()
     loggers = [logging.getLogger()]  # get the root logger
@@ -75,7 +76,7 @@ def run_verbose_test(logger, override, logfile, capsys):
 
     captured = capsys.readouterr()
 
-    if override is False:
+    if override is True:
         assert captured.out == ""
     else:
         assert EXPECTED_MESSAGE in captured.out
@@ -87,10 +88,9 @@ def run_verbose_test(logger, override, logfile, capsys):
 
 
 @pytest.mark.parametrize(["id", "override", "logfile"], [
-    ("fn", False, None),
-    ("tn", True, None),
-    ("nn", None, None),
-    ("tf", True, 'test.log')
+    ("fn", True, None),
+    ("tn", False, None),
+    ("tf", False, 'test.log')
 ])
 def test_verbose(id, override, logfile, capsys):
     from echopype.utils import log

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -266,7 +266,7 @@ def test_water_level_echodata(water_level, expect_warning, caplog):
             range_in_meter=range_in_meter,
             water_level=water_level,
             data_type=EchoData,
-            platform_data=echodata.platform,
+            platform_data=echodata["Platform"],
         )
         if expect_warning:
             assert 'WARNING' in caplog.text

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -1,4 +1,3 @@
-import logging
 
 import echopype
 import echopype.visualize

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -1,3 +1,5 @@
+import logging
+
 import echopype
 import echopype.visualize
 from echopype.testing import TEST_DATA_FOLDER
@@ -212,9 +214,10 @@ def test_plot_mvbs(
         (30.5, False),
     ],
 )
-def test_water_level_echodata(water_level, expect_warning):
+def test_water_level_echodata(water_level, expect_warning, caplog):
     from echopype.echodata import EchoData
     from echopype.visualize.api import _add_water_level
+    echopype.verbose()
 
     filepath = ek60_path / "ncei-wcsd" / "Summer2017-D20170719-T211347.raw"
     sonar_model = "EK60"
@@ -259,21 +262,14 @@ def test_water_level_echodata(water_level, expect_warning):
 
     results = None
     try:
+        results = _add_water_level(
+            range_in_meter=range_in_meter,
+            water_level=water_level,
+            data_type=EchoData,
+            platform_data=echodata.platform,
+        )
         if expect_warning:
-            with pytest.warns(UserWarning):
-                results = _add_water_level(
-                    range_in_meter=range_in_meter,
-                    water_level=water_level,
-                    data_type=EchoData,
-                    platform_data=echodata.platform,
-                )
-        else:
-            results = _add_water_level(
-                range_in_meter=range_in_meter,
-                water_level=water_level,
-                data_type=EchoData,
-                platform_data=echodata.platform,
-            )
+            assert 'WARNING' in caplog.text
     except Exception as e:
         assert isinstance(e, ValueError)
         assert str(e) == 'Water level must have any of these dimensions: channel, ping_time, range_sample'  # noqa
@@ -297,8 +293,9 @@ def test_water_level_echodata(water_level, expect_warning):
         (30.5, False),
     ],
 )
-def test_water_level_Sv_dataset(water_level, expect_warning):
+def test_water_level_Sv_dataset(water_level, expect_warning, caplog):
     from echopype.visualize.api import _add_water_level
+    echopype.verbose()
 
     filepath = ek60_path / "ncei-wcsd" / "Summer2017-D20170719-T211347.raw"
     sonar_model = "EK60"
@@ -324,19 +321,14 @@ def test_water_level_Sv_dataset(water_level, expect_warning):
 
     results = None
     try:
+        results = _add_water_level(
+            range_in_meter=range_in_meter,
+            water_level=water_level,
+            data_type=xr.Dataset,
+        )
+
         if expect_warning:
-            with pytest.warns(UserWarning):
-                results = _add_water_level(
-                    range_in_meter=range_in_meter,
-                    water_level=water_level,
-                    data_type=xr.Dataset,
-                )
-        else:
-            results = _add_water_level(
-                range_in_meter=range_in_meter,
-                water_level=water_level,
-                data_type=xr.Dataset,
-            )
+            assert 'WARNING' in caplog.text
     except Exception as e:
         assert isinstance(e, ValueError)
         assert str(e) == 'Water level must have any of these dimensions: channel, ping_time, range_sample'  # noqa

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -3,13 +3,14 @@ echopype utilities for file handling
 """
 import os
 import sys
-import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Union
 
 import fsspec
 from fsspec import FSMap
 from fsspec.implementations.local import LocalFileSystem
+
+from ..utils.log import _init_logger
 
 if TYPE_CHECKING:
     from ..core import PathHint
@@ -21,6 +22,8 @@ SUPPORTED_ENGINES = {
         "ext": ".zarr",
     },
 }
+
+logger = _init_logger(__name__)
 
 
 def get_files_from_dir(folder):
@@ -162,7 +165,7 @@ def validate_output_path(
     file_ext = SUPPORTED_ENGINES[engine]["ext"]
 
     if save_path is None:
-        warnings.warn("save_path is not provided")
+        logger.warning("save_path is not provided")
 
         current_dir = Path.cwd()
         # Check permission, raise exception if no permission
@@ -171,7 +174,7 @@ def validate_output_path(
         if not out_dir.exists():
             out_dir.mkdir(parents=True)
 
-        warnings.warn(f"Resulting converted file(s) will be available at {str(out_dir)}")
+        logger.warning(f"Resulting converted file(s) will be available at {str(out_dir)}")
         out_path = str(out_dir / (Path(source_file).stem + file_ext))
     elif not isinstance(save_path, Path) and not isinstance(save_path, str):
         raise TypeError("save_path must be a string or Path")
@@ -206,7 +209,7 @@ def validate_output_path(
                 final_path = Path(save_path)
                 out_path = save_path
             if final_path.suffix != file_ext:
-                warnings.warn(
+                logger.warning(
                     "Mismatch between specified engine and save_path found; forcing output format to engine."  # noqa
                 )
     return out_path
@@ -263,7 +266,7 @@ def check_file_permissions(FILE_DIR):
                 FILE_DIR = Path(FILE_DIR)
 
             if not FILE_DIR.exists():
-                warnings.warn(f"{str(FILE_DIR)} does not exist. Attempting to create it.")
+                logger.warning(f"{str(FILE_DIR)} does not exist. Attempting to create it.")
                 FILE_DIR.mkdir(exist_ok=True, parents=True)
             TEST_FILE = FILE_DIR.joinpath(Path(".permission_test"))
             TEST_FILE.write_text("testing\n")

--- a/echopype/utils/log.py
+++ b/echopype/utils/log.py
@@ -1,0 +1,109 @@
+import logging
+import sys
+from typing import List, Optional
+
+LOG_FORMAT = "{asctime}:{name}:{levelname}: {message}"
+LOG_FORMATTER = logging.Formatter(LOG_FORMAT, style="{")
+STDOUT_NAME = "stdout_stream_handler"
+STDERR_NAME = "stderr_stream_handler"
+LOGFILE_HANDLE_NAME = "logfile_file_handler"
+
+
+class _ExcludeWarningsFilter(logging.Filter):
+    def filter(self, record):  # noqa
+        """Only lets through log messages with log level below ERROR ."""
+        return record.levelno < logging.WARNING
+
+
+def verbose(logfile: Optional[str] = None, override: Optional[bool] = None) -> None:
+    """Set the verbosity for echopype print outs.
+    If called it will output logs to terminal by default.
+
+    Parameters
+    ----------
+    logfile : str, optional
+        Optional string path to the desired log file.
+    override: bool, optional
+        Optional boolean flag to override verbosity.
+
+    Returns
+    -------
+    None
+    """
+    if override is not None and not isinstance(override, bool):
+        raise ValueError("override argument must be a boolean!")
+    package_name = __name__.split(".")[0]  # Get the package name
+    loggers = _get_all_loggers()
+    verbose = True if override is None else override
+    _set_verbose(verbose)
+    for logger in loggers:
+        if package_name in logger.name:
+            handlers = [h.name for h in logger.handlers]
+            if logfile is None:
+                if LOGFILE_HANDLE_NAME in handlers:
+                    # Remove log file handler if it exists
+                    handler = next(filter(lambda h: h.name == LOGFILE_HANDLE_NAME, logger.handlers))
+                    logger.removeHandler(handler)
+            elif LOGFILE_HANDLE_NAME not in handlers:
+                # Only add the logfile handler if it doesn't exist
+                _set_logfile(logger, logfile)
+
+
+def _get_all_loggers() -> List[logging.Logger]:
+    """Get all loggers"""
+    loggers = [logging.getLogger()]  # get the root logger
+    return loggers + [logging.getLogger(name) for name in logging.root.manager.loggerDict]
+
+
+def _init_logger(name) -> logging.Logger:
+    """Initialize logger with the default stdout stream handler
+
+    Parameters
+    ----------
+    name : str
+        Logger name
+
+    Returns
+    -------
+    logging.Logger
+    """
+    # Logging setup
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+
+    # Setup stream handler
+    STREAM_HANDLER = logging.StreamHandler(sys.stdout)
+    STREAM_HANDLER.setLevel(logging.INFO)
+    STREAM_HANDLER.set_name(STDOUT_NAME)
+    STREAM_HANDLER.setFormatter(LOG_FORMATTER)
+    STREAM_HANDLER.addFilter(_ExcludeWarningsFilter())
+    logger.addHandler(STREAM_HANDLER)
+
+    # Setup err stream handler
+    ERR_STREAM_HANDLER = logging.StreamHandler(sys.stderr)
+    ERR_STREAM_HANDLER.setLevel(logging.WARNING)
+    ERR_STREAM_HANDLER.set_name(STDERR_NAME)
+    ERR_STREAM_HANDLER.setFormatter(LOG_FORMATTER)
+    logger.addHandler(ERR_STREAM_HANDLER)
+
+    # Prevents multiple handler from propagating messages
+    # this way there are no duplicate line in logfile
+    logger.propagate = False
+    return logger
+
+
+def _set_verbose(verbose: bool) -> None:
+    if not verbose:
+        logging.disable(logging.WARNING)
+    else:
+        logging.disable(logging.NOTSET)
+
+
+def _set_logfile(logger: logging.Logger, logfile: Optional[str] = None) -> logging.Logger:
+    """Adds log file handler to logger"""
+    if not logfile:
+        raise ValueError("Please provide logfile path")
+    file_handler = logging.FileHandler(logfile)
+    file_handler.set_name(LOGFILE_HANDLE_NAME)
+    file_handler.setFormatter(LOG_FORMATTER)
+    logger.addHandler(file_handler)

--- a/echopype/utils/log.py
+++ b/echopype/utils/log.py
@@ -15,7 +15,7 @@ class _ExcludeWarningsFilter(logging.Filter):
         return record.levelno < logging.WARNING
 
 
-def verbose(logfile: Optional[str] = None, override: Optional[bool] = None) -> None:
+def verbose(logfile: Optional[str] = None, override: bool = False) -> None:
     """Set the verbosity for echopype print outs.
     If called it will output logs to terminal by default.
 
@@ -23,18 +23,20 @@ def verbose(logfile: Optional[str] = None, override: Optional[bool] = None) -> N
     ----------
     logfile : str, optional
         Optional string path to the desired log file.
-    override: bool, optional
-        Optional boolean flag to override verbosity.
+    override: bool
+        Boolean flag to override verbosity,
+        which turns off verbosity if the value is `False`.
+        Default is `False`.
 
     Returns
     -------
     None
     """
-    if override is not None and not isinstance(override, bool):
+    if not isinstance(override, bool):
         raise ValueError("override argument must be a boolean!")
     package_name = __name__.split(".")[0]  # Get the package name
     loggers = _get_all_loggers()
-    verbose = True if override is None else override
+    verbose = True if override is False else False
     _set_verbose(verbose)
     for logger in loggers:
         if package_name in logger.name:

--- a/echopype/utils/log.py
+++ b/echopype/utils/log.py
@@ -48,6 +48,13 @@ def verbose(logfile: Optional[str] = None, override: Optional[bool] = None) -> N
                 # Only add the logfile handler if it doesn't exist
                 _set_logfile(logger, logfile)
 
+            if isinstance(logfile, str):
+                # Prevents multiple handler from propagating messages
+                # this way there are no duplicate line in logfile
+                logger.propagate = False
+            else:
+                logger.propagate = True
+
 
 def _get_all_loggers() -> List[logging.Logger]:
     """Get all loggers"""
@@ -85,10 +92,6 @@ def _init_logger(name) -> logging.Logger:
     ERR_STREAM_HANDLER.set_name(STDERR_NAME)
     ERR_STREAM_HANDLER.setFormatter(LOG_FORMATTER)
     logger.addHandler(ERR_STREAM_HANDLER)
-
-    # Prevents multiple handler from propagating messages
-    # this way there are no duplicate line in logfile
-    logger.propagate = False
     return logger
 
 

--- a/echopype/visualize/api.py
+++ b/echopype/visualize/api.py
@@ -1,10 +1,12 @@
-import warnings
 from typing import Optional, Union, List
 
 import xarray as xr
 
 from .plot import _plot_echogram, FacetGrid, QuadMesh
 from ..echodata import EchoData
+from ..utils.log import _init_logger
+
+logger = _init_logger(__name__)
 
 
 def create_echogram(
@@ -68,7 +70,7 @@ def create_echogram(
     }
 
     if channel and frequency:
-        warnings.warn(
+        logger.warning(
             "Both channel and frequency are specified. Channel filtering will be used."
         )
 
@@ -200,7 +202,7 @@ def _add_water_level(
     if isinstance(water_level, bool):
         if water_level is True:
             if data_type == xr.Dataset:
-                warnings.warn(
+                logger.warning(
                     "Boolean type found for water level. Ignored since data is an xarray dataset."
                 )
                 return range_in_meter
@@ -211,11 +213,11 @@ def _add_water_level(
                 ):
                     return range_in_meter + platform_data.water_level.rename({'time3': 'ping_time'})
                 else:
-                    warnings.warn(
+                    logger.warning(
                         "Boolean type found for water level. Please provide platform data with water level in it or provide a separate water level data."  # noqa
                     )
                     return range_in_meter
-        warnings.warn(f"Water level value of {water_level} is ignored.")
+        logger.warning(f"Water level value of {water_level} is ignored.")
         return range_in_meter
     if isinstance(water_level, xr.DataArray):
         check_dims = range_in_meter.dims

--- a/echopype/visualize/plot.py
+++ b/echopype/visualize/plot.py
@@ -1,4 +1,3 @@
-import warnings
 import matplotlib.pyplot as plt
 import matplotlib.cm
 import xarray as xr
@@ -7,6 +6,9 @@ from xarray.plot.facetgrid import FacetGrid
 from matplotlib.collections import QuadMesh
 from typing import Optional, Union, List
 from .cm import cmap_d
+from ..utils.log import _init_logger
+
+logger = _init_logger(__name__)
 
 
 def _format_axis_label(axis_variable):
@@ -114,7 +116,7 @@ def _set_plot_defaults(kwargs):
     exclude_attrs = ['x', 'y', 'col', 'row']
     for attr in exclude_attrs:
         if attr in kwargs:
-            warnings.warn(f"{attr} in kwargs. Removing.")
+            logger.warning(f"{attr} in kwargs. Removing.")
             kwargs.pop(attr)
 
     return kwargs


### PR DESCRIPTION
## Overview
This PR adds logging to echopype by removing print statements throughout the code and replacing them with `logger.info`.

1. There is now a new utility module under `echopype.utils` called `log`.
2. Users can now activate the print statements by calling `ep.verbose()`.
    ```python
    import echopype as ep
    ep.verbose()
    ```
3. The `ep.verbose` function contains argument `logfile` to specify where the log should be outputted to and `override` for overriding the verbosity value, so that users can turn off and on at any time. By default, echopype now hides the info statements.

This PR resolves #457 