### PR TITLE
Add attention statement in docs for `open_raw` beta feature

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -34,6 +34,8 @@ EchoData class
 Open raw and converted files
 ----------------------------
 
+.. _api-open_raw:
+
 .. automodule:: echopype
    :members: open_raw
 

--- a/docs/source/convert.rst
+++ b/docs/source/convert.rst
@@ -85,7 +85,7 @@ all files from the same deployment.
     In version 0.6.2 of echopype we improved the in-memory usage of ``open_raw``
     by allowing users to directly write variables that may consume a large amount of memory
     into a temporary zarr store (see `#774 <https://github.com/OSOceanAcoustics/echopype/pull/774>`_).
-    
+
     This feature is accessible through ``open_raw`` via arguments ``offload_to_zarr`` and ``max_zarr_mb``
     and is only available for the following echosounders: EK60, ES70, EK80, ES80, EA640.
     See :ref:`API reference <api-open_raw>` for usage.

--- a/docs/source/convert.rst
+++ b/docs/source/convert.rst
@@ -85,10 +85,10 @@ all files from the same deployment.
     In version 0.6.2 of echopype we improved the in-memory usage of ``open_raw``
     by allowing users to directly write variables that may consume a large amount of memory
     into a temporary zarr store (see `#774 <https://github.com/OSOceanAcoustics/echopype/pull/774>`_).
-    This feature is accessible through ``open_raw`` and is only available for
-    the following echosounders: EK60, ES70, EK80, ES80, EA640. Additionally, this
-    feature is currently in beta.
-
+    This feature is accessible through ``open_raw`` via arguments ``offload_to_zarr`` and ``max_zarr_mb``
+    and is only available for the following echosounders: EK60, ES70, EK80, ES80, EA640. 
+    See [API references](api) for usage.
+    This is currently a beta feature that will benefit from user feedback.
 
 File access
 -----------

--- a/docs/source/convert.rst
+++ b/docs/source/convert.rst
@@ -85,9 +85,10 @@ all files from the same deployment.
     In version 0.6.2 of echopype we improved the in-memory usage of ``open_raw``
     by allowing users to directly write variables that may consume a large amount of memory
     into a temporary zarr store (see `#774 <https://github.com/OSOceanAcoustics/echopype/pull/774>`_).
+    
     This feature is accessible through ``open_raw`` via arguments ``offload_to_zarr`` and ``max_zarr_mb``
     and is only available for the following echosounders: EK60, ES70, EK80, ES80, EA640.
-    See [API references](api) for usage.
+    See :ref:`API reference <api-open_raw>` for usage.
     This is currently a beta feature that will benefit from user feedback.
 
 File access

--- a/docs/source/convert.rst
+++ b/docs/source/convert.rst
@@ -86,7 +86,7 @@ all files from the same deployment.
     by allowing users to directly write variables that may consume a large amount of memory
     into a temporary zarr store (see `#774 <https://github.com/OSOceanAcoustics/echopype/pull/774>`_).
     This feature is accessible through ``open_raw`` via arguments ``offload_to_zarr`` and ``max_zarr_mb``
-    and is only available for the following echosounders: EK60, ES70, EK80, ES80, EA640. 
+    and is only available for the following echosounders: EK60, ES70, EK80, ES80, EA640.
     See [API references](api) for usage.
     This is currently a beta feature that will benefit from user feedback.
 

--- a/docs/source/convert.rst
+++ b/docs/source/convert.rst
@@ -81,6 +81,14 @@ all files from the same deployment.
    The ``EchoData`` instance contains all the data unpacked from the raw file,
    so it is a good idea to clear it from memory once done with conversion.
 
+.. attention::
+    In version 0.6.2 of echopype we improved the in-memory usage of ``open_raw``
+    by allowing users to directly write variables that may consume a large amount of memory
+    into a temporary zarr store (see `#774 <https://github.com/OSOceanAcoustics/echopype/pull/774>`_).
+    This feature is accessible through ``open_raw`` and is only available for
+    the following echosounders: EK60, ES70, EK80, ES80, EA640. Additionally, this
+    feature is currently in beta.
+
 
 File access
 -----------


### PR DESCRIPTION
This PR adds an attention statement in the `Convert raw files` documentation page. It notifies our users that we added a feature that improves in-memory usage of `open_raw`, however, that it is currently in beta and only available for some echosounder models. 