### PR TITLE
Add requests and aiohttp to dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ xarray==2022.3.0
 zarr
 fsspec
 s3fs
+requests
+aiohttp
 xarray-datatree==0.0.6
 psutil==5.9.1
 more-itertools==8.13.0


### PR DESCRIPTION
## Overview

When installing echopype from pip, I get error shown below when trying to do `open_raw` from an `http` source. This seem to be caused by `requests` and `aiohttp` libraries not being included in requirements by default. So this PR adds them in so that we don't have issues in the future and users don't need to do extra step to install it.

## Error screenshot

![Screenshot from 2022-10-11 10-17-38](https://user-images.githubusercontent.com/17802172/195158094-ed83b30b-c9c2-4dc9-b573-b8c2a008e043.png)
