### PR TITLE
Add unit tests for functions used in `apply_mask` 

### DIFF
--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -17,7 +17,7 @@ str2ops = {
 }
 
 
-def validate_and_collect_mask_input(
+def _validate_and_collect_mask_input(
     mask: Union[
         Union[xr.DataArray, str, pathlib.Path], List[Union[xr.DataArray, str, pathlib.Path]]
     ],
@@ -202,7 +202,7 @@ def apply_mask(
         source_ds = xr.open_dataset(source_ds, engine=file_type, chunks={}, **storage_options_ds)
 
     # validate and form the mask input to be used downstream
-    mask = validate_and_collect_mask_input(mask, storage_options_mask)
+    mask = _validate_and_collect_mask_input(mask, storage_options_mask)
 
     # ensure that var_name and fill_value were correctly provided
     _check_var_name_fill_value(source_ds, var_name, fill_value)

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -77,7 +77,7 @@ def validate_and_collect_mask_input(
             )
 
             # replace mask element path with its corresponding DataArray
-            if isinstance(mask_val, str):
+            if isinstance(mask_val, (str, pathlib.Path)):
                 # open up DataArray using mask path
                 mask[mask_ind] = xr.open_dataarray(
                     mask_val, engine=file_type, chunks={}, **storage_options_mask[mask_ind]
@@ -94,7 +94,7 @@ def validate_and_collect_mask_input(
         # validate the mask type or path (if it is provided)
         mask, file_type = validate_source_ds_da(mask, storage_options_mask)
 
-        if isinstance(mask, str):
+        if isinstance(mask, (str, pathlib.Path)):
             # open up DataArray using mask path
             mask = xr.open_dataarray(mask, engine=file_type, chunks={}, **storage_options_mask)
 

--- a/echopype/tests/mask/test_mask.py
+++ b/echopype/tests/mask/test_mask.py
@@ -10,7 +10,7 @@ import os
 
 import echopype as ep
 import echopype.mask
-from echopype.mask.api import _check_source_Sv_freq_diff, validate_and_collect_mask_input, _check_var_name_fill_value
+from echopype.mask.api import _check_source_Sv_freq_diff, _validate_and_collect_mask_input, _check_var_name_fill_value
 
 from typing import List, Union, Optional
 
@@ -142,9 +142,12 @@ def get_mock_source_ds_apply_mask(n: int, n_chan: int, is_delayed: bool) -> xr.D
     return mock_ds
 
 
-def create_input_mask(mask: Union[np.ndarray, List[np.ndarray]],
-                      mask_file: Optional[Union[str, List[str]]],
-                      mask_coords: Union[xr.core.coordinates.DataArrayCoordinates, dict], n_chan: int):
+def create_input_mask(
+    mask: Union[np.ndarray, List[np.ndarray]],
+    mask_file: Optional[Union[str, List[str]]],
+    mask_coords: Union[xr.core.coordinates.DataArrayCoordinates, dict],
+    n_chan: int
+):
     """
     A helper function that correctly constructs the mask input, so it can be
     used for ``apply_mask`` related tests.
@@ -226,7 +229,6 @@ def create_input_mask(mask: Union[np.ndarray, List[np.ndarray]],
             mask_out = zarr_path
 
     return mask_out, temp_dir
-
 
 
 @pytest.mark.parametrize(
@@ -405,8 +407,8 @@ def test_validate_and_collect_mask_input(
     Notes
     -----
     The input for ``storage_options_mask`` will only contain the value `{}` or a list of
-    empty dictionaries as other options are already tested in `
-    `test_utils_io.py::test_validate_output_path`` and are therefore not included here.
+    empty dictionaries as other options are already tested in
+    ``test_utils_io.py::test_validate_output_path`` and are therefore not included here.
     """
 
     # construct channel values
@@ -417,9 +419,9 @@ def test_validate_and_collect_mask_input(
               "x": np.arange(n), "y": np.arange(n)}
 
     # create input mask and obtain temporary directory, if it was created
-    mask, temp_dir = create_input_mask(mask_np, mask_file, coords, n_chan)
+    mask, _ = create_input_mask(mask_np, mask_file, coords, n_chan)
 
-    mask_out = validate_and_collect_mask_input(mask=mask, storage_options_mask=storage_options_mask)
+    mask_out = _validate_and_collect_mask_input(mask=mask, storage_options_mask=storage_options_mask)
 
     if isinstance(mask_out, list):
         for ind, da in enumerate(mask_out):

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -2,6 +2,7 @@
 echopype utilities for file handling
 """
 import os
+import pathlib
 import platform
 import sys
 from pathlib import Path, WindowsPath
@@ -60,9 +61,13 @@ def get_file_format(file):
     elif isinstance(file, FSMap):
         file = file.root
 
-    if file.endswith(".nc"):
+    if isinstance(file, str) and file.endswith(".nc"):
         return "netcdf4"
-    elif file.endswith(".zarr"):
+    elif isinstance(file, str) and file.endswith(".zarr"):
+        return "zarr"
+    elif isinstance(file, pathlib.Path) and file.suffix == ".nc":
+        return "netcdf4"
+    elif isinstance(file, pathlib.Path) and file.suffix == ".zarr":
         return "zarr"
     else:
         raise ValueError(f"Unsupported file format: {os.path.splitext(file)[1]}")


### PR DESCRIPTION
This PR addresses the https://github.com/OSOceanAcoustics/echopype/pull/905#discussion_r1053612351 by adding unit tests for `validate_and_collect_mask_input` and `_check_var_name_fill_value`. Additionally, while implementing these changes it was discovered that the `utils/io.py` function `get_file_format` and newly created function `validate_and_collect_mask_input` do not correctly account for `pathlib.Path` input. Both of these functions have been modified to allow for `pathlib.Path` input. 