### PR TITLE
Fix meta_source_filenames bug and enable (meta)source_filenames appending of path and list

### DIFF
--- a/echopype/tests/utils/test_source_filenames.py
+++ b/echopype/tests/utils/test_source_filenames.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import numpy as np
+
+from echopype.utils.prov import _sanitize_source_files
+
+
+def test_scalars():
+    """One or more scalar values"""
+    path1 = "/my/path1"
+    path2 = Path("/my/path2")
+
+    # Single scalars
+    assert _sanitize_source_files(path1) == [path1]
+    assert _sanitize_source_files(path2) == [str(path2)]
+    # List of scalars
+    assert _sanitize_source_files([path1, path2]) == [path1, str(path2)]
+
+
+def test_mixed():
+    """A scalar value and a list or ndarray"""
+    path1 = "/my/path1"
+    path2 = Path("/my/path2")
+    # Mixed-type list
+    path_list1 = [path1, path2]
+    # String-type ndarray
+    path_list2 = np.array([path1, str(path2)])
+
+    # A scalar and a list
+    target_path_list = [path1, path1, str(path2)]
+    assert _sanitize_source_files([path1, path_list1]) == target_path_list
+    # A scalar and an ndarray
+    assert _sanitize_source_files([path1, path_list2]) == target_path_list

--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -2,6 +2,7 @@ from datetime import datetime as dt
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
 
+import numpy as np
 from _echopype_version import version as ECHOPYPE_VERSION
 from numpy.typing import NDArray
 from typing_extensions import Literal
@@ -43,7 +44,7 @@ def _sanitize_source_files(paths: Union[PathHint, PathSequenceHint]):
     ----------
     paths : Union[PathHint, PathSequenceHint]
         File paths as either a single path string or pathlib Path,
-        a sequence (tuple, list or NDArray) of strings or pathlib Paths,
+        a sequence (tuple, list or np.ndarray) of strings or pathlib Paths,
         or a mixed sequence that may contain another sequence as an element.
 
     Returns
@@ -51,7 +52,7 @@ def _sanitize_source_files(paths: Union[PathHint, PathSequenceHint]):
     paths_list : List[str]
         List of file paths. Empty list if no source path element was parsed successfully.
     """
-    sequence_types = (list, tuple, NDArray)
+    sequence_types = (list, tuple, np.ndarray)
     if isinstance(paths, (str, Path)):
         return [str(paths)]
     elif isinstance(paths, sequence_types):
@@ -87,11 +88,11 @@ def source_files_vars(
     ----------
     source_paths : Union[PathHint, PathSequenceHint]
         Source file paths as either a single path string or pathlib Path,
-        a sequence (tuple, list or NDArray) of strings or pathlib Paths,
+        a sequence (tuple, list or np.ndarray) of strings or pathlib Paths,
         or a mixed sequence that may contain another sequence as an element.
     meta_source_paths : Union[PathHint, PathSequenceHint]
         Source file paths for metadata files (often as XML files), as either a
-        single path string or pathlib Path, a sequence (tuple, list or NDArray)
+        single path string or pathlib Path, a sequence (tuple, list or np.ndarray)
         of strings or pathlib Paths, or a mixed sequence that may contain another
         sequence as an element.
 
@@ -107,7 +108,7 @@ def source_files_vars(
             meta_source_filenames xarray DataArray with filenames dimension
         source_files_coord : Dict[str, Tuple]
             Single-element dict containing a tuple for creating the
-            filenames coordinate variable DataArray
+            filenames coordinate variable xarray DataArray
     """
 
     source_files = _sanitize_source_files(source_paths)

--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -119,7 +119,9 @@ def source_files_vars(
         ),
     }
 
-    if meta_source_paths is not None:
+    if meta_source_paths is None or meta_source_paths == "":
+        files_vars["meta_source_files_var"] = None
+    else:
         meta_source_files = _source_files(meta_source_paths)
         files_vars["meta_source_files_var"] = {
             "meta_source_filenames": (
@@ -128,8 +130,6 @@ def source_files_vars(
                 {"long_name": "Metadata source filenames"},
             ),
         }
-    else:
-        files_vars["meta_source_files_var"] = None
 
     files_vars["source_files_coord"] = {
         "filenames": (

--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -2,8 +2,8 @@ from datetime import datetime as dt
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
 
-import numpy as np
 from _echopype_version import version as ECHOPYPE_VERSION
+from numpy.typing import NDArray
 from typing_extensions import Literal
 
 from .log import _init_logger
@@ -11,7 +11,7 @@ from .log import _init_logger
 ProcessType = Literal["conversion", "processing"]
 # Note that this PathHint is defined differently from the one in ..core
 PathHint = Union[str, Path]
-PathSequenceHint = Union[List[PathHint], Tuple[PathHint], np.ndarray[PathHint]]
+PathSequenceHint = Union[List[PathHint], Tuple[PathHint], NDArray[PathHint]]
 
 logger = _init_logger(__name__)
 
@@ -43,7 +43,7 @@ def _sanitize_source_files(paths: Union[PathHint, PathSequenceHint]):
     ----------
     paths : Union[PathHint, PathSequenceHint]
         File paths as either a single path string or pathlib Path,
-        a sequence (tuple, list or np.ndarray) of strings or pathlib Paths,
+        a sequence (tuple, list or NDArray) of strings or pathlib Paths,
         or a mixed sequence that may contain another sequence as an element.
 
     Returns
@@ -51,7 +51,7 @@ def _sanitize_source_files(paths: Union[PathHint, PathSequenceHint]):
     paths_list : List[str]
         List of file paths. Empty list if no source path element was parsed successfully.
     """
-    sequence_types = (list, tuple, np.ndarray)
+    sequence_types = (list, tuple, NDArray)
     if isinstance(paths, (str, Path)):
         return [str(paths)]
     elif isinstance(paths, sequence_types):
@@ -87,11 +87,11 @@ def source_files_vars(
     ----------
     source_paths : Union[PathHint, PathSequenceHint]
         Source file paths as either a single path string or pathlib Path,
-        a sequence (tuple, list or np.ndarray) of strings or pathlib Paths,
+        a sequence (tuple, list or NDArray) of strings or pathlib Paths,
         or a mixed sequence that may contain another sequence as an element.
     meta_source_paths : Union[PathHint, PathSequenceHint]
         Source file paths for metadata files (often as XML files), as either a
-        single path string or pathlib Path, a sequence (tuple, list or np.ndarray)
+        single path string or pathlib Path, a sequence (tuple, list or NDArray)
         of strings or pathlib Paths, or a mixed sequence that may contain another
         sequence as an element.
 


### PR DESCRIPTION
Addresses #678. More specifically, it enables `source_files_vars` in `prov.py` to handle the case of an input `source_paths` or `meta_source_paths` that includes both scalar elements (string or pathlib Path) and a list of such elements. This is the case that would arise with `combine_echodata` to append (combine) a converted file to a previously combined echodata object. Note that beyond the enhancement to handle `source_filenames` and `meta_source_filenames`, this PR does not address the larger, blocking issue described in #895, which currently makes that use case not possible.

I've done offline manual tests to confirm that the underlying `prov._source_files` function addresses that use case (heterogeneous list elements).

Also fixes the small bug described in #907 