### PR TITLE
Order the `channel` coordinate values

### DIFF
--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -210,6 +210,17 @@ class ParseAZFP(ParseBase):
         # Explicitly cast frequency to a float in accordance with the SONAR-netCDF4 convention
         self.unpacked_data["frequency"] = self.unpacked_data["frequency"].astype(np.float64)
 
+        # cast unpacked_data values to np arrays, so they are easier to reference
+        for key, val in self.unpacked_data.items():
+            # if it is not a nested list, make the value into a ndarray
+            if isinstance(val, list) and (not isinstance(val[0], list)):
+                self.unpacked_data[key] = np.asarray(val)
+
+        # cast all list parameter values to np array, so they are easier to reference
+        for key, val in self.parameters.items():
+            if isinstance(val, list):
+                self.parameters[key] = np.asarray(val)
+
     @staticmethod
     def _get_fields():
         """Returns the fields contained in each header of the raw file."""

--- a/echopype/convert/parsed_to_zarr_ek60.py
+++ b/echopype/convert/parsed_to_zarr_ek60.py
@@ -19,6 +19,16 @@ class Parsed2ZarrEK60(Parsed2Zarr):
         self.p2z_ch_ids = {}  # channel ids for power, angle, complex
         self.datagram_df = None  # df created from zarr variables
 
