### PR TITLE
Fix interpolating over NA issue in `EchoData._harmonize_env_param_time()`

### DIFF
--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -296,8 +296,7 @@ class EchoData:
                     return p.squeeze(dim="time1").drop("time1")
                 else:
                     if ping_time is not None:
-                        p_nona = p.dropna(dim="time1")
-                        return p_nona.interp(time1=ping_time)
+                        return p.dropna(dim="time1").interp(time1=ping_time)
                     else:
                         raise ValueError("ping_time needs to be provided if p.time1 has length >1")
         else:

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -296,7 +296,8 @@ class EchoData:
                     return p.squeeze(dim="time1").drop("time1")
                 else:
                     if ping_time is not None:
-                        return p.interp(time1=ping_time)
+                        p_nona = p.dropna(dim="time1")
+                        return p_nona.interp(time1=ping_time)
                     else:
                         raise ValueError("ping_time needs to be provided if p.time1 has length >1")
         else:


### PR DESCRIPTION
In `EchoData._harmonize_env_param_time()` the interpolation from `Environment/time1` to `Sonar/Beam_group1/ping_time` was done without considering `NA` that may exist in `Environment/SOME_VAR`. This can result in producing additional `NA` at the locations adjacent to the `NA` entry. 

This interpolation was added in #755 to fix the problem from mismatched timestamp names in the `Environment` and `Sonar/Beam_groupX` groups.

This PR drops `NA`s first before interpolation. This should fix the issue in #834. 
