### PR TITLE
Rename `set_encodings` to `set_time_encodings`

### DIFF
--- a/echopype/convert/set_groups_ad2cp.py
+++ b/echopype/convert/set_groups_ad2cp.py
@@ -7,7 +7,7 @@ import xarray as xr
 import yaml
 
 from .. import convert
-from ..utils.coding import set_encodings
+from ..utils.coding import set_time_encodings
 from .parse_ad2cp import DataType, Dimension, Field, HeaderOrDataRecordFormats
 from .set_groups_base import SetGroupsBase
 
@@ -235,7 +235,7 @@ class SetGroupsAd2cp(SetGroupsBase):
             }
         )
 
-        return set_encodings(ds)
+        return set_time_encodings(ds)
 
     def set_platform(self) -> xr.Dataset:
         ds = self._make_dataset(
@@ -252,7 +252,7 @@ class SetGroupsAd2cp(SetGroupsBase):
                 "platform_code_ICES": self.ui_param["platform_code_ICES"],  # type: ignore
             }
         )
-        return set_encodings(ds)
+        return set_time_encodings(ds)
 
     def set_beam(self) -> List[xr.Dataset]:
         # TODO: should we divide beam into burst/average (e.g., beam_burst, beam_average)
@@ -425,7 +425,7 @@ class SetGroupsAd2cp(SetGroupsBase):
         for i, ds in enumerate(beam_groups):
             beam_groups[i] = ds.sel(time1=ds["ping_time"]).drop_vars("time1", errors="ignore")
 
-        return [set_encodings(ds) for ds in beam_groups]
+        return [set_time_encodings(ds) for ds in beam_groups]
 
     def set_vendor(self) -> xr.Dataset:
         ds = self._make_dataset(
@@ -498,7 +498,7 @@ class SetGroupsAd2cp(SetGroupsBase):
             }
         )
 
-        return set_encodings(ds)
+        return set_time_encodings(ds)
 
     def set_sonar(self) -> xr.Dataset:
         """Set the Sonar group."""
@@ -534,4 +534,4 @@ class SetGroupsAd2cp(SetGroupsBase):
 
         ds = ds.assign_attrs(sonar_attr_dict)
 
-        return set_encodings(ds)
+        return set_time_encodings(ds)

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -6,7 +6,7 @@ from typing import List
 import numpy as np
 import xarray as xr
 
-from ..utils.coding import set_encodings
+from ..utils.coding import set_time_encodings
 from .set_groups_base import SetGroupsBase
 
 
@@ -109,7 +109,7 @@ class SetGroupsAZFP(SetGroupsBase):
             attrs={"long_name": "Water temperature", "units": "C"},
         )
 
-        return set_encodings(ds)
+        return set_time_encodings(ds)
 
     def set_sonar(self) -> xr.Dataset:
         """Set the Sonar group."""
@@ -182,7 +182,7 @@ class SetGroupsAZFP(SetGroupsBase):
             },
         )
         ds = ds.assign_attrs(platform_dict)
-        return set_encodings(ds)
+        return set_time_encodings(ds)
 
     def set_beam(self) -> List[xr.Dataset]:
         """Set the Beam group."""
@@ -282,7 +282,7 @@ class SetGroupsAZFP(SetGroupsBase):
             ds, self.beam_only_names, self.beam_ping_time_names, self.ping_time_only_names
         )
 
-        return [set_encodings(ds)]
+        return [set_time_encodings(ds)]
 
     def set_vendor(self) -> xr.Dataset:
         """Set the Vendor_specific group."""
@@ -425,4 +425,4 @@ class SetGroupsAZFP(SetGroupsBase):
                 "tilt_Y_d": parameters["Y_d"],
             },
         )
-        return set_encodings(ds)
+        return set_time_encodings(ds)

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -7,7 +7,7 @@ import pynmea2
 import xarray as xr
 
 from ..echodata.convention import sonarnetcdf_1
-from ..utils.coding import COMPRESSION_SETTINGS, set_encodings
+from ..utils.coding import COMPRESSION_SETTINGS, set_time_encodings
 from ..utils.prov import echopype_prov_attrs, source_files_vars
 
 NMEA_SENTENCE_DEFAULT = ["GGA", "GLL", "RMC"]
