### PR TITLE
🐛 Delete 'v' in version string for really old version to avoid error

### DIFF
--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -185,9 +185,9 @@ class EchoData:
         if self["Provenance"].attrs.get("conversion_software_name", None) == "echopype":
             version_str = self["Provenance"].attrs.get("conversion_software_version", None)
             if version_str is not None:
-                if "v" in version_str:
+                if version_str.startswith("v"):
                     # Removes v in case of v0.4.x or less
-                    version_str = version_str.replace("v", "")
+                    version_str = version_str.strip("v")
                 version_num = version_str.split(".")[:3]
                 return tuple([int(i) for i in version_num])
         return None

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -185,6 +185,9 @@ class EchoData:
         if self["Provenance"].attrs.get("conversion_software_name", None) == "echopype":
             version_str = self["Provenance"].attrs.get("conversion_software_version", None)
             if version_str is not None:
+                if "v" in version_str:
+                    # Removes v in case of v0.4.x or less
+                    version_str = version_str.replace("v", "")
                 version_num = version_str.split(".")[:3]
                 return tuple([int(i) for i in version_num])
         return None


### PR DESCRIPTION
## Overview

This PR is a small one to catch really old versions of echopype in Provenance. OOI used converted file that went back to 0.4.1 and the string for the version is `v0.4.1`. Rather than getting a nice not implemented error that @b-reyes has: `NotImplementedError: Conversion from echopype v0.4.1 to ...` we currently get `ValueError: invalid literal for int() with base 10: 'v0'`... so this PR fixes that bug.