### PR TITLE
Fix `_harmonize_env_param_time` and associated `env_params` calculation

### DIFF
--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -756,8 +756,7 @@ class CalibrateEK80(CalibrateEK):
             if "channel" in self.env_params[p].coords:
                 self.env_params[p] = self.env_params[p].sel(channel=chan_sel)
             self.env_params[p] = self.echodata._harmonize_env_param_time(
-                self.env_params[p],
-                ping_time=self.echodata["Sonar/Beam_group1"].ping_time
+                self.env_params[p], ping_time=self.echodata["Sonar/Beam_group1"].ping_time
             )
 
         sound_speed = self.env_params["sound_speed"]

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -753,8 +753,11 @@ class CalibrateEK80(CalibrateEK):
         # Harmonize time coordinate between Beam_groupX data and env_params
         # Use self.echodata["Sonar/Beam_group1"] because complex sample is always in Beam_group1
         for p in self.env_params.keys():
+            if "channel" in self.env_params[p].coords:
+                self.env_params[p] = self.env_params[p].sel(channel=chan_sel)
             self.env_params[p] = self.echodata._harmonize_env_param_time(
-                self.env_params[p], ping_time=self.echodata["Sonar/Beam_group1"].ping_time
+                self.env_params[p],
+                ping_time=self.echodata["Sonar/Beam_group1"].ping_time
             )
 
         sound_speed = self.env_params["sound_speed"]

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -292,17 +292,20 @@ class EchoData:
             if "time1" not in p.coords:
                 return p
             else:
-                if p["time1"].size == 1:
-                    return p.squeeze(dim="time1").drop("time1")
+                # If there's only 1 time1 value,
+                # or if after dropping NaN there's only 1 time1 value
+                if p["time1"].size == 1 or p.dropna(dim="time1").size == 1:
+                    return p.dropna(dim="time1").squeeze(dim="time1").drop("time1")
+
+                # Direct assignment if all timestamps are identical (EK60 data)
+                elif np.all(p["time1"].values == ping_time.values):
+                    return p.rename({"time1": "ping_time"})
+
+                elif ping_time is None:
+                    raise ValueError(f"ping_time needs to be provided for interpolating {p.name}")
+
                 else:
-                    if ping_time is not None:
-                        # Direct assignment if all timestamps are identical (EK60 data)
-                        if np.all(p.time1.values == ping_time.values):
-                            return p.rename({"time1": "ping_time"})
-                        else:
-                            return p.dropna(dim="time1").interp(time1=ping_time)
-                    else:
-                        raise ValueError("ping_time needs to be provided if p.time1 has length >1")
+                    return p.dropna(dim="time1").interp(time1=ping_time)
         else:
             return p
 

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -296,7 +296,11 @@ class EchoData:
                     return p.squeeze(dim="time1").drop("time1")
                 else:
                     if ping_time is not None:
-                        return p.dropna(dim="time1").interp(time1=ping_time)
+                        # Direct assignment if all timestamps are identical (EK60 data)
+                        if np.all(p.time1.values == ping_time.values):
+                            return p.rename({"time1": "ping_time"})
+                        else:
+                            return p.dropna(dim="time1").interp(time1=ping_time)
                     else:
                         raise ValueError("ping_time needs to be provided if p.time1 has length >1")
         else:

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -105,19 +105,17 @@ def test_convert_ek80_complex_matlab(ek80_path):
     # Test complex parsed data
     ds_matlab = loadmat(ek80_matlab_path_bb)
     assert np.array_equal(
-        echodata["Sonar/Beam_group1"].backscatter_r.sel(channel='WBT 549762-15 ES70-7C',
-                                        ping_time='2017-09-12T23:49:10.722999808')
-        .dropna('range_sample')
-        .values[1:, :],
+        echodata["Sonar/Beam_group1"].backscatter_r.sel(
+            channel='WBT 549762-15 ES70-7C', ping_time='2017-09-12T23:49:10.722999808'
+        ).dropna('range_sample').squeeze().values[1:, :],
         np.real(
             ds_matlab['data']['echodata'][0][0][0, 0]['complexsamples']
         ),  # real part
     )
     assert np.array_equal(
-        echodata["Sonar/Beam_group1"].backscatter_i.sel(channel='WBT 549762-15 ES70-7C',
-                                        ping_time='2017-09-12T23:49:10.722999808')
-        .dropna('range_sample')
-        .values[1:, :],
+        echodata["Sonar/Beam_group1"].backscatter_i.sel(
+            channel='WBT 549762-15 ES70-7C', ping_time='2017-09-12T23:49:10.722999808'
+        ).dropna('range_sample').squeeze().values[1:, :],
         np.imag(
             ds_matlab['data']['echodata'][0][0][0, 0]['complexsamples']
         ),  # imag part

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -107,7 +107,7 @@ def test_convert_ek80_complex_matlab(ek80_path):
     assert np.array_equal(
         echodata["Sonar/Beam_group1"].backscatter_r.sel(
             channel='WBT 549762-15 ES70-7C', ping_time='2017-09-12T23:49:10.722999808'
-        ).dropna('range_sample').squeeze().values[1:, :],
+        ).dropna('range_sample').squeeze().values[1:, :],  # squeeze remove ping_time dimension
         np.real(
             ds_matlab['data']['echodata'][0][0][0, 0]['complexsamples']
         ),  # real part
@@ -115,7 +115,7 @@ def test_convert_ek80_complex_matlab(ek80_path):
     assert np.array_equal(
         echodata["Sonar/Beam_group1"].backscatter_i.sel(
             channel='WBT 549762-15 ES70-7C', ping_time='2017-09-12T23:49:10.722999808'
-        ).dropna('range_sample').squeeze().values[1:, :],
+        ).dropna('range_sample').squeeze().values[1:, :],  # squeeze remove ping_time dimension
         np.imag(
             ds_matlab['data']['echodata'][0][0][0, 0]['complexsamples']
         ),  # imag part


### PR DESCRIPTION
This PR addresses the following:
- change `_harmonize_env_param_time` behavior:
  - to directly rename `time1` to `ping_time` for EK60 data
  - if the env variable of interest (`p` in the function) is length=1 along `time1`, or is length=1 after dropping all NaNs along `time1`, then drop the `time1` dimension altogether (i.e. makes it a scalar)
- pre-select channel in `CalibrateEK80._cal_complex` before harmonizing env variable time dimension
- fix test `echopype/tests/convert/test_convert_ek80.py::test_convert_ek80_complex_matlab`
  - this one is mysterious: shouldn't it fail before? this is convert tests, not in calibration tests...