### PR TITLE
Small fixes following calibration refactoring and mask history 

### DIFF
--- a/echopype/consolidate/api.py
+++ b/echopype/consolidate/api.py
@@ -315,9 +315,7 @@ def add_splitbeam_angle(
 
     # check that the appropriate waveform and encode mode have been given
     # and obtain the echodata group path corresponding to encode_mode
-    encode_mode_ed_group = retrieve_correct_beam_group(
-        echodata, waveform_mode, encode_mode, pulse_compression
-    )
+    encode_mode_ed_group = retrieve_correct_beam_group(echodata, waveform_mode, encode_mode)
 
     # check that source_Sv at least has a channel dimension
     if "channel" not in source_Sv.variables:

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -547,7 +547,7 @@ def frequency_differencing(
     history_attr = (
         f"{datetime.datetime.utcnow()} +00:00. "
         "Mask created by mask.frequency_differencing. "
-        f"Operation: Sv['{str(chanA.values)}'] - Sv['{str(chanB.values)}'] {operator} {diff}"
+        f"Operation: Sv['{chanA}'] - Sv['{chanB}'] {operator} {diff}"
     )
 
     da = da.assign_attrs({**mask_attrs, **{"history": history_attr}})


### PR DESCRIPTION
This PR includes fixes 2 small bugs:
- update use of `retrieve_correct_beam_group` in `add_splitbeam_angle` (from #904)
- fix bug in chanAB type in constructing freq-diff mask history (from #918)