@@ -150,7 +150,7 @@ class SetGroupsBase(abc.ABC):
             attrs={"description": "All NMEA sensor datagrams"},
         )
 
-        return set_encodings(ds)
+        return set_time_encodings(ds)
 
     @abc.abstractmethod
     def set_vendor(self) -> xr.Dataset:

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -4,7 +4,7 @@ from typing import List
 import numpy as np
 import xarray as xr
 
-from ..utils.coding import set_encodings
+from ..utils.coding import set_time_encodings
 from ..utils.log import _init_logger
 from ..utils.prov import echopype_prov_attrs, source_files_vars
 
@@ -209,7 +209,7 @@ class SetGroupsEK60(SetGroupsBase):
         # Merge data from all channels
         ds = xr.merge(ds_env)
 
-        return set_encodings(ds)
+        return set_time_encodings(ds)
 
     def set_sonar(self) -> xr.Dataset:
         """Set the Sonar group."""
@@ -391,7 +391,7 @@ class SetGroupsEK60(SetGroupsBase):
         # Merge with NMEA data
         ds = xr.merge([ds, ds_plat], combine_attrs="override")
 
-        return set_encodings(ds)
+        return set_time_encodings(ds)
 
     def _set_beam_group1_zarr_vars(self, ds: xr.Dataset) -> xr.Dataset:
         """
@@ -768,7 +768,7 @@ class SetGroupsEK60(SetGroupsBase):
             ds, self.beam_only_names, self.beam_ping_time_names, self.ping_time_only_names
         )
 
-        return [set_encodings(ds)]
+        return [set_time_encodings(ds)]
 
     def set_vendor(self) -> xr.Dataset:
 

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -4,7 +4,7 @@ from typing import List
 import numpy as np
 import xarray as xr
 
-from ..utils.coding import set_encodings
+from ..utils.coding import set_time_encodings
 from ..utils.log import _init_logger
 from .set_groups_base import SetGroupsBase
 
@@ -183,7 +183,7 @@ class SetGroupsEK80(SetGroupsBase):
                 ),
             },
         )
-        return set_encodings(ds)
+        return set_time_encodings(ds)
 
     def set_sonar(self, beam_group_count=1) -> xr.Dataset:
         # Collect unique variables
@@ -427,7 +427,7 @@ class SetGroupsEK80(SetGroupsBase):
                 # TODO: check what this 'drop_keel_offset' is
             },
         )
-        return set_encodings(ds)
+        return set_time_encodings(ds)
 
     def _assemble_ds_ping_invariant(self, params, data_type):
         """Assemble dataset for ping-invariant params in the /Sonar/Beam_group1 group.
@@ -714,7 +714,7 @@ class SetGroupsEK80(SetGroupsBase):
 
         ds_tmp = self._add_freq_start_end_ds(ds_tmp, ch)
 
-        return set_encodings(ds_tmp)
+        return set_time_encodings(ds_tmp)
 
     def _add_trasmit_pulse_complex(self, ds_tmp: xr.Dataset, ch: str) -> xr.Dataset:
         """
@@ -831,7 +831,7 @@ class SetGroupsEK80(SetGroupsBase):
                 }
             )
 
-        return set_encodings(ds_tmp)
+        return set_time_encodings(ds_tmp)
 
     def _assemble_ds_common(self, ch, range_sample_size):
         """Variables common to complex and power/angle data."""
@@ -892,7 +892,7 @@ class SetGroupsEK80(SetGroupsBase):
                 ),
             },
         )
-        return set_encodings(ds_common)
+        return set_time_encodings(ds_common)
 
     @staticmethod
     def merge_save(ds_combine: List[xr.Dataset], ds_invariant: xr.Dataset) -> xr.Dataset:
@@ -902,7 +902,7 @@ class SetGroupsEK80(SetGroupsBase):
         ds_combine = xr.merge(
             [ds_invariant, ds_combine], combine_attrs="override"
         )  # override keeps the Dataset attributes
-        return set_encodings(ds_combine)
+        return set_time_encodings(ds_combine)
 
     def _attach_vars_to_ds_data(self, ds_data: xr.Dataset, ch: str, rs_size: int) -> xr.Dataset:
         """
