### PR TITLE
Fix mkdir to not raise error and skip directory creation if exists

### DIFF
--- a/echopype/core.py
+++ b/echopype/core.py
@@ -30,7 +30,7 @@ ECHOPYPE_DIR = Path(os.path.expanduser("~")) / ".echopype"
 def init_ep_dir():
     """Initialize hidden directory for echopype"""
     if not ECHOPYPE_DIR.exists():
-        ECHOPYPE_DIR.mkdir()
+        ECHOPYPE_DIR.mkdir(exist_ok=True)
 
 
 def validate_azfp_ext(test_ext: str):


### PR DESCRIPTION
## Overview

To avoid parallel runs to fail, let's allow skipping of directory creation.