### PR TITLE
Change `_` to `-` in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ fsspec
 s3fs
 xarray-datatree==0.0.6
 psutil==5.9.1
-more_itertools==8.13.0
+more-itertools==8.13.0


### PR DESCRIPTION
This PR changes the `_` for a `-` in the specification of `more-itertools`. 

Thanks @ocefpaf for pointing this out:

> Pip changes that automatically but in conda those are different characters.