### PR TITLE
Add `mask` and `consolidate` folders / subpackages to the set of target modules in run-test [all tests ci]

### DIFF
--- a/.ci_helpers/run-test.py
+++ b/.ci_helpers/run-test.py
@@ -33,6 +33,7 @@ MODULES_TO_TEST = {
     "visualize": {},
     "metrics": {},
     "mask": {},
+    "consolidate": {},
 }
 
 if __name__ == "__main__":

--- a/.ci_helpers/run-test.py
+++ b/.ci_helpers/run-test.py
@@ -32,6 +32,7 @@ MODULES_TO_TEST = {
     "utils": {},
     "visualize": {},
     "metrics": {},
+    "mask": {},
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
`tests/mask/test_mask.py` was being skipped from the default test suite because the new `mask` subpackage folder needed to be added to `MODULES_TO_TEST` in `.ci_helpers/run-test.py`.

In this PR I'm using "[all tests ci]" to force all tests to run. Note that some `test_mask.py` tests are failing. I'll address them in a separate PR. This PR is simply exposing tests that were failing but were not normally running.

ref: https://github.com/OSOceanAcoustics/echopype/pull/926#issuecomment-1369357462