### PR TITLE
Change repr output for `Beam_group` descriptions

### DIFF
--- a/echopype/echodata/widgets/utils.py
+++ b/echopype/echodata/widgets/utils.py
@@ -23,16 +23,15 @@ def make_key(value: str) -> str:
     return value + str(uuid.uuid4())
 
 
-def _single_node_repr(node: DataTree, tree: DataTree) -> str:
+def _single_node_repr(node: DataTree) -> str:
     """
-    Obtains the string repr for a single node in a ``RenderTree``.
+    Obtains the string repr for a single node in a
+    ``RenderTree`` or ``DataTree``.
 
     Parameters
     ----------
     node: DataTree
-        A single node obtained from a ``RenderTree``
-    tree: DataTree
-        The full ``DataTree`` corresponding to``EchoData._tree``
+        A single node obtained from a ``RenderTree`` or ``DataTree``
 
     Returns
     -------
@@ -51,7 +50,7 @@ def _single_node_repr(node: DataTree, tree: DataTree) -> str:
     if "Beam_group" in sonar_group["name"]:
         # get description of Beam_group directly from the Sonar group
         group_descr = str(
-            tree["/Sonar"].ds.beam_group_descr.sel(beam_group=sonar_group["name"]).values
+            node.parent["/Sonar"].ds.beam_group_descr.sel(beam_group=sonar_group["name"]).values
         )
     else:
         # get description of group from yaml file
@@ -68,7 +67,7 @@ def tree_repr(tree: DataTree) -> str:
     lines = []
     for pre, _, node in renderer:
         if node.has_data or node.has_attrs:
-            node_repr = _single_node_repr(node, tree)
+            node_repr = _single_node_repr(node)
 
             node_line = f"{pre}{node_repr.splitlines()[0]}"
             lines.append(node_line)

--- a/echopype/echodata/widgets/utils.py
+++ b/echopype/echodata/widgets/utils.py
@@ -23,7 +23,7 @@ def make_key(value: str) -> str:
     return value + str(uuid.uuid4())
 
 
-def _single_node_repr(node: DataTree, renderer: RenderTree) -> str:
+def _single_node_repr(node: DataTree, tree: DataTree) -> str:
     """
     Obtains the string repr for a single node in a ``RenderTree``.
 
@@ -31,8 +31,8 @@ def _single_node_repr(node: DataTree, renderer: RenderTree) -> str:
     ----------
     node: DataTree
         A single node obtained from a ``RenderTree``
-    renderer: RenderTree
-        The full ``RenderTree`` constructed from ``EchoData._tree``
+    tree: DataTree
+        The full ``DataTree`` corresponding to``EchoData._tree``
 
     Returns
     -------
@@ -50,8 +50,8 @@ def _single_node_repr(node: DataTree, renderer: RenderTree) -> str:
 
     if "Beam_group" in sonar_group["name"]:
         # get description of Beam_group directly from the Sonar group
-        group_descr = (
-            renderer.node["/Sonar"].ds.beam_group_descr.sel(beam_group=sonar_group["name"]).item()
+        group_descr = str(
+            tree["/Sonar"].ds.beam_group_descr.sel(beam_group=sonar_group["name"]).values
         )
     else:
         # get description of group from yaml file
@@ -68,7 +68,7 @@ def tree_repr(tree: DataTree) -> str:
     lines = []
     for pre, _, node in renderer:
         if node.has_data or node.has_attrs:
-            node_repr = _single_node_repr(node, renderer)
+            node_repr = _single_node_repr(node, tree)
 
             node_line = f"{pre}{node_repr.splitlines()[0]}"
             lines.append(node_line)

--- a/echopype/echodata/widgets/utils.py
+++ b/echopype/echodata/widgets/utils.py
@@ -23,13 +23,43 @@ def make_key(value: str) -> str:
     return value + str(uuid.uuid4())
 
 
-def _single_node_repr(node):
-    root_path = "root"
+def _single_node_repr(node: DataTree, renderer: RenderTree) -> str:
+    """
+    Obtains the string repr for a single node in a ``RenderTree``.
+
+    Parameters
+    ----------
+    node: DataTree
+        A single node obtained from a ``RenderTree``
+    renderer: RenderTree
+        The full ``RenderTree`` constructed from ``EchoData._tree``
+
+    Returns
+    -------
+    node_info: str
+        string representation of repr for the input ``node``
+    """
+
+    # initialize node_pathstr
     node_pathstr = "Top-level"
-    if node.name != root_path:
+
+    # obtain the appropriate group name and get its descriptions from the yaml
+    if node.name != "root":
         node_pathstr = node.path[1:]
     sonar_group = SONAR_GROUPS[node_pathstr]
-    node_info = f"{sonar_group['name']}: {sonar_group['description']}"
+
+    if "Beam_group" in sonar_group["name"]:
+        # get description of Beam_group directly from the Sonar group
+        group_descr = (
+            renderer.node["/Sonar"].ds.beam_group_descr.sel(beam_group=sonar_group["name"]).item()
+        )
+    else:
+        # get description of group from yaml file
+        group_descr = sonar_group["description"]
+
+    # construct the final node information string for repr
+    node_info = f"{sonar_group['name']}: {group_descr}"
+
     return node_info
 
 
@@ -38,7 +68,7 @@ def tree_repr(tree: DataTree) -> str:
     lines = []
     for pre, _, node in renderer:
         if node.has_data or node.has_attrs:
-            node_repr = _single_node_repr(node)
+            node_repr = _single_node_repr(node, renderer)
 
             node_line = f"{pre}{node_repr.splitlines()[0]}"
             lines.append(node_line)

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -238,7 +238,7 @@ class TestEchoData:
             │   └── NMEA: contains information specific to the NMEA protocol.
             ├── Provenance: contains metadata about how the SONAR-netCDF4 version of the data were obtained.
             ├── Sonar: contains sonar system metadata and sonar beam groups.
-            │   └── Beam_group1: contains backscatter data (either complex samples or uncalibrated power samples) and other beam or channel-specific data, including split-beam angle data when they exist.
+            │   └── Beam_group1: contains backscatter power (uncalibrated) and other beam or channel-specific data, including split-beam angle data when they exist.
             └── Vendor_specific: contains vendor-specific information about the sonar and the data."""
         )
         ed = self.create_ed(converted_raw_path=converted_zarr)

--- a/echopype/tests/echodata/test_echodata_combine.py
+++ b/echopype/tests/echodata/test_echodata_combine.py
@@ -331,7 +331,7 @@ def test_combined_echodata_repr(ek60_test_data):
         │   └── NMEA: contains information specific to the NMEA protocol.
         ├── Provenance: contains metadata about how the SONAR-netCDF4 version of the data were obtained.
         ├── Sonar: contains sonar system metadata and sonar beam groups.
-        │   └── Beam_group1: contains backscatter data (either complex samples or uncalibrated power samples) and other beam or channel-specific data, including split-beam angle data when they exist.
+        │   └── Beam_group1: contains backscatter power (uncalibrated) and other beam or channel-specific data, including split-beam angle data when they exist.
         └── Vendor_specific: contains vendor-specific information about the sonar and the data."""
     )
 


### PR DESCRIPTION
This PR addresses issue #625 by modifying `_single_node_repr` such that the `Beam_group` descriptions are pulled directly from the `Sonar` group. 