### PR TITLE
`open_raw(offload_to_zarr=True)` integration tests and bug fix

### DIFF
--- a/echopype/convert/parsed_to_zarr_ek60.py
+++ b/echopype/convert/parsed_to_zarr_ek60.py
@@ -261,11 +261,13 @@ class Parsed2ZarrEK60(Parsed2Zarr):
         # convert channel column to a string
         self.datagram_df["channel"] = self.datagram_df["channel"].astype(str)
 
-        self._write_power(df=self.datagram_df, max_mb=max_mb)
+        if not self.datagram_df.empty:
+            self._write_power(df=self.datagram_df, max_mb=max_mb)
 
         del self.datagram_df["power"]  # free memory
 
-        self._write_angle(df=self.datagram_df, max_mb=max_mb)
+        if not self.datagram_df.empty:
+            self._write_angle(df=self.datagram_df, max_mb=max_mb)
 
         del self.datagram_df  # free memory
 

--- a/echopype/convert/parsed_to_zarr_ek80.py
+++ b/echopype/convert/parsed_to_zarr_ek80.py
@@ -281,12 +281,14 @@ class Parsed2ZarrEK80(Parsed2ZarrEK60):
             self._get_zarr_dfs()
             del self.parser_obj.zarr_datagrams  # free memory
 
-        self._write_power(df=self.pow_ang_df, max_mb=max_mb)
-        self._write_angle(df=self.pow_ang_df, max_mb=max_mb)
+        if not self.pow_ang_df.empty:
+            self._write_power(df=self.pow_ang_df, max_mb=max_mb)
+            self._write_angle(df=self.pow_ang_df, max_mb=max_mb)
 
         del self.pow_ang_df  # free memory
 
-        self._write_complex(df=self.complex_df, max_mb=max_mb)
+        if not self.complex_df.empty:
+            self._write_complex(df=self.complex_df, max_mb=max_mb)
 
         del self.complex_df  # free memory
 

--- a/echopype/test_data/README.md
+++ b/echopype/test_data/README.md
@@ -11,8 +11,6 @@ Most of these files are stored on Git LFS but the ones that aren't (due to file 
 - 2019118 group2survey-D20191214-T081342.raw: Contains 6 channels but only 2 of those channels collect ping data
 - D20200528-T125932.raw: Data collected from WBT mini (instead of WBT), from @emlynjdavies
 - Green2.Survey2.FM.short.slow.-D20191004-T211557.raw: Contains 2-in-1 transducer, from @FletcherFT (reduced from 104.9 MB to 765 KB in test data updates)
-- raw4-D20220514-T172704.raw: Contains RAW4 datagram, 1 channel only, from @cornejotux
-- D20210330-T123857.raw: do not contain filter coefficients
 
 
 ### EA640
@@ -24,7 +22,6 @@ Most of these files are stored on Git LFS but the ones that aren't (due to file 
 - Winter2017-D20170115-T150122.raw: Contains a change of recording length in the middle of the file
 - 2015843-D20151023-T190636.raw: Not used in tests but contains ranges are not constant across ping times
 - SH1701_consecutive_files_w_range_change: Not used in tests. [Folder](https://drive.google.com/drive/u/1/folders/1PaDtL-xnG5EK3N3P1kGlXa5ub16Yic0f) on shared drive that contains sequential files with ranges that are not constant across ping times.
-- NBP_B050N-D20180118-T090228.raw: split-beam setup without angle data
 
 
 ### AZFP

--- a/echopype/test_data/README.md
+++ b/echopype/test_data/README.md
@@ -11,6 +11,8 @@ Most of these files are stored on Git LFS but the ones that aren't (due to file 
 - 2019118 group2survey-D20191214-T081342.raw: Contains 6 channels but only 2 of those channels collect ping data
 - D20200528-T125932.raw: Data collected from WBT mini (instead of WBT), from @emlynjdavies
 - Green2.Survey2.FM.short.slow.-D20191004-T211557.raw: Contains 2-in-1 transducer, from @FletcherFT (reduced from 104.9 MB to 765 KB in test data updates)
+- raw4-D20220514-T172704.raw: Contains RAW4 datagram, 1 channel only, from @cornejotux
+- D20210330-T123857.raw: do not contain filter coefficients
 
 
 ### EA640
@@ -22,6 +24,7 @@ Most of these files are stored on Git LFS but the ones that aren't (due to file 
 - Winter2017-D20170115-T150122.raw: Contains a change of recording length in the middle of the file
 - 2015843-D20151023-T190636.raw: Not used in tests but contains ranges are not constant across ping times
 - SH1701_consecutive_files_w_range_change: Not used in tests. [Folder](https://drive.google.com/drive/u/1/folders/1PaDtL-xnG5EK3N3P1kGlXa5ub16Yic0f) on shared drive that contains sequential files with ranges that are not constant across ping times.
+- NBP_B050N-D20180118-T090228.raw: split-beam setup without angle data
 
 
 ### AZFP


### PR DESCRIPTION
In this PR I added some integration tests for the `offload_to_zarr=True` option in `open_raw`. The integration tests are for some EK60 and EK80 files. The test ensures that the output of `open_raw` for `offload_to_zarr=True` and `offload_to_zarr=False` are identical. 

While running these tests, I found that there is a small bug in PR #774. This PR did not account for the case where no data can exist for those variables written directly to zarr. This PR also fixes this bug. 

@leewujung for the integration tests, I used most of the files we came up with when we were doing integration tests for the conversion routine. Can you think of any other files that would be good to test? 