### PR TITLE
Remove the user option to select NMEA sentences

### DIFF
--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -25,8 +25,6 @@ COMPRESSION_SETTINGS = {
 
 DEFAULT_CHUNK_SIZE = {"range_sample": 25000, "ping_time": 2500}
 
-NMEA_SENTENCE_DEFAULT = ["GGA", "GLL", "RMC"]
-
 BEAM_SUBGROUP_DEFAULT = "Beam_group1"
 
 
@@ -238,9 +236,6 @@ def _set_convert_params(param_dict: Dict[str, str]) -> Dict[str, str]:
 
     The default set of parameters include:
     - Platform group: ``platform_name``, ``platform_type``, ``platform_code_ICES``, ``water_level``
-    - Platform/NMEA: ``nmea_gps_sentence``,
-                     for selecting specific NMEA sentences,
-                     with default values ['GGA', 'GLL', 'RMC'].
     - Top-level group: ``survey_name``
 
     Other parameters will be saved to the top level.
@@ -261,7 +256,6 @@ def _set_convert_params(param_dict: Dict[str, str]) -> Dict[str, str]:
     out_params["platform_code_ICES"] = param_dict.get("platform_code_ICES", "")
     out_params["platform_type"] = param_dict.get("platform_type", "")
     out_params["water_level"] = param_dict.get("water_level", None)
-    out_params["nmea_gps_sentence"] = param_dict.get("nmea_gps_sentence", NMEA_SENTENCE_DEFAULT)
 
     # Parameters for the Top-level group
     out_params["survey_name"] = param_dict.get("survey_name", "")

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -11,6 +11,8 @@ from ..utils.prov import echopype_prov_attrs, source_files_vars
 
 DEFAULT_CHUNK_SIZE = {"range_sample": 25000, "ping_time": 2500}
 
+NMEA_SENTENCE_DEFAULT = ["GGA", "GLL", "RMC"]
+
 
 class SetGroupsBase(abc.ABC):
     """Base class for saving groups to netcdf or zarr from echosounder data files."""
@@ -146,7 +148,7 @@ class SetGroupsBase(abc.ABC):
     def _parse_NMEA(self):
         """Get the lat and lon values from the raw nmea data"""
         messages = [string[3:6] for string in self.parser_obj.nmea["nmea_string"]]
-        idx_loc = np.argwhere(np.isin(messages, self.ui_param["nmea_gps_sentence"])).squeeze()
+        idx_loc = np.argwhere(np.isin(messages, NMEA_SENTENCE_DEFAULT)).squeeze()
         if idx_loc.size == 1:  # in case of only 1 matching message
             idx_loc = np.expand_dims(idx_loc, axis=0)
         nmea_msg = []

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -145,7 +145,7 @@ class SetGroupsBase(abc.ABC):
         raise NotImplementedError
 
     # TODO: move this to be part of parser as it is not a "set" operation
-    def _parse_NMEA(self):
+    def _extract_NMEA_latlon(self):
         """Get the lat and lon values from the raw nmea data"""
         messages = [string[3:6] for string in self.parser_obj.nmea["nmea_string"]]
         idx_loc = np.argwhere(np.isin(messages, NMEA_SENTENCE_DEFAULT)).squeeze()

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -218,7 +218,7 @@ class SetGroupsEK60(SetGroupsBase):
 
         # Collect variables
         # Read lat/long from NMEA datagram
-        time1, msg_type, lat, lon = self._parse_NMEA()
+        time1, msg_type, lat, lon = self._extract_NMEA_latlon()
 
         # NMEA dataset: variables filled with nan if do not exist
         ds = xr.Dataset(

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -228,7 +228,7 @@ class SetGroupsEK80(SetGroupsBase):
             water_level = np.nan
             print("WARNING: The water_level_draft was not in the file. " "Value set to NaN.")
 
-        time1, msg_type, lat, lon = self._parse_NMEA()
+        time1, msg_type, lat, lon = self._extract_NMEA_latlon()
         time2 = self.parser_obj.mru.get("timestamp", None)
         time2 = np.array(time2) if time2 is not None else [np.nan]
 


### PR DESCRIPTION
In this PR I address #580. This PR removes the option that allows the user to select a subset of the GPS position sentences. It then ensures that we only select the NMEA sentences: `["GGA", "GLL", "RMC"] `.