@@ -964,13 +964,13 @@ class SetGroupsEK80(SetGroupsBase):
 
         # create power related ds using DataArrays created from zarr file
         ds_power = xr.merge([backscatter_r, angle_athwartship, angle_alongship])
-        ds_power = set_encodings(ds_power)
+        ds_power = set_time_encodings(ds_power)
 
         # obtain additional variables that need to be added to ds_power
         ds_tmp = []
         for ch in self.sorted_channel["power"]:
             ds_data = self._add_trasmit_pulse_complex(ds_tmp=xr.Dataset(), ch=ch)
-            ds_data = set_encodings(ds_data)
+            ds_data = set_time_encodings(ds_data)
 
             ds_data = self._attach_vars_to_ds_data(ds_data, ch, rs_size=ds_power.range_sample.size)
             ds_tmp.append(ds_data)
@@ -1005,7 +1005,7 @@ class SetGroupsEK80(SetGroupsBase):
 
         # create power related ds using DataArrays created from zarr file
         ds_complex = xr.merge([backscatter_r, backscatter_i])
-        ds_complex = set_encodings(ds_complex)
+        ds_complex = set_time_encodings(ds_complex)
 
         # obtain additional variables that need to be added to ds_complex
         ds_tmp = []
@@ -1013,7 +1013,7 @@ class SetGroupsEK80(SetGroupsBase):
             ds_data = self._add_trasmit_pulse_complex(ds_tmp=xr.Dataset(), ch=ch)
             ds_data = self._add_freq_start_end_ds(ds_data, ch)
 
-            ds_data = set_encodings(ds_data)
+            ds_data = set_time_encodings(ds_data)
 
             ds_data = self._attach_vars_to_ds_data(
                 ds_data, ch, rs_size=ds_complex.range_sample.size

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from ..core import EngineHint, FileFormatHint, PathHint, SonarModelsHint
 
 from ..calibrate.env_params import EnvParams
-from ..utils.coding import set_encodings
+from ..utils.coding import set_time_encodings
 from ..utils.io import check_file_existence, sanitize_file_path
 from ..utils.log import _init_logger
 from ..utils.uwa import calc_sound_speed
@@ -713,7 +713,7 @@ class EchoData:
                 var_attrs["history"] = history_attr
             platform[var] = platform[var].assign_attrs(**var_attrs)
 
-        self["Platform"] = set_encodings(platform)
+        self["Platform"] = set_time_encodings(platform)
 
     @classmethod
     def _load_convert(cls, convert_obj):

--- a/echopype/tests/echodata/test_zarr_combine.py
+++ b/echopype/tests/echodata/test_zarr_combine.py
@@ -2,7 +2,7 @@ from echopype.echodata.zarr_combine import ZarrCombine
 from dask.distributed import Client
 import numpy as np
 import xarray as xr
-from echopype.utils.coding import set_encodings
+from echopype.utils.coding import set_time_encodings
 from typing import List, Tuple, Dict
 import tempfile
 import pytest
@@ -102,7 +102,7 @@ def generate_test_ds(append_dims_ranges: Dict[str, Tuple[int, int]],
     Notes
     -----
     If a coordinate is a time value (i.e., having variable names like "*_time" or "time_*"),
-    then ``set_encodings`` will change the integer values of the coordinates to datetime stamps.
+    then ``set_time_encodings`` will change the integer values of the coordinates to datetime stamps.
 
     Examples
     --------
@@ -136,7 +136,7 @@ def generate_test_ds(append_dims_ranges: Dict[str, Tuple[int, int]],
     ds = xr.Dataset(xr_vars_dict, coords=xr_coords_dict)
 
     # set time encodings for time coordinates
-    ds = set_encodings(ds)
+    ds = set_time_encodings(ds)
 
     return ds
 

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -53,7 +53,7 @@ def _encode_dataarray(da, dtype):
     return coding.times.decode_cf_datetime(encoded_data, **read_encoding)
 
 
-def set_encodings(ds: xr.Dataset) -> xr.Dataset:
+def set_time_encodings(ds: xr.Dataset) -> xr.Dataset:
     """
     Set the default encoding for variables.
     """


### PR DESCRIPTION
This PR addresses #821 by renaming `set_encodings` to `set_time_encodings` and changing all references to the old name to `set_time_encodings`.