### PR TITLE
Revert prov 'combination' process_type back to 'conversion'

### DIFF
--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -105,7 +105,7 @@ def check_and_correct_reversed_time(
 
 
 def assemble_combined_provenance(input_paths):
-    prov_dict = echopype_prov_attrs(process_type="combination")
+    prov_dict = echopype_prov_attrs(process_type="conversion")
     source_files_var, source_files_coord = source_files_vars(input_paths)
     ds = xr.Dataset(data_vars=source_files_var, coords=source_files_coord, attrs=prov_dict)
     return ds

--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Tuple, Union
 from _echopype_version import version as ECHOPYPE_VERSION
 from typing_extensions import Literal
 
-ProcessType = Literal["conversion", "combination", "processing"]
+ProcessType = Literal["conversion", "processing"]
 
 
 def echopype_prov_attrs(process_type: ProcessType) -> Dict[str, str]:


### PR DESCRIPTION
A change I made in #806 had downstream ramifications that are best left to the next release, 0.6.4.

I am reverting the change the provenance `process_type` used in `combine_echodata`, from "combination" back to "conversion".

I'll self merge once the CI tests are complete.

See also discussions in #810 and #811