+        # get channel and channel_id association and sort by channel_id
+        channels = list(self.parser_obj.config_datagram["transceivers"].keys())
+        channel_ids = {
+            ch: self.parser_obj.config_datagram["transceivers"][ch]["channel_id"] for ch in channels
+        }
+        sorted_channel = dict(sorted(channel_ids.items(), key=lambda item: item[1]))
+
+        # obtain sort rule for the channel index
+        self.channel_sort_rule = dict(zip(list(map(str, channels)), sorted_channel.keys()))
+
     @staticmethod
     def _get_string_dtype(pd_series: pd.Index) -> str:
         """
@@ -55,26 +65,15 @@ class Parsed2ZarrEK60(Parsed2Zarr):
         # obtain power data
         power_series = df.set_index(self.power_dims)["power"].copy()
 
-        print(power_series.iloc[:10])
-        print(" ")
-
-        channels = list(self.parser_obj.config_datagram["transceivers"].keys())
-        channel_ids = {ch: self.parser_obj.config_datagram["transceivers"][ch]["channel_id"] for ch in channels}
-        self.sorted_channel = dict(sorted(channel_ids.items(), key=lambda item: item[1]))
-
-        print(f"self.sorted_channel = {self.sorted_channel}")
-        sort_rule = dict(zip(list(map(str, channels)), self.sorted_channel.keys()))
-        print(f"sort_rule = {sort_rule} ")
-
-        power_series.sort_index(axis=0, level=self.power_dims[1],
-                                ascending=True, key=lambda x: x.map(sort_rule), inplace=True)
-
-        print(power_series.iloc[:10])
-        print(" ")
-
         # get unique indices
         times = power_series.index.get_level_values(0).unique()
         channels = power_series.index.get_level_values(1).unique()
+
+        # sort the channels based on rule
+        _, indexer = channels.map(self.channel_sort_rule).sort_values(
+            ascending=True, return_indexer=True
+        )
+        channels = channels[indexer]
 
         self.p2z_ch_ids["power"] = channels.values  # store channel ids for variable
 
@@ -82,9 +81,6 @@ class Parsed2ZarrEK60(Parsed2Zarr):
         unique_dims = [times, channels]
 
         power_series = self.set_multi_index(power_series, unique_dims)
-
-        print("multi-index")
-        print(power_series.iloc[:10])
 
         # write power data to the power group
         zarr_grp = self.zarr_root.create_group("power")
@@ -156,6 +152,12 @@ class Parsed2ZarrEK60(Parsed2Zarr):
         # get unique indices
         times = angle_df.index.get_level_values(0).unique()
         channels = angle_df.index.get_level_values(1).unique()
+
+        # sort the channels based on rule
+        _, indexer = channels.map(self.channel_sort_rule).sort_values(
+            ascending=True, return_indexer=True
+        )
+        channels = channels[indexer]
 
         self.p2z_ch_ids["angle"] = channels.values  # store channel ids for variable
 

--- a/echopype/convert/parsed_to_zarr_ek60.py
+++ b/echopype/convert/parsed_to_zarr_ek60.py
@@ -23,18 +23,14 @@ class Parsed2ZarrEK60(Parsed2Zarr):
         if "transceivers" in self.parser_obj.config_datagram:
 
             # get channel and channel_id association and sort by channel_id
-            channels = list(self.parser_obj.config_datagram["transceivers"].keys())
-            channel_ids = {
-                ch: self.parser_obj.config_datagram["transceivers"][ch]["channel_id"]
-                for ch in channels
-            }
-            sorted_channel = dict(sorted(channel_ids.items(), key=lambda item: item[1]))
+            channels_old = list(self.parser_obj.config_datagram["transceivers"].keys())
 
-            # get just the channel
-            sorted_channel = list(sorted_channel.keys())
+            # sort the channels in ascending order
+            channels_new = channels_old[:]
+            channels_new.sort(reverse=False)
 
             # obtain sort rule for the channel index
-            self.channel_sort_rule = {str(ch): sorted_channel.index(ch) for ch in channels}
+            self.channel_sort_rule = {str(ch): channels_new.index(ch) for ch in channels_old}
 
     @staticmethod
     def _get_string_dtype(pd_series: pd.Index) -> str:

--- a/echopype/convert/parsed_to_zarr_ek60.py
+++ b/echopype/convert/parsed_to_zarr_ek60.py
@@ -19,15 +19,22 @@ class Parsed2ZarrEK60(Parsed2Zarr):
         self.p2z_ch_ids = {}  # channel ids for power, angle, complex
         self.datagram_df = None  # df created from zarr variables
 
-        # get channel and channel_id association and sort by channel_id
-        channels = list(self.parser_obj.config_datagram["transceivers"].keys())
-        channel_ids = {
-            ch: self.parser_obj.config_datagram["transceivers"][ch]["channel_id"] for ch in channels
-        }
-        sorted_channel = dict(sorted(channel_ids.items(), key=lambda item: item[1]))
+        # get the channel sort rule for EK60 type sensors
+        if "transceivers" in self.parser_obj.config_datagram:
 
-        # obtain sort rule for the channel index
-        self.channel_sort_rule = dict(zip(list(map(str, channels)), sorted_channel.keys()))
+            # get channel and channel_id association and sort by channel_id
+            channels = list(self.parser_obj.config_datagram["transceivers"].keys())
+            channel_ids = {
+                ch: self.parser_obj.config_datagram["transceivers"][ch]["channel_id"]
+                for ch in channels
+            }
+            sorted_channel = dict(sorted(channel_ids.items(), key=lambda item: item[1]))
+
+            # get just the channel
+            sorted_channel = list(sorted_channel.keys())
+
+            # obtain sort rule for the channel index
+            self.channel_sort_rule = {str(ch): sorted_channel.index(ch) for ch in channels}
 
     @staticmethod
     def _get_string_dtype(pd_series: pd.Index) -> str:

--- a/echopype/convert/parsed_to_zarr_ek80.py
+++ b/echopype/convert/parsed_to_zarr_ek80.py
@@ -21,6 +21,16 @@ class Parsed2ZarrEK80(Parsed2ZarrEK60):
         self.pow_ang_df = None  # df that holds power and angle data
         self.complex_df = None  # df that holds complex data
 
+        # get channel and channel_id association and sort by channel_id
+        channels_old = list(self.parser_obj.config_datagram["configuration"].keys())
+
+        # sort the channels in ascending order
+        channels_new = channels_old[:]
+        channels_new.sort(reverse=False)
+
+        # obtain sort rule for the channel index
+        self.channel_sort_rule = {ch: channels_new.index(ch) for ch in channels_old}
+
     def _get_num_transd_sec(self, x: pd.DataFrame):
         """
         Returns the number of transducer sectors.
@@ -125,6 +135,12 @@ class Parsed2ZarrEK80(Parsed2ZarrEK60):
         # get unique indices
         times = complex_series.index.get_level_values(0).unique()
         channels = complex_series.index.get_level_values(1).unique()
+
+        # sort the channels based on rule
+        _, indexer = channels.map(self.channel_sort_rule).sort_values(
+            ascending=True, return_indexer=True
+        )
+        channels = channels[indexer]
 
         complex_series = self._reshape_series(complex_series)
 

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -48,13 +48,13 @@ class SetGroupsAZFP(SetGroupsBase):
         self.freq_ind_sorted = [freq_new.index(ch) for ch in freq_old]
 
         # obtain sorted frequencies
-        self.freq = self.parser_obj.unpacked_data["frequency"][self.freq_ind_sorted]
+        self.freq_sorted = self.parser_obj.unpacked_data["frequency"][self.freq_ind_sorted]
 
         # obtain channel_ids
