### PR TITLE
Write Parsed2Zarr  generated files to `temp_echopype_output/parsed2zarr_temp_files`

### DIFF
--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -347,7 +347,8 @@ def open_raw(
         options for cloud storage
     offload_to_zarr: bool
         If True, variables with a large memory footprint will be
-        written to a temporary zarr store.
+        written to a temporary zarr store called ``temp_echopype_output/parsed2zarr_temp_files``
+        under the current execution folder
     max_zarr_mb : int
         maximum MB that each zarr chunk should hold, when offloading
         variables with a large memory footprint to a temporary zarr store

--- a/echopype/convert/parsed_to_zarr.py
+++ b/echopype/convert/parsed_to_zarr.py
@@ -40,8 +40,12 @@ class Parsed2Zarr:
         # Check permission of cwd, raise exception if no permission
         check_file_permissions(current_dir)
 
+        # since this could be run in parallel, it is best to create a
+        # reasonably unique run directory that can be safely deleted
+        run_dir = "run_" + secrets.token_hex(16)
+
         # construct temporary directory that will hold the zarr file
-        out_dir = current_dir.joinpath(Path("temp_echopype_output") / "parsed2zarr_temp_files")
+        out_dir = current_dir.joinpath(Path("temp_echopype_output") / "parsed2zarr_temp_files" / run_dir)
         if not out_dir.exists():
             out_dir.mkdir(parents=True)
 

--- a/echopype/convert/parsed_to_zarr.py
+++ b/echopype/convert/parsed_to_zarr.py
@@ -45,7 +45,9 @@ class Parsed2Zarr:
         run_dir = "run_" + secrets.token_hex(16)
 
         # construct temporary directory that will hold the zarr file
-        out_dir = current_dir.joinpath(Path("temp_echopype_output") / "parsed2zarr_temp_files" / run_dir)
+        out_dir = current_dir.joinpath(
+            Path("temp_echopype_output") / "parsed2zarr_temp_files" / run_dir
+        )
         if not out_dir.exists():
             out_dir.mkdir(parents=True)
 

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -84,15 +84,15 @@ class EchoData:
         # TODO: this destructor seems to not work in Jupyter Lab if restart or
         #  even clear all outputs is used. It will work if you explicitly delete the object
 
-        if (self.parsed2zarr_obj is not None) and (self.parsed2zarr_obj.temp_zarr_dir is not None):
+        if (self.parsed2zarr_obj is not None) and (self.parsed2zarr_obj.zarr_file_name is not None):
 
-            # get Path object of temporary zarr directory created by Parsed2Zarr
-            p2z_temp_dir = Path(self.parsed2zarr_obj.temp_zarr_dir)
+            # get Path object of temporary zarr file created by Parsed2Zarr
+            p2z_temp_file = Path(self.parsed2zarr_obj.zarr_file_name)
 
             # remove temporary directory created by Parsed2Zarr, if it exists
-            if p2z_temp_dir.exists():
+            if p2z_temp_file.exists():
                 # TODO: do we need to check file permissions here?
-                shutil.rmtree(p2z_temp_dir)
+                shutil.rmtree(p2z_temp_file)
 
     def __str__(self) -> str:
         fpath = "Internal Memory"

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -84,7 +84,7 @@ class EchoData:
         # TODO: this destructor seems to not work in Jupyter Lab if restart or
         #  even clear all outputs is used. It will work if you explicitly delete the object
 
-        if self.parsed2zarr_obj.temp_zarr_dir is not None:
+        if (self.parsed2zarr_obj is not None) and (self.parsed2zarr_obj.temp_zarr_dir is not None):
 
             # get Path object of temporary zarr directory created by Parsed2Zarr
             p2z_temp_dir = Path(self.parsed2zarr_obj.temp_zarr_dir)

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -84,13 +84,15 @@ class EchoData:
         # TODO: this destructor seems to not work in Jupyter Lab if restart or
         #  even clear all outputs is used. It will work if you explicitly delete the object
 
-        # get Path object of temporary zarr directory created by Parsed2Zarr
-        p2z_temp_dir = Path(self.parsed2zarr_obj.temp_zarr_dir)
+        if self.parsed2zarr_obj.temp_zarr_dir is not None:
 
-        # remove temporary directory created by Parsed2Zarr, if it exists
-        if p2z_temp_dir.exists():
-            # TODO: do we need to check file permissions here?
-            shutil.rmtree(p2z_temp_dir)
+            # get Path object of temporary zarr directory created by Parsed2Zarr
+            p2z_temp_dir = Path(self.parsed2zarr_obj.temp_zarr_dir)
+
+            # remove temporary directory created by Parsed2Zarr, if it exists
+            if p2z_temp_dir.exists():
+                # TODO: do we need to check file permissions here?
+                shutil.rmtree(p2z_temp_dir)
 
     def __str__(self) -> str:
         fpath = "Internal Memory"

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -1,4 +1,5 @@
 import datetime
+import shutil
 import warnings
 from html import escape
 from pathlib import Path
@@ -77,6 +78,19 @@ class EchoData:
         # self.__read_converted(converted_raw_path)
 
         self._varattrs = sonarnetcdf_1.yaml_dict["variable_and_varattributes"]
+
+    def __del__(self):
+
+        # TODO: this destructor seems to not work in Jupyter Lab if restart or
+        #  even clear all outputs is used. It will work if you explicitly delete the object
+
+        # get Path object of temporary zarr directory created by Parsed2Zarr
+        p2z_temp_dir = Path(self.parsed2zarr_obj.temp_zarr_dir)
+
+        # remove temporary directory created by Parsed2Zarr, if it exists
+        if p2z_temp_dir.exists():
+            # TODO: do we need to check file permissions here?
+            shutil.rmtree(p2z_temp_dir)
 
     def __str__(self) -> str:
         fpath = "Internal Memory"

--- a/echopype/tests/convert/test_parsed_to_zarr.py
+++ b/echopype/tests/convert/test_parsed_to_zarr.py
@@ -2,6 +2,7 @@ import pytest
 import xarray as xr
 from typing import List, Tuple
 from echopype import open_raw
+from pathlib import Path
 
 
 @pytest.fixture
@@ -91,7 +92,13 @@ def test_raw2zarr(raw_file, sonar_model, offload_to_zarr, ek60_path):
         assert os.path.exists(output_save_path)
 
     if offload_to_zarr:
+        # create a copy of zarr_file_name. The join is necessary so that we are not referencing zarr_file_name
+        temp_zarr_path = ''.join(echodata.parsed2zarr_obj.zarr_file_name)
+
         del echodata
+
+        # make sure that the temporary zarr was deleted
+        assert Path(temp_zarr_path).exists() is False
 
 
 @pytest.mark.parametrize(
@@ -162,4 +169,10 @@ def test_direct_to_zarr_integration(path_model: str, raw_file: str,
 
         assert ed_zarr[grp].identical(ed_no_zarr[grp])
 
+    # create a copy of zarr_file_name. The join is necessary so that we are not referencing zarr_file_name
+    temp_zarr_path = ''.join(ed_zarr.parsed2zarr_obj.zarr_file_name)
+
     del ed_zarr
+
+    # make sure that the temporary zarr was deleted
+    assert Path(temp_zarr_path).exists() is False

--- a/echopype/tests/convert/test_parsed_to_zarr.py
+++ b/echopype/tests/convert/test_parsed_to_zarr.py
@@ -90,6 +90,9 @@ def test_raw2zarr(raw_file, sonar_model, offload_to_zarr, ek60_path):
         # If it goes all the way to here it is most likely successful
         assert os.path.exists(output_save_path)
 
+    if offload_to_zarr:
+        del echodata
+
 
 @pytest.mark.parametrize(
     ["path_model", "raw_file", "sonar_model"],
@@ -158,3 +161,5 @@ def test_direct_to_zarr_integration(path_model: str, raw_file: str,
             ed_zarr, ed_no_zarr = compare_zarr_vars(ed_zarr, ed_no_zarr, var_to_comp, grp)
 
         assert ed_zarr[grp].identical(ed_no_zarr[grp])
+
+    del ed_zarr


### PR DESCRIPTION
This PR addresses #825 by writing generated files to `temp_echopype_output/parsed2zarr_temp_files`, rather than using `tempfile.TemporaryDirectory()`. In addition to this, the following items were done: 
- Added a destructor to `EchoData` class to remove temp directory 
- Modify tests so that they delete the echodata object (which will delete the `parsed2zarr_temp_files`) 
    - I noticed that when I ran the tests with `open_raw(offload_to_zarr=True)`, the directory `temp_echopype_output` stuck around and I had to manually delete it. How do we want to handle this?
- Modify `open_raw` docs to let users know where the temporary files will be placed 

A few notes: 
- The `EchoData` destructor seems to not work in Jupyter Lab, even if you restart or clear all outputs. It will work if you explicitly delete the object (as long as you do not reassign the variable). 
- In the destructor, I call `shutil.rmtree()` on the temporary directory. @leewujung or @lsetiawan do you know if we need file permissions to do this? 