### PR TITLE
Modify `version_info` function

### DIFF
--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -9,7 +9,7 @@ from ..utils.log import _init_logger
 from ..utils.prov import echopype_prov_attrs, source_files_vars
 
 # fmt: off
-from .set_groups_base import DEFAULT_CHUNK_SIZE, SetGroupsBase
+from .set_groups_base import SetGroupsBase
 
 # fmt: on
 
@@ -250,7 +250,6 @@ class SetGroupsEK60(SetGroupsBase):
                 )
             },
         )
-        ds = ds.chunk({"time1": DEFAULT_CHUNK_SIZE["ping_time"]})
 
         if not NMEA_only:
             ch_ids = list(self.parser_obj.config_datagram["transceivers"].keys())
@@ -384,8 +383,6 @@ class SetGroupsEK60(SetGroupsBase):
 
             # Merge with NMEA data
             ds = xr.merge([ds, ds_plat], combine_attrs="override")
-
-            ds = ds.chunk({"time2": DEFAULT_CHUNK_SIZE["ping_time"]})
 
         return set_encodings(ds)
 

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -182,11 +182,23 @@ class EchoData:
 
     @property
     def version_info(self) -> Tuple[int]:
-        if self["Provenance"].attrs.get("conversion_software_name", None) == "echopype":
-            version_str = self["Provenance"].attrs.get("conversion_software_version", None)
+
+        # get software name from converted or combined file
+        software_name = self["Provenance"].attrs.get("conversion_software_name", None) or self[
+            "Provenance"
+        ].attrs.get("combination_software_name", None)
+
+        if software_name == "echopype":
+
+            # get software version str from converted or combined file
+            version_str = self["Provenance"].attrs.get("conversion_software_version", None) or self[
+                "Provenance"
+            ].attrs.get("combination_software_version", None)
+
             if version_str is not None:
                 version_num = version_str.split(".")[:3]
                 return tuple([int(i) for i in version_num])
+
         return None
 
     @property


### PR DESCRIPTION
This PR addresses issue #810 by looking for either `combination_*` or `conversion_*` attributes in `version_info`. 

Additionally, while testing out the changes I found that the chunking in the `Platform` group for EK60 was causing issues in the current implementation of `combine` when we write to a zarr. This is because the chunking can result in non-uniform chunks, which zarr does not allow for. The solution is to remove chunking in this area. 