### PR TITLE
Fix more itertools in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ fsspec
 s3fs
 xarray-datatree==0.0.6
 psutil==5.9.1
-more_itertools==8.13.0
+more-itertools==8.13.0


### PR DESCRIPTION
Last release we introduced more itertools as a dependency. @leewujung found that it was incorrectly named in the requirements.txt. It looks like this incorrect naming was never fixed in the `dev` branch. In this PR, I change `more_itertools` to `more-itertools` in the requirements.txt