### PR TITLE
Pin netcdf4 to be <1.6 for pypi package.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 dask[array,distributed]
 jinja2
-netCDF4
+# https://github.com/Unidata/netcdf4-python/issues/1175#issuecomment-1173142506
+netCDF4<1.6
 numpy
 pynmea2
 pytz


### PR DESCRIPTION
## Overview

This PR is a temporary patch for `netCDF4` issue when doing `to_netcdf` until it's fixed upstream at the very low-level `netcdf-c` library. This addresses #801 and #789