### PR TITLE
Fix pre-commit ci and update RTD config for jupyter-book

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/executablebooks/jupyter-book
-    rev: v0.12.3
+    rev: v0.13.1
     hooks:
     - id: jb-to-sphinx
       args: ["docs/source"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,12 +33,6 @@ repos:
     hooks:
       - id: flake8
 
-  - repo: https://github.com/executablebooks/jupyter-book
-    rev: v0.13.1
-    hooks:
-    - id: jb-to-sphinx
-      args: ["docs/source"]
-
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
     hooks:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -28,7 +28,6 @@ formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: "3.8"
    install:
       - requirements: docs/requirements.txt
       - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,16 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+  jobs:
+    pre_build:
+      # Generate the Sphinx configuration for this Jupyter Book so it builds.
+      - "jupyter-book config sphinx docs/source"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py


### PR DESCRIPTION
## Overview 

This PR removes the `jupyter-book` pre-commit hook since there's no such thing anymore. The hook is now placed into the Read The Docs config to create the sphinx's `conf.py` file.