### PR TITLE
Remove hard coded version in `Provenance` attributes

### DIFF
--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -2,8 +2,7 @@ from datetime import datetime as dt
 from pathlib import PosixPath
 from typing import Any, Dict, List, Tuple, Union
 
-# TODO: uncomment after release (causes flake8 to fail)
-# from _echopype_version import version as ECHOPYPE_VERSION
+from _echopype_version import version as ECHOPYPE_VERSION
 from typing_extensions import Literal
 
 ProcessType = Literal["conversion", "processing"]
@@ -18,10 +17,10 @@ def echopype_prov_attrs(process_type: ProcessType) -> Dict[str, str]:
     process_type : ProcessType
         Echopype process function type
     """
-    # TODO: change hard coded 0.6.0 after release
+
     prov_dict = {
         f"{process_type}_software_name": "echopype",
-        f"{process_type}_software_version": "0.6.0",  # ECHOPYPE_VERSION,
+        f"{process_type}_software_version": ECHOPYPE_VERSION,
         f"{process_type}_time": dt.utcnow().isoformat(timespec="seconds") + "Z",  # use UTC time
     }
 


### PR DESCRIPTION
In the 0.6.0 release we had to hard code attributes for the `Provenance` group to get flake8 to pass and prevent the conversion routine from running. Unfortunately, we forgot to remove this hard coding. This PR removes this hard coded version. 