### PR TITLE
Fix version string on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,9 @@ jobs:
           - 8080:80
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Fetch all history for all branches and tags.
       - name: Setup Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -36,7 +36,9 @@ jobs:
           - 8080:80
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Fetch all history for all branches and tags.
       - name: Setup Python
         uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
This PR should fix the version string on CI since it will now pulls all the tags and history of the repo, similar like if one clone complete repo.