### PR TITLE
Turn filenames dimension into coordinate variable

### DIFF
--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -100,7 +100,8 @@ def _compute_cal(
     else:
         source_file = "SOURCE FILE NOT IDENTIFIED"
 
-    cal_ds["source_filenames"] = source_files_vars(source_file)["source_filenames"]
+    source_files_var, source_files_coord = source_files_vars(source_file)
+    cal_ds = cal_ds.assign(**source_files_var).assign_coords(**source_files_coord)
     prov_dict = echopype_prov_attrs(process_type="processing")
     prov_dict["processing_function"] = f"calibrate.compute_{cal_type}"
     cal_ds = cal_ds.assign_attrs(prov_dict)

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -81,7 +81,8 @@ class SetGroupsBase(abc.ABC):
     def set_provenance(self) -> xr.Dataset:
         """Set the Provenance group."""
         prov_dict = echopype_prov_attrs(process_type="conversion")
-        ds = xr.Dataset(source_files_vars(self.input_file))
+        source_files_var, source_files_coord = source_files_vars(self.input_file)
+        ds = xr.Dataset(data_vars=source_files_var, coords=source_files_coord)
         ds = ds.assign_attrs(prov_dict)
         return ds
 

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -119,7 +119,7 @@ class SetGroupsEK60(SetGroupsBase):
                     "old_ping_time": self.old_ping_time,
                     **source_files_var,
                 },
-                coords=source_files_coord
+                coords=source_files_coord,
             )
         else:
             ds = xr.Dataset(data_vars=source_files_var, coords=source_files_coord)

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -111,7 +111,6 @@ class SetGroupsEK60(SetGroupsBase):
         """Set the Provenance group."""
         prov_dict = echopype_prov_attrs(process_type="conversion")
         prov_dict["duplicate_ping_times"] = 1 if self.old_ping_time is not None else 0
-        # source_files = source_files_vars(self.input_file)
         source_files_var, source_files_coord = source_files_vars(self.input_file)
         if self.old_ping_time is not None:
             ds = xr.Dataset(

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -111,16 +111,18 @@ class SetGroupsEK60(SetGroupsBase):
         """Set the Provenance group."""
         prov_dict = echopype_prov_attrs(process_type="conversion")
         prov_dict["duplicate_ping_times"] = 1 if self.old_ping_time is not None else 0
-        source_files = source_files_vars(self.input_file)
+        # source_files = source_files_vars(self.input_file)
+        source_files_var, source_files_coord = source_files_vars(self.input_file)
         if self.old_ping_time is not None:
             ds = xr.Dataset(
                 data_vars={
                     "old_ping_time": self.old_ping_time,
-                    **source_files,
-                }
+                    **source_files_var,
+                },
+                coords=source_files_coord
             )
         else:
-            ds = xr.Dataset(data_vars=source_files)
+            ds = xr.Dataset(data_vars=source_files_var, coords=source_files_coord)
         ds = ds.assign_attrs(prov_dict)
         return ds
 

