### PR TITLE
Remove print statement in version conversion routine

### DIFF
--- a/echopype/echodata/sensor_ep_version_mapping/v05x_to_v06x.py
+++ b/echopype/echodata/sensor_ep_version_mapping/v05x_to_v06x.py
@@ -192,8 +192,6 @@ def _frequency_to_channel(ed_obj, sensor):
 
     channel_id = get_channel_id(ed_obj, sensor)  # all channel ids
 
-    print(f"channel_id = {channel_id}")
-
     for grp_path in ed_obj.group_paths:
 
         if "frequency" in ed_obj[grp_path]:


### PR DESCRIPTION
While looking at the version 0.0.5 to 0.0.6 conversion routine, I noticed that there was an unnecessary print happening. This PR removes this print statement. 