### PR TITLE
Try pinning xarray to previous version [all tests ci]

### DIFF
--- a/.ci_helpers/py3.10.yaml
+++ b/.ci_helpers/py3.10.yaml
@@ -8,7 +8,7 @@ dependencies:
   - pynmea2
   - pytz
   - scipy
-  - xarray
+  - xarray==2022.3.0
   - zarr
   - fsspec
   - s3fs==2022.5.0

--- a/.ci_helpers/py3.8.yaml
+++ b/.ci_helpers/py3.8.yaml
@@ -8,7 +8,7 @@ dependencies:
   - pynmea2
   - pytz
   - scipy
-  - xarray
+  - xarray==2022.3.0
   - zarr
   - fsspec
   - s3fs==2022.5.0

--- a/.ci_helpers/py3.9.yaml
+++ b/.ci_helpers/py3.9.yaml
@@ -8,7 +8,7 @@ dependencies:
   - pynmea2
   - pytz
   - scipy
-  - xarray
+  - xarray==2022.3.0
   - zarr
   - fsspec
   - s3fs==2022.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy
 pynmea2
 pytz
 scipy
-xarray
+xarray==2022.3.0
 zarr
 fsspec
 s3fs


### PR DESCRIPTION
## Overview

This PR pins `xarray` to version `2022.5.0`. The new version `2022.6.0` seem to break echopype functions.