### PR TITLE
Ignore docs/source/_build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,4 +43,6 @@ repos:
     rev: v2.1.0
     hooks:
       - id: codespell
-        args: ["--skip=*.ipynb", "-w", "docs/source", "echopype"]
+        # Checks spelling in docs/source and echopype dirs ONLY
+        # Ignores ipynb and _build folders
+        args: ["--skip=*.ipynb,docs/source/_build", "-w", "docs/source", "echopype"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,6 @@ repos:
     rev: v2.1.0
     hooks:
       - id: codespell
-        # Checks spelling in docs/source and echopype dirs ONLY
-        # Ignores ipynb and _build folders
+        # Checks spelling in `docs/source` and `echopype` dirs ONLY
+        # Ignores `.ipynb` files and `_build` folders
         args: ["--skip=*.ipynb,docs/source/_build", "-w", "docs/source", "echopype"]


### PR DESCRIPTION
## Overview

This PR add a codespell config to ignore `_build` directory within `docs/source`. 

## How to test

Do the following in the root of the repository

1. Build the docs with jupyter-book: `jb build docs/source/`
2. Run pre-commit `pre-commit run --all`
