### PR TITLE
Add missing `pytest` in `test_combine_integration.py`

### DIFF
--- a/echopype/tests/echodata/test_combine_integration.py
+++ b/echopype/tests/echodata/test_combine_integration.py
@@ -1,5 +1,6 @@
 from textwrap import dedent
 from pathlib import Path
+import pytest
 
 import numpy as np
 import xarray as xr


### PR DESCRIPTION
This PR adds the missing `pytest` in `test_combine_integration.py` from #902.