### PR TITLE
Fix `check_zarr_path` for `zarr_path=None`

### DIFF
--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -46,13 +46,14 @@ def check_zarr_path(
         If ``zarr_path`` already exists and ``overwrite=False``
     """
 
-    # check that zarr_path is a string, if it is not None
-    if (zarr_path is not None) and (not isinstance(zarr_path, str)):
-        raise TypeError(f"zarr_path must be of type {str}")
+    if zarr_path is not None:
+        # check that zarr_path is a string
+        if not isinstance(zarr_path, str):
+            raise TypeError(f"zarr_path must be of type {str}")
 
-    # check that the appropriate suffix was provided, if zarr_path is not None
-    if (zarr_path is not None) and (not zarr_path.strip("/").endswith(".zarr")):
-        raise ValueError("The provided zarr_path input must have '.zarr' suffix!")
+        # check that the appropriate suffix was provided
+        if not zarr_path.strip("/").endswith(".zarr"):
+            raise ValueError("The provided zarr_path input must have '.zarr' suffix!")
 
     # set default source_file name (will be used only if zarr_path is None)
     source_file = "combined_echodatas.zarr"

--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -46,12 +46,12 @@ def check_zarr_path(
         If ``zarr_path`` already exists and ``overwrite=False``
     """
 
-    # check that zarr_path is a string
-    if not isinstance(zarr_path, str):
+    # check that zarr_path is a string, if it is not None
+    if (zarr_path is not None) and (not isinstance(zarr_path, str)):
         raise TypeError(f"zarr_path must be of type {str}")
 
-    # check that the appropriate suffix was provided
-    if not zarr_path.strip("/").endswith(".zarr"):
+    # check that the appropriate suffix was provided, if zarr_path is not None
+    if (zarr_path is not None) and (not zarr_path.strip("/").endswith(".zarr")):
         raise ValueError("The provided zarr_path input must have '.zarr' suffix!")
 
     # set default source_file name (will be used only if zarr_path is None)


### PR DESCRIPTION
This PR addresses issue #839. This is done by conducting the `zarr_path` checks only if `zarr_path` is not `None`. 