### PR TITLE
Redo: Add `apply_mask` function to `mask` sub-package

### DIFF
--- a/echopype/mask/__init__.py
+++ b/echopype/mask/__init__.py
@@ -1,3 +1,3 @@
-from .api import frequency_differencing
+from .api import apply_mask, frequency_differencing
 
-__all__ = ["frequency_differencing"]
+__all__ = ["frequency_differencing", "apply_mask"]

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -48,7 +48,7 @@ def validate_and_collect_mask_input(
 
     Raises
     ------
-    RuntimeError
+    ValueError
         If ``mask`` is a single-element and ``storage_options_mask`` is not a single dict
     TypeError
         If ``storage_options_mask`` is not a list of dict or a dict
@@ -86,7 +86,7 @@ def validate_and_collect_mask_input(
     else:
 
         if not isinstance(storage_options_mask, dict):
-            raise RuntimeError(
+            raise ValueError(
                 "The provided input storage_options_mask should be a single "
                 "dict because mask is a single value!"
             )
@@ -121,9 +121,9 @@ def _check_var_name_fill_value(
     ------
     TypeError
         If ``var_name`` or ``fill_value`` are not an accepted type
-    RuntimeError
+    ValueError
         If the Dataset ``source_ds`` does not contain ``var_name``
-    RuntimeError
+    ValueError
         If ``fill_value`` is an array and not the same shape as ``var_name``
     """
 
@@ -133,7 +133,7 @@ def _check_var_name_fill_value(
 
     # ensure var_name is in source_ds
     if var_name not in source_ds.variables:
-        raise RuntimeError("The Dataset source_ds does not contain the variable var_name!")
+        raise ValueError("The Dataset source_ds does not contain the variable var_name!")
 
     # check the type of fill_value
     if not isinstance(fill_value, (int, float, np.ndarray, xr.DataArray)):
@@ -145,7 +145,7 @@ def _check_var_name_fill_value(
     if isinstance(fill_value, (np.ndarray, xr.DataArray)) and (
         fill_value.shape != source_ds[var_name].shape
     ):
-        raise RuntimeError("If fill_value is an array is must be of the same shape as var_name!")
+        raise ValueError("If fill_value is an array is must be of the same shape as var_name!")
 
 
 def apply_mask(
@@ -226,7 +226,7 @@ def apply_mask(
 
     # sanity check to make sure final_mask is the same shape as source_ds[var_name]
     if final_mask.shape != source_ds[var_name].shape:
-        raise RuntimeError("Final constructed mask is not the same shape as source_ds[var_name]!")
+        raise ValueError("Final constructed mask is not the same shape as source_ds[var_name]!")
 
     # apply the mask to var_name
     var_name_masked = xr.where(final_mask, x=source_ds[var_name], y=fill_value, keep_attrs=True)
@@ -270,26 +270,26 @@ def _check_freq_diff_non_data_inputs(
 
     # check that either freqAB or chanAB are provided and they are a list of length 2
     if (freqAB is None) and (chanAB is None):
-        raise RuntimeError("Either freqAB or chanAB must be given!")
+        raise ValueError("Either freqAB or chanAB must be given!")
     elif (freqAB is not None) and (chanAB is not None):
-        raise RuntimeError("Only freqAB or chanAB must be given, but not both!")
+        raise ValueError("Only freqAB or chanAB must be given, but not both!")
     elif freqAB is not None:
         if not isinstance(freqAB, list):
             raise TypeError("freqAB must be a list!")
         elif len(set(freqAB)) != 2:
-            raise RuntimeError("freqAB must be a list of length 2 with unique elements!")
+            raise ValueError("freqAB must be a list of length 2 with unique elements!")
     else:
         if not isinstance(chanAB, list):
             raise TypeError("chanAB must be a list!")
         elif len(set(chanAB)) != 2:
-            raise RuntimeError("chanAB must be a list of length 2 with unique elements!")
+            raise ValueError("chanAB must be a list of length 2 with unique elements!")
 
     # check that operator is a string and a valid operator
     if not isinstance(operator, str):
         raise TypeError("operator must be a string!")
     else:
         if operator not in [">", "<", "<=", ">=", "=="]:
-            raise RuntimeError("Invalid operator!")
+            raise ValueError("Invalid operator!")
 
     # ensure that diff is a float or an int
     if not isinstance(diff, (float, int)):
@@ -324,34 +324,34 @@ def _check_source_Sv_freq_diff(
 
     # check that channel and frequency nominal are in source_Sv
     if "channel" not in source_Sv.coords:
-        raise RuntimeError("The Dataset defined by source_Sv must have channel as a coordinate!")
+        raise ValueError("The Dataset defined by source_Sv must have channel as a coordinate!")
     elif "frequency_nominal" not in source_Sv.variables:
-        raise RuntimeError(
+        raise ValueError(
             "The Dataset defined by source_Sv must have frequency_nominal as a variable!"
         )
 
     # make sure that the channel and frequency_nominal values are not repeated in source_Sv
     if len(set(source_Sv.channel.values)) < source_Sv.channel.size:
-        raise RuntimeError(
-            "The provided source_Sv contains repeated channel values, " "this is not allowed!"
+        raise ValueError(
+            "The provided source_Sv contains repeated channel values, this is not allowed!"
         )
 
     if len(set(source_Sv.frequency_nominal.values)) < source_Sv.frequency_nominal.size:
-        raise RuntimeError(
+        raise ValueError(
             "The provided source_Sv contains repeated frequency_nominal "
             "values, this is not allowed!"
         )
 
     # check that the elements of freqAB are in frequency_nominal
     if (freqAB is not None) and (not all([freq in source_Sv.frequency_nominal for freq in freqAB])):
-        raise RuntimeError(
+        raise ValueError(
             "The provided list input freqAB contains values that "
             "are not in the frequency_nominal variable!"
         )
 
     # check that the elements of chanAB are in channel
     if (chanAB is not None) and (not all([chan in source_Sv.channel for chan in chanAB])):
-        raise RuntimeError(
+        raise ValueError(
             "The provided list input chanAB contains values that are "
             "not in the channel coordinate!"
         )
@@ -402,24 +402,24 @@ def frequency_differencing(
 
     Raises
     ------
-    RuntimeError
+    ValueError
         If neither ``freqAB`` or ``chanAB`` are given
-    RuntimeError
+    ValueError
         If both ``freqAB`` and ``chanAB`` are given
     TypeError
         If any input is not of the correct type
-    RuntimeError
+    ValueError
         If either ``freqAB`` or ``chanAB`` are provided and the list
         does not contain 2 distinct elements
-    RuntimeError
+    ValueError
         If ``freqAB`` contains values that are not contained in ``frequency_nominal``
-    RuntimeError
+    ValueError
         If ``chanAB`` contains values that not contained in ``channel``
-    RuntimeError
+    ValueError
         If ``operator`` is not one of the following: ``">", "<", "<=", ">=", "=="``
-    RuntimeError
+    ValueError
         If the path provided for ``source_Sv`` is not a valid path
-    RuntimeError
+    ValueError
         If ``freqAB`` or ``chanAB`` is provided and the Dataset produced by ``source_Sv``
         does not contain the coordinate ``channel`` and variable ``frequency_nominal``
 

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -31,7 +31,7 @@ def validate_and_collect_mask_input(
     Parameters
     ----------
     mask: xr.DataArray, str, pathlib.Path, or a list of these datatypes
-        The mask(s) to be applied. 
+        The mask(s) to be applied.
         Can be a single input or list that corresponds to a DataArray or a path. If a path
         is provided this should point to a zarr or netcdf file with only one data variable in it.
     storage_options_mask: dict or list of dict, default={}
@@ -169,7 +169,7 @@ def apply_mask(
     var_name: str
         The variable name in ``source_ds`` that the mask should be applied to
     mask: xr.DataArray, str, pathlib.Path, or a list of these datatypes
-        The mask(s) to be applied. 
+        The mask(s) to be applied.
         Can be a single input or list that corresponds to a DataArray or a path. If a path
         is provided this should point to a zarr or netcdf file with only one data variable in it.
     fill_value: int or float or np.ndarray or xr.DataArray, default=np.nan

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -209,6 +209,11 @@ def apply_mask(
     # ensure that var_name and fill_value were correctly provided
     _check_var_name_fill_value(source_ds, var_name, fill_value)
 
+    # select data only, if fill_value is a DataArray (necessary since
+    # xr.where(keep_attrs=True) is not functioning correctly)
+    if isinstance(fill_value, xr.DataArray):
+        fill_value = fill_value.data
+
     # obtain final mask to be applied to var_name
     if isinstance(mask, list):
         # perform a logical AND element-wise operation across the masks

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Union
 import numpy as np
 import xarray as xr
 
-from ..utils.io import validate_source_ds
+from ..utils.io import validate_source_ds_da
 
 # lookup table with key string operator and value as corresponding Python operator
 str2ops = {
@@ -15,6 +15,13 @@ str2ops = {
     ">=": op.ge,
     "==": op.eq,
 }
+
+
+# def _check_apply_mask_inputs(source_ds: xr.Dataset, var_name: str, mask, ):
+#     """
+#     Ensures that the inputs to the function ``apply_mask`` are
+#     appropriate.
+#     """
 
 
 def apply_mask(
@@ -39,8 +46,8 @@ def apply_mask(
         The variable name in ``source_ds`` that the mask should be applied to
     mask: xr.DataArray or str or pathlib.Path or list of xr.DataArray or str or pathlib.Path
         The mask(s) to apply to the variable specified by ``var_name``. This input can be a
-        single input or list that corresponds to a DataArray or a path to a DataArray.
-        # TODO: if it is a path it is only to .zarr or .nc no array groups
+        single input or list that corresponds to a DataArray or a path to a DataArray. If a path
+        is provided this should point to a zarr or netcdf file with only one array in it.
     fill_value: int or float or np.ndarray or xr.DataArray, default=np.nan
         Specifies the value(s) at false indices
     storage_options_ds: dict, default={}
@@ -63,19 +70,19 @@ def apply_mask(
     mask that will be applied to ``var_name``.
     """
 
-    # TODO: check types of all inputs
-
-    # TODO: if mask is a list and storage_options_mask is not, create a list filled
-    #  with single dict provided only for those elements that are paths
-
     # validate the source_ds type or path (if it is provided)
-    source_ds, file_type = validate_source_ds(source_ds, storage_options_ds)
+    source_ds, file_type = validate_source_ds_da(source_ds, storage_options_ds)
 
     if isinstance(source_ds, str):
         # open up Dataset using source_ds path
         source_ds = xr.open_dataset(
             source_ds, engine=file_type, chunks="auto", **storage_options_ds
         )
+
+    # TODO: check types of all inputs
+
+    # TODO: if mask is a list and storage_options_mask is not, create a list filled
+    #  with single dict provided only for those elements that are paths
 
     mask_file_types = []  # TODO: create this!
 
@@ -347,7 +354,7 @@ def frequency_differencing(
     _check_freq_diff_non_data_inputs(freqAB, chanAB, operator, diff)
 
     # validate the source_Sv type or path (if it is provided)
-    source_Sv, file_type = validate_source_ds(source_Sv, storage_options)
+    source_Sv, file_type = validate_source_ds_da(source_Sv, storage_options)
 
     if isinstance(source_Sv, str):
         # open up Dataset using source_Sv path

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -150,10 +150,10 @@ def _check_var_name_fill_value(
 
 def apply_mask(
     source_ds: Union[xr.Dataset, str, pathlib.Path],
-    var_name: str,
     mask: Union[
         Union[xr.DataArray, str, pathlib.Path], List[Union[xr.DataArray, str, pathlib.Path]]
     ],
+    var_name: str = "Sv",
     fill_value: Union[int, float, np.ndarray, xr.DataArray] = np.nan,
     storage_options_ds: dict = {},
     storage_options_mask: Union[dict, List[dict]] = {},
@@ -166,13 +166,13 @@ def apply_mask(
     ----------
     source_ds: xr.Dataset, str, or pathlib.Path
         Points to a Dataset that contains the variable the mask should be applied to
-    var_name: str
-        The variable name in ``source_ds`` that the mask should be applied to
     mask: xr.DataArray, str, pathlib.Path, or a list of these datatypes
         The mask(s) to be applied. Can be a single input or list that corresponds to
         a DataArray or a path. If a path is provided this should point to a zarr or
         netcdf file with only one data variable in it.
-    fill_value: int or float or np.ndarray or xr.DataArray, default=np.nan
+    var_name: str, default="Sv"
+        The variable name in ``source_ds`` that the mask should be applied to
+    fill_value: int, float, np.ndarray, or xr.DataArray, default=np.nan
         Value(s) at masked indices
     storage_options_ds: dict, default={}
         Any additional parameters for the storage backend, corresponding to the

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -80,7 +80,7 @@ def validate_and_collect_mask_input(
             if isinstance(mask_val, str):
                 # open up DataArray using mask path
                 mask[mask_ind] = xr.open_dataarray(
-                    mask_val, engine=file_type, chunks="auto", **storage_options_mask[mask_ind]
+                    mask_val, engine=file_type, chunks={}, **storage_options_mask[mask_ind]
                 )
 
     else:
@@ -96,7 +96,7 @@ def validate_and_collect_mask_input(
 
         if isinstance(mask, str):
             # open up DataArray using mask path
-            mask = xr.open_dataarray(mask, engine=file_type, chunks="auto", **storage_options_mask)
+            mask = xr.open_dataarray(mask, engine=file_type, chunks={}, **storage_options_mask)
 
     return mask
 
@@ -199,9 +199,7 @@ def apply_mask(
 
     if isinstance(source_ds, str):
         # open up Dataset using source_ds path
-        source_ds = xr.open_dataset(
-            source_ds, engine=file_type, chunks="auto", **storage_options_ds
-        )
+        source_ds = xr.open_dataset(source_ds, engine=file_type, chunks={}, **storage_options_ds)
 
     # validate and form the mask input to be used downstream
     mask = validate_and_collect_mask_input(mask, storage_options_mask)
@@ -471,7 +469,7 @@ def frequency_differencing(
 
     if isinstance(source_Sv, str):
         # open up Dataset using source_Sv path
-        source_Sv = xr.open_dataset(source_Sv, engine=file_type, chunks="auto", **storage_options)
+        source_Sv = xr.open_dataset(source_Sv, engine=file_type, chunks={}, **storage_options)
 
     # check the source_Sv with respect to channel and frequency_nominal
     _check_source_Sv_freq_diff(source_Sv, freqAB, chanAB)

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -30,10 +30,10 @@ def validate_and_collect_mask_input(
 
     Parameters
     ----------
-    mask: xr.DataArray or str or pathlib.Path or list of xr.DataArray or str or pathlib.Path
-        The mask(s) to apply to the variable specified by ``var_name``. This input can be a
-        single input or list that corresponds to a DataArray or a path to a DataArray. If a path
-        is provided this should point to a zarr or netcdf file with only one array in it.
+    mask: xr.DataArray, str, pathlib.Path, or a list of these datatypes
+        The mask(s) to be applied. 
+        Can be a single input or list that corresponds to a DataArray or a path. If a path
+        is provided this should point to a zarr or netcdf file with only one data variable in it.
     storage_options_mask: dict or list of dict, default={}
         Any additional parameters for the storage backend, corresponding to the
         path provided for ``mask``. If ``mask`` is a list, then this input should either
@@ -164,16 +164,16 @@ def apply_mask(
 
     Parameters
     ----------
-    source_ds: xr.Dataset or str or pathlib.Path
+    source_ds: xr.Dataset, str, or pathlib.Path
         Points to a Dataset that contains the variable the mask should be applied to
     var_name: str
         The variable name in ``source_ds`` that the mask should be applied to
-    mask: xr.DataArray or str or pathlib.Path or list of xr.DataArray or str or pathlib.Path
-        The mask(s) to apply to the variable specified by ``var_name``. This input can be a
-        single input or list that corresponds to a DataArray or a path to a DataArray. If a path
-        is provided this should point to a zarr or netcdf file with only one array in it.
+    mask: xr.DataArray, str, pathlib.Path, or a list of these datatypes
+        The mask(s) to be applied. 
+        Can be a single input or list that corresponds to a DataArray or a path. If a path
+        is provided this should point to a zarr or netcdf file with only one data variable in it.
     fill_value: int or float or np.ndarray or xr.DataArray, default=np.nan
-        Specifies the value(s) at false indices
+        Value(s) at masked indices
     storage_options_ds: dict, default={}
         Any additional parameters for the storage backend, corresponding to the
         path provided for ``source_ds``

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -31,9 +31,9 @@ def validate_and_collect_mask_input(
     Parameters
     ----------
     mask: xr.DataArray, str, pathlib.Path, or a list of these datatypes
-        The mask(s) to be applied.
-        Can be a single input or list that corresponds to a DataArray or a path. If a path
-        is provided this should point to a zarr or netcdf file with only one data variable in it.
+        The mask(s) to be applied. Can be a single input or list that corresponds to a
+        DataArray or a path. If a path is provided this should point to a zarr or netcdf
+        file with only one data variable in it.
     storage_options_mask: dict or list of dict, default={}
         Any additional parameters for the storage backend, corresponding to the
         path provided for ``mask``. If ``mask`` is a list, then this input should either
@@ -169,9 +169,9 @@ def apply_mask(
     var_name: str
         The variable name in ``source_ds`` that the mask should be applied to
     mask: xr.DataArray, str, pathlib.Path, or a list of these datatypes
-        The mask(s) to be applied.
-        Can be a single input or list that corresponds to a DataArray or a path. If a path
-        is provided this should point to a zarr or netcdf file with only one data variable in it.
+        The mask(s) to be applied. Can be a single input or list that corresponds to
+        a DataArray or a path. If a path is provided this should point to a zarr or
+        netcdf file with only one data variable in it.
     fill_value: int or float or np.ndarray or xr.DataArray, default=np.nan
         Value(s) at masked indices
     storage_options_ds: dict, default={}

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -1,0 +1,45 @@
+import operator as op
+import pathlib
+from typing import List, Optional, Union
+
+import numpy as np
+import xarray as xr
+
+
+def apply_mask(source_ds: Union[xr.Dataset, str, pathlib.Path],
+               var_name: str,
+               mask: Union[Union[xr.DataArray, str, pathlib.Path],
+                           List[Union[xr.DataArray, str, pathlib.Path]]],
+               fill_value: Union[int, float, np.ndarray, xr.DataArray] = np.nan) -> xr.Dataset:
+    """
+    Applies the provided mask(s) to the variable ``var_name``
+    in the provided Dataset ``source_ds``.
+
+    Parameters
+    ----------
+    source_ds: xr.Dataset or str or pathlib.Path
+        Points to a Dataset that contains the variable the mask should be applied to
+    var_name: str
+        The variable name in ``source_ds`` that the mask should be applied to
+    mask: xr.DataArray or str or pathlib.Path or list of xr.DataArray or str or pathlib.Path
+        The mask(s) to apply to the variable specified by ``var_name``. This input can be a
+        single input or list that corresponds to a DataArray or a path to a DataArray.
+    fill_value: int or float or np.ndarray or xr.DataArray, default=np.nan
+        Specifies the value(s) at false indices
+
+    Returns
+    -------
+    xr.Dataset
+        A Dataset with the same format of ``source_ds`` with the mask(s) applied to ``var_name``
+
+    Notes
+    -----
+    If the input ``mask`` is a list, then a logical AND will be used to produce the final
+    mask that will be applied to ``var_name``.
+    """
+
+    # TODO: use validate_source_Sv on source_ds
+
+    # TODO: if fill_value is an array, then make sure its dimensions match var_name variable
+
+    print("hello")

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -40,6 +40,7 @@ def apply_mask(
     mask: xr.DataArray or str or pathlib.Path or list of xr.DataArray or str or pathlib.Path
         The mask(s) to apply to the variable specified by ``var_name``. This input can be a
         single input or list that corresponds to a DataArray or a path to a DataArray.
+        # TODO: if it is a path it is only to .zarr or .nc no array groups
     fill_value: int or float or np.ndarray or xr.DataArray, default=np.nan
         Specifies the value(s) at false indices
     storage_options_ds: dict, default={}
@@ -97,7 +98,11 @@ def apply_mask(
 
     # obtain final mask to be applied to var_name
     if isinstance(mask, list):
-        final_mask = np.logical_and(mask)
+        # perform a logical AND element-wise operation across the masks
+        final_mask = np.logical_and.reduce(mask)
+
+        # xr.where has issues with attrs when final_mask is an array, so we make it a DataArray
+        final_mask = xr.DataArray(final_mask, coords=mask[0].coords)
     else:
         final_mask = mask
 

--- a/echopype/tests/mask/test_mask.py
+++ b/echopype/tests/mask/test_mask.py
@@ -4,6 +4,7 @@ import numpy as np
 import xarray as xr
 
 import echopype as ep
+import echopype.mask
 from echopype.mask.api import _check_source_Sv_freq_diff
 
 from typing import List, Union
@@ -84,6 +85,49 @@ def get_mock_freq_diff_data(n: int, n_chan_freq: int, add_chan: bool,
     mock_Sv_ds = xr.Dataset(data_vars=data_vars)
 
     return mock_Sv_ds
+
+
+def get_mock_source_ds_apply_mask(n: int, n_chan: int) -> xr.Dataset:
+    """
+    Constructs a mock ``source_ds`` Dataset input for the
+    ``apply_mask`` function.
+
+    Parameters
+    ----------
+    n: int
+        The number of rows (``x``) and columns (``y``) of
+        each channel matrix
+    n_chan: int
+        Determines the size of the ``channel`` coordinate
+
+    Returns
+    -------
+    xr.Dataset
+        A Dataset with coordinates ``channel, x, y`` and
+        variables ``var1, var2`` (with the created coordinates). The
+        variables will contain square matrices of ones for each ``channel``.
+    """
+
+    # construct channel values
+    chan_vals = ['chan' + str(i) for i in range(1, n_chan + 1)]
+
+    # construct mock variable data for each channel
+    mock_var_data = [np.ones((n, n)) for i in range(n_chan)]
+
+    # create mock var1 and var2 DataArrays
+    mock_var1_da = xr.DataArray(data=np.stack(mock_var_data),
+                                coords={"channel": chan_vals, "x": np.arange(n),
+                                        "y": np.arange(n)},
+                                attrs={"long_name": "variable 1"})
+    mock_var2_da = xr.DataArray(data=np.stack(mock_var_data),
+                                coords={"channel": chan_vals, "x": np.arange(n),
+                                        "y": np.arange(n)},
+                                attrs={"long_name": "variable 2"})
+
+    # create mock Dataset
+    mock_ds = xr.Dataset(data_vars={"var1": mock_var1_da, "var2": mock_var2_da})
+
+    return mock_ds
 
 
 @pytest.mark.parametrize(
@@ -217,6 +261,47 @@ def test_frequency_differencing(n: int, n_chan_freq: int,
 
     # test that the output DataArray is correctly names
     assert out.name == "mask"
+
+
+@pytest.mark.parametrize(
+    ("n", "n_chan", "var_name", "mask", "var_masked_truth"),
+    [
+        (5, 1, "var1", np.identity(5), np.nan*np.ones((5, 5))),
+    ],
+    ids=["test1"]
+)
+def test_apply_mask(n: int, n_chan: int, var_name: str,
+                    mask: Union[Union[np.ndarray], List[np.ndarray]],
+                    var_masked_truth: np.ndarray):
+
+    # TODO: test different fill_value
+    fill_value = np.nan
+
+    mock_ds = get_mock_source_ds_apply_mask(n, n_chan)
+
+    # TODO: create test for list of masks
+
+    mask = xr.DataArray(data=np.stack([mask for i in range(n_chan)]),
+                        coords=mock_ds.coords)
+
+    np.fill_diagonal(var_masked_truth, 1.0)
+
+    var_masked_truth = xr.DataArray(data=np.stack([var_masked_truth for i in range(n_chan)]),
+                                    coords=mock_ds[var_name].coords, attrs=mock_ds[var_name].attrs)
+    var_masked_truth.name = mock_ds[var_name].name
+
+    masked_ds = echopype.mask.apply_mask(source_ds=mock_ds, var_name=var_name, mask=mask,
+                                         fill_value=fill_value, storage_options_ds={},
+                                         storage_options_mask={})
+
+    # TODO: check that masked_ds has the same structure as mock_ds
+
+    # TODO: check that masked_ds[var_name] == var_masked_truth
+
+    print("hello")
+
+    assert masked_ds[var_name].identical(var_masked_truth)
+
 
 
 

--- a/echopype/tests/utils/test_utils_io.py
+++ b/echopype/tests/utils/test_utils_io.py
@@ -6,7 +6,7 @@ from typing import Tuple
 import platform
 import xarray as xr
 
-from echopype.utils.io import sanitize_file_path, validate_output_path, env_indep_joinpath, validate_source_ds
+from echopype.utils.io import sanitize_file_path, validate_output_path, env_indep_joinpath, validate_source_ds_da
 
 
 @pytest.mark.parametrize(
@@ -260,18 +260,14 @@ def test_env_indep_joinpath_os_dependent(save_path: str, is_windows: bool, is_cl
 
 
 @pytest.mark.parametrize(
-    ("source_ds_input", "storage_options_input", "true_file_type"),
+    ("source_ds_da_input", "storage_options_input", "true_file_type"),
     [
         pytest.param(42, {}, None,
                      marks=pytest.mark.xfail(
                          strict=True,
                          reason='This test should fail because source_ds is not of the correct type.')
                      ),
-        pytest.param(xr.DataArray(), {}, None,
-                     marks=pytest.mark.xfail(
-                         strict=True,
-                         reason='This test should fail because source_ds is not of the correct type.')
-                     ),
+        pytest.param(xr.DataArray(), {}, None),
         pytest.param({}, 42, None,
                      marks=pytest.mark.xfail(
                          strict=True,
@@ -283,17 +279,17 @@ def test_env_indep_joinpath_os_dependent(save_path: str, is_windows: bool, is_cl
     ]
 
 )
-def test_validate_source_ds(source_ds_input, storage_options_input, true_file_type):
+def test_validate_source_ds_da(source_ds_da_input, storage_options_input, true_file_type):
     """
-    Tests that ``validate_source_ds`` has the appropriate outputs. 
-    An exhaustive list of combinations of ``source_ds`` and ``storage_options``
+    Tests that ``validate_source_ds_da`` has the appropriate outputs.
+    An exhaustive list of combinations of ``source_ds_da`` and ``storage_options``
     are tested in ``test_validate_output_path`` and are therefore not included here.
     """
 
-    source_ds_output, file_type_output = validate_source_ds(source_ds_input, storage_options_input)
+    source_ds_output, file_type_output = validate_source_ds_da(source_ds_da_input, storage_options_input)
 
-    if isinstance(source_ds_input, xr.Dataset):
-        assert source_ds_output.identical(source_ds_input)
+    if isinstance(source_ds_da_input, (xr.Dataset, xr.DataArray)):
+        assert source_ds_output.identical(source_ds_da_input)
         assert file_type_output is None
     else:
         assert isinstance(source_ds_output, str)

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -318,29 +318,29 @@ def env_indep_joinpath(*args: Tuple[str, ...]) -> str:
     return joined_path
 
 
-def validate_source_ds(
-    source_ds: Union[xr.Dataset, str, Path], storage_options: Optional[dict]
+def validate_source_ds_da(
+    source_ds_da: Union[xr.Dataset, xr.DataArray, str, Path], storage_options: Optional[dict]
 ) -> Tuple[Union[xr.Dataset, str, xr.DataArray], Optional[str]]:
     """
-    This function ensures that ``source_ds`` is of the correct
-    type and validates the path of ``source_ds``, if it is provided.
+    This function ensures that ``source_ds_da`` is of the correct
+    type and validates the path of ``source_ds_da``, if it is provided.
 
     Parameters
     ----------
-    source_ds: xr.Dataset or str or pathlib.Path
-        A source that points to a Dataset. If the input is a path, it specifies
-        the path to a zarr or netcdf file.
+    source_ds_da: xr.Dataset or xr.DataArray or str or pathlib.Path
+        A source that points to a Dataset or DataArray. If the input is a path,
+        it specifies the path to a zarr or netcdf file.
     storage_options: dict, optional
         Any additional parameters for the storage backend, corresponding to the
-        path provided for ``source_ds``
+        path provided for ``source_ds_da``
 
     Returns
     -------
-    source_ds: xr.Dataset or str
-        A Dataset which will be the same as the input ``source_ds`` or a validated
-        path to a zarr or netcdf file
+    source_ds_da: xr.Dataset or xr.DataArray or str
+        A Dataset or DataArray which will be the same as the input ``source_ds_da`` or
+        a validated path to a zarr or netcdf file
     file_type: {"netcdf4", "zarr"}, optional
-        The file type of the input path if ``source_ds`` is a path, otherwise ``None``
+        The file type of the input path if ``source_ds_da`` is a path, otherwise ``None``
     """
 
     # initialize file_type
@@ -350,25 +350,24 @@ def validate_source_ds(
     if not isinstance(storage_options, dict):
         raise TypeError("storage_options must be a dict!")
 
-    # check that source_ds is of the correct type, if it is a path validate
-    # the path and open the dataset using xarray
-    if not isinstance(source_ds, (xr.Dataset, str, Path)):
-        raise TypeError("source_ds must be a Dataset or str or pathlib.Path!")
-    elif isinstance(source_ds, (str, Path)):
+    # check that source_ds_da is of the correct type, if it is a path validate
+    # the path and open the Dataset or DataArray using xarray
+    if not isinstance(source_ds_da, (xr.Dataset, xr.DataArray, str, Path)):
+        raise TypeError("source_ds_da must be a Dataset or DataArray or str or pathlib.Path!")
+    elif isinstance(source_ds_da, (str, Path)):
 
         # determine if we obtained a zarr or netcdf file
-        file_type = get_file_format(source_ds)
+        file_type = get_file_format(source_ds_da)
 
-        # validate source_ds if it is a path
-        source_ds = validate_output_path(
+        # validate source_ds_da if it is a path
+        source_ds_da = validate_output_path(
             source_file="blank",  # will be unused since source_ds cannot be none
             engine=file_type,
             output_storage_options=storage_options,
-            save_path=source_ds,
+            save_path=source_ds_da,
         )
 
         # check that the path exists
-        check_file_existence(file_path=source_ds, storage_options=storage_options)
+        check_file_existence(file_path=source_ds_da, storage_options=storage_options)
 
-    return source_ds, file_type
-    # TODO extend to DataArray
+    return source_ds_da, file_type

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -371,3 +371,4 @@ def validate_source_ds(
         check_file_existence(file_path=source_ds, storage_options=storage_options)
 
     return source_ds, file_type
+    # TODO extend to DataArray

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -327,7 +327,7 @@ def validate_source_ds_da(
 
     Parameters
     ----------
-    source_ds_da: xr.Dataset or xr.DataArray or str or pathlib.Path
+    source_ds_da: xr.Dataset, xr.DataArray, str or pathlib.Path
         A source that points to a Dataset or DataArray. If the input is a path,
         it specifies the path to a zarr or netcdf file.
     storage_options: dict, optional


### PR DESCRIPTION
This PR redos PR #905. See #905 for all conversations.

This is part of the fix to ensure that we have a clean squash-and-merge history on `dev` and eventually `main`.