-        self.channel_ids = self._create_unique_channel_name()
+        self.channel_ids_sorted = self._create_unique_channel_name()
 
         # Put Frequency in Hz (this should be done after create_unique_channel_name)
-        self.freq = self.freq * 1000  # Frequency in Hz
+        self.freq_sorted = self.freq_sorted * 1000  # Frequency in Hz
 
     def _create_unique_channel_name(self):
         """
@@ -67,7 +67,7 @@ class SetGroupsAZFP(SetGroupsBase):
 
         if serial_number.size == 1:
 
-            freq_as_str = self.freq.astype(int).astype(str)
+            freq_as_str = self.freq_sorted.astype(int).astype(str)
 
             # TODO: replace str(i+1) with Frequency Number from XML
             channel_id = [
@@ -232,7 +232,7 @@ class SetGroupsAZFP(SetGroupsBase):
             {
                 "frequency_nominal": (
                     ["channel"],
-                    self.freq,
+                    self.freq_sorted,
                     {
                         "units": "Hz",
                         "long_name": "Transducer frequency",
@@ -257,7 +257,7 @@ class SetGroupsAZFP(SetGroupsBase):
             coords={
                 "channel": (
                     ["channel"],
-                    self.channel_ids,
+                    self.channel_ids_sorted,
                     self._varattrs["beam_coord_default"]["channel"],
                 ),
                 "ping_time": (
@@ -293,18 +293,18 @@ class SetGroupsAZFP(SetGroupsBase):
         anc = np.array(unpacked_data["ancillary"])  # convert to np array for easy slicing
 
         # Build variables in the output xarray Dataset
-        Sv_offset = np.zeros_like(self.freq)
+        Sv_offset = np.zeros_like(self.freq_sorted)
         for ind, ich in enumerate(self.freq_ind_sorted):
             # TODO: should not access the private function, better to compute Sv_offset in parser
             Sv_offset[ind] = self.parser_obj._calc_Sv_offset(
-                self.freq[ind], unpacked_data["pulse_length"][ich]
+                self.freq_sorted[ind], unpacked_data["pulse_length"][ich]
             )
 
         ds = xr.Dataset(
             {
                 "frequency_nominal": (
                     ["channel"],
-                    self.freq,
+                    self.freq_sorted,
                     {
                         "units": "Hz",
                         "long_name": "Transducer frequency",
@@ -374,7 +374,7 @@ class SetGroupsAZFP(SetGroupsBase):
             coords={
                 "channel": (
                     ["channel"],
-                    self.channel_ids,
+                    self.channel_ids_sorted,
                     self._varattrs["beam_coord_default"]["channel"],
                 ),
                 "ping_time": (

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -62,11 +62,16 @@ class SetGroupsEK60(SetGroupsBase):
 
         # obtain sorted channel dict in ascending order
         channels = list(self.parser_obj.config_datagram["transceivers"].keys())
-        channel_ids = {ch: self.parser_obj.config_datagram["transceivers"][ch]["channel_id"] for ch in channels}
+        channel_ids = {
+            ch: self.parser_obj.config_datagram["transceivers"][ch]["channel_id"] for ch in channels
+        }
         self.sorted_channel = dict(sorted(channel_ids.items(), key=lambda item: item[1]))
 
         # obtain corresponding frequency dict from sorted channels
-        self.freq = [self.parser_obj.config_datagram["transceivers"][ch]["frequency"] for ch in self.sorted_channel.keys()]
+        self.freq = [
+            self.parser_obj.config_datagram["transceivers"][ch]["frequency"]
+            for ch in self.sorted_channel.keys()
+        ]
 
         # correct duplicate ping_time
         for ch in self.sorted_channel.keys():
@@ -176,9 +181,7 @@ class SetGroupsEK60(SetGroupsBase):
                 },
             )
             # Attach channel dimension/coordinate
-            ds_tmp = ds_tmp.expand_dims(
-                {"channel": [self.sorted_channel[ch]]}
-            )
+            ds_tmp = ds_tmp.expand_dims({"channel": [self.sorted_channel[ch]]})
             ds_tmp["channel"] = ds_tmp["channel"].assign_attrs(
                 self._varattrs["beam_coord_default"]["channel"]
             )
@@ -363,9 +366,7 @@ class SetGroupsEK60(SetGroupsBase):
                 )
 
                 # Attach channel dimension/coordinate
-                ds_tmp = ds_tmp.expand_dims(
-                    {"channel": [self.sorted_channel[ch]]}
-                )
+                ds_tmp = ds_tmp.expand_dims({"channel": [self.sorted_channel[ch]]})
                 ds_tmp["channel"] = ds_tmp["channel"].assign_attrs(
                     self._varattrs["beam_coord_default"]["channel"]
                 )
@@ -752,9 +753,7 @@ class SetGroupsEK60(SetGroupsBase):
                     )
 
             # Attach frequency dimension/coordinate
-            ds_tmp = ds_tmp.expand_dims(
-                {"channel": [self.sorted_channel[ch]]}
-            )
+            ds_tmp = ds_tmp.expand_dims({"channel": [self.sorted_channel[ch]]})
             ds_tmp["channel"] = ds_tmp["channel"].assign_attrs(
                 self._varattrs["beam_coord_default"]["channel"]
             )
@@ -778,14 +777,24 @@ class SetGroupsEK60(SetGroupsBase):
     def set_vendor(self) -> xr.Dataset:
 
         # Retrieve pulse length, gain, and sa correction
-        pulse_length = np.array([self.parser_obj.config_datagram["transceivers"][ch]["pulse_length_table"] for ch in
-                                 self.sorted_channel.keys()])
+        pulse_length = np.array(
+            [
+                self.parser_obj.config_datagram["transceivers"][ch]["pulse_length_table"]
+                for ch in self.sorted_channel.keys()
+            ]
+        )
 
-        gain = np.array([self.parser_obj.config_datagram["transceivers"][ch]["gain_table"] for ch in
-                         self.sorted_channel.keys()])
+        gain = np.array(
+            [
+                self.parser_obj.config_datagram["transceivers"][ch]["gain_table"]
+                for ch in self.sorted_channel.keys()
+            ]
+        )
 
-        sa_correction = [self.parser_obj.config_datagram["transceivers"][ch]["sa_correction_table"] for ch in
-                         self.sorted_channel.keys()]
+        sa_correction = [
+            self.parser_obj.config_datagram["transceivers"][ch]["sa_correction_table"]
+            for ch in self.sorted_channel.keys()
+        ]
 
         # Save pulse length and sa correction
         ds = xr.Dataset(
@@ -805,7 +814,11 @@ class SetGroupsEK60(SetGroupsBase):
                 "pulse_length": (["channel", "pulse_length_bin"], pulse_length),
             },
             coords={
-                "channel": (["channel"], list(self.sorted_channel.values()), self._varattrs["beam_coord_default"]["channel"]),
+                "channel": (
+                    ["channel"],
+                    list(self.sorted_channel.values()),
+                    self._varattrs["beam_coord_default"]["channel"],
+                ),
                 "pulse_length_bin": (
                     ["pulse_length_bin"],
                     np.arange(pulse_length.shape[1]),

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -65,6 +65,13 @@ class SetGroupsEK60(SetGroupsBase):
         channel_ids = {
             ch: self.parser_obj.config_datagram["transceivers"][ch]["channel_id"] for ch in channels
         }
+        # example sorted_channel from a 5-channel data file for future reference:
+        # 1: 'GPT  18 kHz 009072034d45 1-1 ES18-11'
+        # 2: 'GPT  38 kHz 009072033fa2 2-1 ES38B' 
+        # 3: 'GPT  70 kHz 009072058c6c 3-1 ES70-7C'
+        # 4: 'GPT 120 kHz 00907205794e 4-1 ES120-7C'
+        # 5: 'GPT 200 kHz 0090720346a8 5-1 ES200-7C'
+        # In this particular case the channels are ordered already, but they may not be, hence the sorting here
         self.sorted_channel = dict(sorted(channel_ids.items(), key=lambda item: item[1]))
 
         # obtain corresponding frequency dict from sorted channels

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -71,7 +71,7 @@ class SetGroupsEK60(SetGroupsBase):
         # 3: 'GPT  70 kHz 009072058c6c 3-1 ES70-7C'
         # 4: 'GPT 120 kHz 00907205794e 4-1 ES120-7C'
         # 5: 'GPT 200 kHz 0090720346a8 5-1 ES200-7C'
-        # In this particular case the channels are ordered already, but they may not be, hence the sorting here
+        # In some examples the channels may not be ordered, thus sorting is required
         self.sorted_channel = dict(sorted(channel_ids.items(), key=lambda item: item[1]))
 
         # obtain corresponding frequency dict from sorted channels

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -67,7 +67,7 @@ class SetGroupsEK60(SetGroupsBase):
         }
         # example sorted_channel from a 5-channel data file for future reference:
         # 1: 'GPT  18 kHz 009072034d45 1-1 ES18-11'
-        # 2: 'GPT  38 kHz 009072033fa2 2-1 ES38B' 
+        # 2: 'GPT  38 kHz 009072033fa2 2-1 ES38B'
         # 3: 'GPT  70 kHz 009072058c6c 3-1 ES70-7C'
         # 4: 'GPT 120 kHz 00907205794e 4-1 ES120-7C'
         # 5: 'GPT 200 kHz 0090720346a8 5-1 ES200-7C'

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -71,30 +71,41 @@ class SetGroupsEK80(SetGroupsBase):
             for k, v in self.parsed2zarr_obj.p2z_ch_ids.items():
                 self.parser_obj.ch_ids[k] = self._get_channel_ids(v)
 
-        # construct sorted channel ids (ascending) for various usage scenarios
-        all_chan_ids = list(self.parser_obj.config_datagram["configuration"].keys())
-        all_chan_ids.sort(reverse=False)
-
-        power_chan_ids = self.parser_obj.ch_ids["power"]
-        power_chan_ids.sort(reverse=False)
-
-        complex_chan_ids = self.parser_obj.ch_ids["complex"]
-        complex_chan_ids.sort(reverse=False)
-
-        pow_comp_chan_ids = self.parser_obj.ch_ids["power"] + self.parser_obj.ch_ids["complex"]
-        pow_comp_chan_ids.sort(reverse=False)
-
-        angle_chan_ids = self.parser_obj.ch_ids["angle"]
-        angle_chan_ids.sort(reverse=False)
-
         # obtain sorted channel dict in ascending order for each usage scenario
         self.sorted_channel = {
-            "all": all_chan_ids,
-            "power": power_chan_ids,
-            "complex": complex_chan_ids,
-            "power_complex": pow_comp_chan_ids,
-            "angle": angle_chan_ids,
+            "all": self.sort_list(list(self.parser_obj.config_datagram["configuration"].keys())),
+            "power": self.sort_list(self.parser_obj.ch_ids["power"]),
+            "complex": self.sort_list(self.parser_obj.ch_ids["complex"]),
+            "power_complex": self.sort_list(
+                self.parser_obj.ch_ids["power"] + self.parser_obj.ch_ids["complex"]
+            ),
+            "angle": self.sort_list(self.parser_obj.ch_ids["angle"]),
         }
+
+    @staticmethod
+    def sort_list(list_in: List[str]) -> List[str]:
+        """
+        Sorts a list in ascending order and then returns
+        the sorted list.
+
+        Parameters
+        ----------
+        list_in: List[str]
+            List to be sorted
+
+        Returns
+        -------
+        List[str]
+            A copy of the input list in ascending order
+        """
+
+        # make copy so we don't directly modify input list
+        list_in_copy = list_in.copy()
+
+        # sort list in ascending order
+        list_in_copy.sort(reverse=False)
+
+        return list_in_copy
 
     def set_env(self) -> xr.Dataset:
         """Set the Environment group."""

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -73,17 +73,17 @@ class SetGroupsEK80(SetGroupsBase):
 
         # obtain sorted channel dict in ascending order for each usage scenario
         self.sorted_channel = {
-            "all": self.sort_list(list(self.parser_obj.config_datagram["configuration"].keys())),
-            "power": self.sort_list(self.parser_obj.ch_ids["power"]),
-            "complex": self.sort_list(self.parser_obj.ch_ids["complex"]),
-            "power_complex": self.sort_list(
+            "all": self._sort_list(list(self.parser_obj.config_datagram["configuration"].keys())),
+            "power": self._sort_list(self.parser_obj.ch_ids["power"]),
+            "complex": self._sort_list(self.parser_obj.ch_ids["complex"]),
+            "power_complex": self._sort_list(
                 self.parser_obj.ch_ids["power"] + self.parser_obj.ch_ids["complex"]
             ),
-            "angle": self.sort_list(self.parser_obj.ch_ids["angle"]),
+            "angle": self._sort_list(self.parser_obj.ch_ids["angle"]),
         }
 
     @staticmethod
-    def sort_list(list_in: List[str]) -> List[str]:
+    def _sort_list(list_in: List[str]) -> List[str]:
         """
         Sorts a list in ascending order and then returns
         the sorted list.


### PR DESCRIPTION
This PR addresses issue #815 by ensuring that the `channel` coordinate values are in ascending order for the EK60, EK80, and AZFP sensors (AD2CP will be addressed at a later time). This requires modification of `set_groups_*` and `parsed_to_zarr_*`. 


Attention! This is currently a draft PR. As of now, the `channel` coordinate has been ordered for EK60 and EK80. However, the `channel` dimension has not been modified for the AZFP sensor. 