### PR TITLE
Add `.nbytes` to get at echodata data size

### DIFF
--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -209,6 +209,10 @@ class EchoData:
         return None
 
     @property
+    def nbytes(self) -> float:
+        return float(sum(self[p].nbytes for p in self.group_paths))
+
+    @property
     def group_paths(self) -> Set[str]:
         return {i[1:] if i != "/" else "Top-level" for i in self._tree.groups}
 


### PR DESCRIPTION
## Overview

This PR allows for a `EchoData.nbytes` call, which sums all the individual `xr.Dataset.nbytes` to get a total size of the data.