### PR TITLE
Clean up `combine_echodata`

### DIFF
--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -146,7 +146,7 @@ def examine_group_time_coords(
 
     Notes
     -----
-    If old time coordinates need to be stored, ``old_times``
+    If old time coordinates need to be stored, the input variable ``old_times``
     will be directly modified.
 
     This does not check the AD2CP time coordinates!

--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -32,15 +32,18 @@ def check_echodatas_input(echodatas: List[EchoData]) -> Tuple[str, List[str]]:
         The source files names for all values in ``echodatas``
     """
 
-    sonar_model = None
+    # get the sonar model for the combined object
+    if echodatas[0].sonar_model is None:
+        raise ValueError("all EchoData objects must have non-None sonar_model values")
+    else:
+        sonar_model = echodatas[0].sonar_model
+
     echodata_filenames = []
     for ed in echodatas:
 
-        # check sonar model and store it
+        # check sonar model
         if ed.sonar_model is None:
             raise ValueError("all EchoData objects must have non-None sonar_model values")
-        elif sonar_model is None:
-            sonar_model = ed.sonar_model
         elif ed.sonar_model != sonar_model:
             raise ValueError("all EchoData objects must have the same sonar_model value")
 
@@ -52,6 +55,7 @@ def check_echodatas_input(echodatas: List[EchoData]) -> Tuple[str, List[str]]:
         else:
             # unreachable
             raise ValueError("EchoData object does not have a file path")
+
         filename = Path(filepath).name
         if filename in echodata_filenames:
             raise ValueError("EchoData objects have conflicting filenames")

--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -138,7 +138,7 @@ def examine_group_time_coords(
     combined_group: xr.Dataset
         Dataset representing a combined ``EchoData`` group
     group: str
-        Group name of ``combined_group`` obtained from ``Echodata.group_map``
+        Group name of ``combined_group`` obtained from ``EchoData.group_map``
     sonar_model: str
         Name of sonar model
     old_times: Dict[str, Optional[xr.DataArray]]

--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -157,23 +157,6 @@ def combine_echodata(echodatas: List[EchoData], combine_attrs="override") -> Ech
         elif echodata.sonar_model != sonar_model:
             raise ValueError("all EchoData objects must have the same sonar_model value")
 
-    # ping time before reversal correction
-    old_ping_time = None
-    # ping time after reversal correction
-    new_ping_time = None
-    # location time before reversal correction
-    old_time1 = None
-    # location time after reversal correction
-    new_time1 = None
-    # mru time before reversal correction
-    old_time2 = None
-    # mru time after reversal correction
-    new_time2 = None
-    # time3 before reversal correction
-    old_time3 = None
-    # time3 after reversal correction
-    new_time3 = None
-
     # all attributes before combination
     # { group1: [echodata1 attrs, echodata2 attrs, ...], ... }
     old_attrs: Dict[str, List[Dict[str, Any]]] = dict()

--- a/echopype/qc/api.py
+++ b/echopype/qc/api.py
@@ -1,4 +1,5 @@
 import numpy as np
+import xarray as xr
 
 
 def _clean_ping_time(ping_time_old, local_win_len=100):
@@ -25,12 +26,11 @@ def _clean_ping_time(ping_time_old, local_win_len=100):
         return ping_time_old  # no negative diff
 
 
-def coerce_increasing_time(ds, time_name="ping_time", local_win_len=100):
-    """Coerce a time coordinate to always flow forward.
-
-    This is to correct for problems sometimes observed in EK60 data
-    where a time coordinate (``ping_time`` or ``time1``)
-    would suddenly go backward for one ping but with the rest of the pinging interval undisturbed.
+def coerce_increasing_time(ds: xr.Dataset, time_name: str = "ping_time",
+                           local_win_len: int = 100) -> None:
+    """
+    Coerce a time coordinate so that it always flows forward. If coercion
+    is necessary, the input `ds` will be directly modified.
 
     Parameters
     ----------
@@ -45,9 +45,15 @@ def coerce_increasing_time(ds, time_name="ping_time", local_win_len=100):
     Returns
     -------
     the input dataset but with specified time coordinate coerced to flow forward
+
+    Notes
+    -----
+    This is to correct for problems sometimes observed in EK60 data
+    where a time coordinate (``ping_time`` or ``time1``) would suddenly
+    go backward for one ping, but then the rest of the pinging interval
+    would remain undisturbed.
     """
     ds[time_name] = _clean_ping_time(ds[time_name].values, local_win_len=local_win_len)
-    return ds
 
 
 def exist_reversed_time(ds, time_name):

--- a/echopype/qc/api.py
+++ b/echopype/qc/api.py
@@ -26,8 +26,9 @@ def _clean_ping_time(ping_time_old, local_win_len=100):
         return ping_time_old  # no negative diff
 
 
-def coerce_increasing_time(ds: xr.Dataset, time_name: str = "ping_time",
-                           local_win_len: int = 100) -> None:
+def coerce_increasing_time(
+    ds: xr.Dataset, time_name: str = "ping_time", local_win_len: int = 100
+) -> None:
     """
     Coerce a time coordinate so that it always flows forward. If coercion
     is necessary, the input `ds` will be directly modified.
@@ -53,6 +54,7 @@ def coerce_increasing_time(ds: xr.Dataset, time_name: str = "ping_time",
     go backward for one ping, but then the rest of the pinging interval
     would remain undisturbed.
     """
+
     ds[time_name] = _clean_ping_time(ds[time_name].values, local_win_len=local_win_len)
 
 


### PR DESCRIPTION
This PR addresses issue #705, cleans up the current state of `combine_echodata`, and makes some preparation for the lazy combine option that will be implemented. The following changes were made:
* remove unnecessary declaration of `old_*` and `new_*` variables and replace it with a dictionary that will hold old times
* remove return of `ds` in `coerce_increasing_time` and correct documentation.
* remove `old_time/new_time` in `check_and_correct_reversed_time` input and only return `old_time`
* simplify saving of old times to the `Provenance` group of `result`
* make a function that stores all attributes in the `Provenance` group of `result`
* create a function for the in-memory combine and include kwarg for in-memory computation