### PR TITLE
Investigate failing CI for Python 3.9 build resulting after PR #878 merge

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: Running All Tests
         shell: bash -l {0}
         run: |
-          pytest -vv -rx --numprocesses=${{ env.NUM_WORKERS }} --max-worker-restart=3 --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings |& tee ci_${{ matrix.python-version }}_test_log.log
+          pytest -vv -rx --max-worker-restart=3 --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings |& tee ci_${{ matrix.python-version }}_test_log.log
       - name: Upload ci test log
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This PR is a draft PR to test out why the Python 3.9 build for the CI is failing after PR #878 was merged. 