### PR TITLE
Return dict and standardize prov.source_files_vars usage

### DIFF
--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -104,8 +104,7 @@ def _compute_cal(
     prov_dict["processing_function"] = f"calibrate.compute_{cal_type}"
     files_vars = source_files_vars(source_file)
     cal_ds = (
-        cal_ds
-        .assign(**files_vars["source_files_var"])
+        cal_ds.assign(**files_vars["source_files_var"])
         .assign_coords(**files_vars["source_files_coord"])
         .assign_attrs(prov_dict)
     )

--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -100,11 +100,15 @@ def _compute_cal(
     else:
         source_file = "SOURCE FILE NOT IDENTIFIED"
 
-    source_files_var, _, source_files_coord = source_files_vars(source_file)
-    cal_ds = cal_ds.assign(**source_files_var).assign_coords(**source_files_coord)
     prov_dict = echopype_prov_attrs(process_type="processing")
     prov_dict["processing_function"] = f"calibrate.compute_{cal_type}"
-    cal_ds = cal_ds.assign_attrs(prov_dict)
+    files_vars = source_files_vars(source_file)
+    cal_ds = (
+        cal_ds
+        .assign(**files_vars["source_files_var"])
+        .assign_coords(**files_vars["source_files_coord"])
+        .assign_attrs(prov_dict)
+    )
 
     if "water_level" in echodata["Platform"].data_vars.keys():
         # add water_level to the created xr.Dataset

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -81,15 +81,17 @@ class SetGroupsBase(abc.ABC):
     def set_provenance(self) -> xr.Dataset:
         """Set the Provenance group."""
         prov_dict = echopype_prov_attrs(process_type="conversion")
-        source_files_var, meta_source_files_var, source_files_coord = source_files_vars(
-            self.input_file, self.xml_path
-        )
-        if meta_source_files_var is None:
-            source_vars = source_files_var
+        files_vars = source_files_vars(self.input_file, self.xml_path)
+        if files_vars["meta_source_files_var"] is None:
+            source_vars = files_vars["source_files_var"]
         else:
-            source_vars = {**source_files_var, **meta_source_files_var}
+            source_vars = {**files_vars["source_files_var"], **files_vars["meta_source_files_var"]}
 
-        ds = xr.Dataset(data_vars=source_vars, coords=source_files_coord, attrs=prov_dict)
+        ds = xr.Dataset(
+            data_vars=source_vars,
+            coords=files_vars["source_files_coord"],
+            attrs=prov_dict
+        )
 
         return ds
 

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -88,9 +88,7 @@ class SetGroupsBase(abc.ABC):
             source_vars = {**files_vars["source_files_var"], **files_vars["meta_source_files_var"]}
 
         ds = xr.Dataset(
-            data_vars=source_vars,
-            coords=files_vars["source_files_coord"],
-            attrs=prov_dict
+            data_vars=source_vars, coords=files_vars["source_files_coord"], attrs=prov_dict
         )
 
         return ds

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -132,18 +132,18 @@ class SetGroupsEK60(SetGroupsBase):
         """Set the Provenance group."""
         prov_dict = echopype_prov_attrs(process_type="conversion")
         prov_dict["duplicate_ping_times"] = 1 if self.old_ping_time is not None else 0
-        source_files_var, _, source_files_coord = source_files_vars(self.input_file)
+        files_vars = source_files_vars(self.input_file)
         if self.old_ping_time is not None:
-            ds = xr.Dataset(
-                data_vars={
-                    "old_ping_time": self.old_ping_time,
-                    **source_files_var,
-                },
-                coords=source_files_coord,
-            )
+            source_vars = {"old_ping_time": self.old_ping_time, **files_vars["source_files_var"]}
         else:
-            ds = xr.Dataset(data_vars=source_files_var, coords=source_files_coord)
-        ds = ds.assign_attrs(prov_dict)
+            source_vars = files_vars["source_files_var"]
+
+        ds = xr.Dataset(
+            data_vars=source_vars,
+            coords=files_vars["source_files_coord"],
+            attrs=prov_dict
+        )
+
         return ds
 
     def set_env(self) -> xr.Dataset:

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -139,9 +139,7 @@ class SetGroupsEK60(SetGroupsBase):
             source_vars = files_vars["source_files_var"]
 
         ds = xr.Dataset(
-            data_vars=source_vars,
-            coords=files_vars["source_files_coord"],
-            attrs=prov_dict
+            data_vars=source_vars, coords=files_vars["source_files_coord"], attrs=prov_dict
         )
 
         return ds

--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -32,7 +32,7 @@ def echopype_prov_attrs(process_type: ProcessType) -> Dict[str, str]:
 
 def source_files_vars(
     source_paths: Union[str, List[Any]], meta_source_paths: Union[str, List[Any]] = None
-) -> Tuple[Dict[str, Tuple], Dict[str, Tuple], Dict[str, Tuple]]:
+) -> Dict[str, Dict[str, Tuple]]:
     """
     Create source_filenames and meta_source_filenames provenance
     variables dicts to be used for creating xarray DataArray.
@@ -47,15 +47,17 @@ def source_files_vars(
 
     Returns
     -------
-    source_files_var : Dict[str, Tuple]
-        Single-element dict containing a tuple for creating the
-        source_filenames xarray DataArray with filenames dimension
-    meta_source_files_var : Dict[str, Tuple]
-        Single-element dict containing a tuple for creating the
-        meta_source_filenames xarray DataArray with filenames dimension
-    source_files_coord : Dict[str, Tuple]
-        Single-element dict containing a tuple for creating the
-        filenames coordinate variable DataArray
+    files_vars : Dict[str, Dict[str, Tuple]]
+        Contains 3 items:
+        source_files_var : Dict[str, Tuple]
+            Single-element dict containing a tuple for creating the
+            source_filenames xarray DataArray with filenames dimension
+        meta_source_files_var : Dict[str, Tuple]
+            Single-element dict containing a tuple for creating the
+            meta_source_filenames xarray DataArray with filenames dimension
+        source_files_coord : Dict[str, Tuple]
+            Single-element dict containing a tuple for creating the
+            filenames coordinate variable DataArray
     """
 
     def _source_files(paths):
@@ -68,7 +70,9 @@ def source_files_vars(
             return [str(p) for p in paths if isinstance(p, (str, Path))]
 
     source_files = _source_files(source_paths)
-    source_files_var = {
+    files_vars = dict()
+
+    files_vars["source_files_var"] = {
         "source_filenames": (
             "filenames",
             source_files,
@@ -78,7 +82,7 @@ def source_files_vars(
 
     if meta_source_paths is not None:
         meta_source_files = _source_files(meta_source_paths)
-        meta_source_files_var = {
+        files_vars["meta_source_files_var"] = {
             "meta_source_filenames": (
                 "filenames",
                 meta_source_files,
@@ -86,9 +90,9 @@ def source_files_vars(
             ),
         }
     else:
-        meta_source_files_var = None
+        files_vars["meta_source_files_var"] = None
 
-    source_files_coord = {
+    files_vars["source_files_coord"] = {
         "filenames": (
             "filenames",
             list(range(len(source_files))),
@@ -96,4 +100,4 @@ def source_files_vars(
         ),
     }
 
-    return source_files_var, meta_source_files_var, source_files_coord
+    return files_vars


### PR DESCRIPTION
Return a dict rather than list of variables .

This PR addresses the remaining task in #677.

Some tests are failing right now, but I suspect many, if not all these failures are not due to the changes in this PR. I tested the changes manually on several data files. I'll set the PR to draft and investigate further.