### PR TITLE
Fix WindowsPath error with compute_Sv when run on Windows

### DIFF
--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -1,5 +1,5 @@
 from datetime import datetime as dt
-from pathlib import PosixPath
+from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 
 from _echopype_version import version as ECHOPYPE_VERSION
@@ -62,10 +62,10 @@ def source_files_vars(
         """Handle a plain string containing a single path,
         a single pathlib Path, or a list of strings or pathlib paths
         """
-        if type(paths) in (str, PosixPath):
+        if isinstance(paths, (str, Path)):
             return [str(paths)]
         else:
-            return [str(p) for p in paths]
+            return [str(p) for p in paths if isinstance(p, (str, Path))]
 
     source_files = _source_files(source_paths)
     source_files_var = {


### PR DESCRIPTION
Fixes the error identified in #796. 

I tested it on a Windows computer by running the relevant parts of https://osoceanacoustics.github.io/echopype-examples/echopype_tour.html. 

All CI tests are passing on Ubuntu (ie, no negative impact on Linux).