--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -107,11 +107,7 @@ def check_and_correct_reversed_time(
 def assemble_combined_provenance(input_paths):
     prov_dict = echopype_prov_attrs(process_type="combination")
     source_files_var, source_files_coord = source_files_vars(input_paths)
-    ds = xr.Dataset(
-        data_vars=source_files_var,
-        coords=source_files_coord,
-        attrs=prov_dict
-    )
+    ds = xr.Dataset(data_vars=source_files_var, coords=source_files_coord, attrs=prov_dict)
     return ds
 
 

--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -105,10 +105,14 @@ def check_and_correct_reversed_time(
 
 
 def assemble_combined_provenance(input_paths):
-    return xr.Dataset(
-        data_vars=source_files_vars(input_paths),
-        attrs=echopype_prov_attrs(process_type="conversion"),
+    prov_dict = echopype_prov_attrs(process_type="combination")
+    source_files_var, source_files_coord = source_files_vars(input_paths)
+    ds = xr.Dataset(
+        data_vars=source_files_var,
+        coords=source_files_coord,
+        attrs=prov_dict
     )
+    return ds
 
 
 def union_attrs(datasets: List[xr.Dataset]) -> Dict[str, Any]:

--- a/echopype/preprocess/api.py
+++ b/echopype/preprocess/api.py
@@ -127,6 +127,9 @@ def compute_MVBS(ds_Sv, range_meter_bin=20, ping_time_bin="20S"):
         .apply(_freq_MVBS, args=(range_interval, ping_time_bin))
         .to_dataset()
     )
+    # Added this check to support the test in test_process.py::test_compute_MVBS
+    if "filenames" in ds_MVBS.variables:
+        ds_MVBS = ds_MVBS.drop_vars("filenames")
 
     # ping_time_bin parsing and conversions
     # Need to convert between pd.Timedelta and np.timedelta64 offsets/frequency strings

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -173,6 +173,10 @@ def test_plot_mvbs(
     azfp_xml_path,
     range_kwargs,
 ):
+
+    # pytest.xfail("Test momentarily (2022-9-9, EM) set to xfail due to 'Killed' failure")
+
+
     # TODO: Need to figure out how to compare the actual rendered plots
     ed = echopype.open_raw(filepath, sonar_model, azfp_xml_path)
     if ed.sonar_model.lower() == 'azfp':

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -174,9 +174,6 @@ def test_plot_mvbs(
     range_kwargs,
 ):
 
-    # pytest.xfail("Test momentarily (2022-9-9, EM) set to xfail due to 'Killed' failure")
-
-
     # TODO: Need to figure out how to compare the actual rendered plots
     ed = echopype.open_raw(filepath, sonar_model, azfp_xml_path)
     if ed.sonar_model.lower() == 'azfp':

--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -27,7 +27,7 @@ def echopype_prov_attrs(process_type: ProcessType) -> Dict[str, str]:
     return prov_dict
 
 
-def source_files_vars(source_paths: Union[str, List[Any]]) -> Dict[str, Tuple]:
+def source_files_vars(source_paths: Union[str, List[Any]]) -> Tuple[Dict[str, Tuple], Dict[str, Tuple]]:
     """
     Create source_filenames provenance variable dict to be used for creating
     xarray dataarray.
@@ -42,6 +42,9 @@ def source_files_vars(source_paths: Union[str, List[Any]]) -> Dict[str, Tuple]:
     source_files_var: Dict[str, Tuple]
         Single-element dict containing a tuple for creating the
         source_filenames xarray dataarray with filenames dimension
+    source_files_coord: Dict[str, Tuple]
+        Single-element dict containing a tuple for creating the
+        filenames coordinate variable dataarray
     """
 
     # Handle a plain string containing a single path,
@@ -59,4 +62,11 @@ def source_files_vars(source_paths: Union[str, List[Any]]) -> Dict[str, Tuple]:
         ),
     }
 
-    return source_files_var
+    source_files_coord = {
+        "filenames": (
+            "filenames",
+            list(range(len(source_files))),
+            {"long_name": "Source filenames index"},
+        ),
+    }
+    return source_files_var, source_files_coord

--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -27,7 +27,9 @@ def echopype_prov_attrs(process_type: ProcessType) -> Dict[str, str]:
     return prov_dict
 
 
-def source_files_vars(source_paths: Union[str, List[Any]]) -> Tuple[Dict[str, Tuple], Dict[str, Tuple]]:
+def source_files_vars(
+    source_paths: Union[str, List[Any]]
+) -> Tuple[Dict[str, Tuple], Dict[str, Tuple]]:
     """
     Create source_filenames provenance variable dict to be used for creating
     xarray dataarray.

--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Tuple, Union
 from _echopype_version import version as ECHOPYPE_VERSION
 from typing_extensions import Literal
 
-ProcessType = Literal["conversion", "processing"]
+ProcessType = Literal["conversion", "combination", "processing"]
 
 
 def echopype_prov_attrs(process_type: ProcessType) -> Dict[str, str]:


### PR DESCRIPTION
Addresses #742 across the board, including in the converted dataset (provenance group) and not just for `Sv`.