### PR TITLE
Tidy up `cal_params` related routines for calibration

### DIFF
--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -1,6 +1,7 @@
 import xarray as xr
 
 from ..echodata import EchoData
+from ..echodata.simrad import check_input_args_combination
 from ..utils.log import _init_logger
 from ..utils.prov import echopype_prov_attrs, source_files_vars
 from .calibrate_azfp import CalibrateAZFP
@@ -26,21 +27,11 @@ def _compute_cal(
     waveform_mode=None,
     encode_mode=None,
 ):
-    # TODO: change below to use echodata.simrad::_check_input_args_combination
-    #       for checking Simrad sonar models
-
     # Check on waveform_mode and encode_mode inputs
     if echodata.sonar_model == "EK80":
         if waveform_mode is None or encode_mode is None:
             raise ValueError("waveform_mode and encode_mode must be specified for EK80 calibration")
-        elif waveform_mode not in ("BB", "CW"):
-            raise ValueError("Input waveform_mode not recognized!")
-        elif encode_mode not in ("complex", "power"):
-            raise ValueError("Input encode_mode not recognized!")
-        elif waveform_mode == "BB" and encode_mode == "power":
-            raise ValueError(
-                "Data from broadband ('BB') transmission must be recorded as complex samples"
-            )
+        check_input_args_combination(waveform_mode, encode_mode)
     elif echodata.sonar_model in ("EK60", "AZFP"):
         if waveform_mode is not None and waveform_mode != "CW":
             logger.warning(

--- a/echopype/calibrate/cal_params.py
+++ b/echopype/calibrate/cal_params.py
@@ -6,7 +6,11 @@ import xarray as xr
 from ..echodata import EchoData
 
 CAL_PARAMS = {
-    "EK": ("sa_correction", "gain_correction", "equivalent_beam_angle"),
+    "EK": (  # TODO: consider including impedance?
+        "sa_correction", "gain_correction", "equivalent_beam_angle",
+        "angle_offset_alongship", "angle_offset_athwartship",
+        "beamwidth_alongship", "beamwidth_athwartship",
+    ),
     "AZFP": ("EL", "DS", "TVR", "VTX", "equivalent_beam_angle", "Sv_offset"),
 }
 

--- a/echopype/calibrate/cal_params.py
+++ b/echopype/calibrate/cal_params.py
@@ -54,16 +54,14 @@ def get_cal_params_AZFP(echodata: EchoData, user_cal_dict: dict) -> dict:
         user_cal_dict = {}
 
     # Get params from Beam_group1
-    out_dict["equivalent_beam_angle"] = (
-        user_cal_dict["equivalent_beam_angle"]
-        if "equivalent_beam_angle" in user_cal_dict
-        else echodata["Sonar/Beam_group1"]["equivalent_beam_angle"]
+    out_dict["equivalent_beam_angle"] = user_cal_dict.get(
+        "equivalent_beam_angle", echodata["Sonar/Beam_group1"]["equivalent_beam_angle"]
     )
 
     # Get params from the Vendor_specific group
     for p in ["EL", "DS", "TVR", "VTX", "Sv_offset"]:
         # substitute if None in user input
-        out_dict[p] = user_cal_dict[p] if p in user_cal_dict else echodata["Vendor_specific"][p]
+        out_dict[p] = user_cal_dict.get(p, echodata["Vendor_specific"][p])
 
     return out_dict
 
@@ -98,27 +96,17 @@ def get_cal_params_EK(
         "angle_offset_athwartship",
         "beamwidth_twoway_alongship",
         "beamwidth_twoway_athwartship",
+        "equivalent_beam_angle",
     ]
     for p in params_from_beam:
         # substitute if p not in user input
-        out_dict[p] = user_cal_dict[p] if p in user_cal_dict else beam[p]
+        out_dict[p] = user_cal_dict.get(p, beam[p])
 
     # Params from the Vendor_specific group
     params_from_vend = ["sa_correction", "gain_correction"]
     for p in params_from_vend:
         # substitute if p not in user input
-        out_dict[p] = (
-            user_cal_dict[p]
-            if p in user_cal_dict
-            else get_vend_cal_params_power(beam=beam, vend=vend, param=p)
-        )
-
-    # Other params
-    out_dict["equivalent_beam_angle"] = (
-        user_cal_dict["equivalent_beam_angle"]
-        if "equivalent_beam_angle" in user_cal_dict
-        else beam["equivalent_beam_angle"]
-    )
+        out_dict[p] = user_cal_dict.get(p, get_vend_cal_params_power(beam=beam, vend=vend, param=p))
 
     return out_dict
 

--- a/echopype/calibrate/cal_params.py
+++ b/echopype/calibrate/cal_params.py
@@ -7,9 +7,13 @@ from ..echodata import EchoData
 
 CAL_PARAMS = {
     "EK": (  # TODO: consider including impedance?
-        "sa_correction", "gain_correction", "equivalent_beam_angle",
-        "angle_offset_alongship", "angle_offset_athwartship",
-        "beamwidth_alongship", "beamwidth_athwartship",
+        "sa_correction",
+        "gain_correction",
+        "equivalent_beam_angle",
+        "angle_offset_alongship",
+        "angle_offset_athwartship",
+        "beamwidth_alongship",
+        "beamwidth_athwartship",
     ),
     "AZFP": ("EL", "DS", "TVR", "VTX", "equivalent_beam_angle", "Sv_offset"),
 }

--- a/echopype/calibrate/calibrate_base.py
+++ b/echopype/calibrate/calibrate_base.py
@@ -3,11 +3,6 @@ import abc
 from ..echodata import EchoData
 from .env_params_old import EnvParams
 
-CAL_PARAMS = {
-    "EK": ("sa_correction", "gain_correction", "equivalent_beam_angle"),
-    "AZFP": ("EL", "DS", "TVR", "VTX", "equivalent_beam_angle", "Sv_offset"),
-}
-
 
 class CalibrateBase(abc.ABC):
     """Class to handle calibration for all sonar models."""

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -411,7 +411,7 @@ class CalibrateEK80(CalibrateEK):
         to allow scaling for potential center frequency changes.
         """
         beam = self.echodata[self.ed_group]
-        psifc = beam["equivalent_beam_angle"].sel(channel=self.chan_sel).isel(beam=0).drop("beam")
+        psifc = self.cal_params["equivalent_beam_angle"]
         if self.waveform_mode == "BB":
             # if BB scale according to true center frequency
             psifc += 20 * np.log10(  # TODO: BUGS! should be 20 * log10 [WJ resolved 2022/12/27]

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -206,7 +206,7 @@ class CalibrateEK80(CalibrateEK):
 
         # Use center frequency if in BB mode, else use nominal channel frequency
         if self.waveform_mode == "BB":
-            # use true center frequency to interpolate for gain factor
+            # use true center frequency to interpolate for various cal params
             self.freq_center = (beam["frequency_start"] + beam["frequency_end"]).sel(
                 channel=self.chan_sel
             ).isel(beam=0).drop("beam") / 2
@@ -490,7 +490,7 @@ class CalibrateEK80(CalibrateEK):
 
             # Correct for sa_correction if CW mode
             if self.waveform_mode == "CW":
-                out = out - 2 * self.cal_params["sa_correction"].sel(channel=self.chan_sel)
+                out = out - 2 * self.cal_params["sa_correction"]
 
             out.name = "Sv"
             # out = out.rename_vars({list(out.data_vars.keys())[0]: "Sv"})

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -445,7 +445,7 @@ class CalibrateEK80(CalibrateEK):
         z_er, z_et = self._get_impedance()  # transmit and receive impedance
         gain = self._get_gain()  # gain
         absorption = self.env_params["sound_absorption"]
-        range_meter = self.range_meter  # TODO: BUG: THIS IS NOT SELECTED WITH THE RIGHT CHANNELS!
+        range_meter = self.range_meter
         sound_speed = self.env_params["sound_speed"]
         wavelength = sound_speed / self.freq_center
         transmit_power = beam["transmit_power"]
@@ -544,11 +544,9 @@ class CalibrateEK80(CalibrateEK):
 
         if flag_complex:
             # Complex samples can be BB or CW
-            self.compute_echo_range()
             ds_cal = self._cal_complex_samples(cal_type=cal_type, complex_ed_group=self.ed_group)
         else:
             # Power samples only make sense for CW mode data
-            self.compute_echo_range()
             ds_cal = self._cal_power_samples(cal_type=cal_type, power_ed_group=self.ed_group)
 
         return ds_cal

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -5,7 +5,7 @@ import numpy as np
 import xarray as xr
 
 from ..echodata import EchoData
-from ..echodata.simrad import check_input_args_combination, retrieve_correct_beam_group
+from ..echodata.simrad import retrieve_correct_beam_group
 from ..utils.log import _init_logger
 from .cal_params import get_cal_params_EK, get_param_BB, get_vend_filter_EK80
 from .calibrate_base import CalibrateBase
@@ -180,8 +180,8 @@ class CalibrateEK80(CalibrateEK):
     def __init__(self, echodata, env_params, cal_params, waveform_mode, encode_mode):
         super().__init__(echodata, env_params, cal_params)
 
-        # Check the combination of waveform and encode mode makes sense
-        check_input_args_combination(waveform_mode, encode_mode)
+        # The waveform and encode mode combination checked in calibrate/api.py::_compute_cal
+        # so just doing assignment here
         self.waveform_mode = waveform_mode
         self.encode_mode = encode_mode
         self.echodata = echodata

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -256,7 +256,7 @@ class CalibrateEK80(CalibrateEK):
             # All channels are CW
             return {"BB": None, "CW": beam.channel}
 
-    def _get_filter_coeff(self, channel: xr.DataArray) -> Dict:
+    def _get_filter_coeff(self) -> Dict:
         """
         Get WBT and PC filter coefficients for constructing the transmit replica.
 
@@ -265,9 +265,9 @@ class CalibrateEK80(CalibrateEK):
         A dictionary indexed by ``channel`` and values being dictionaries containing
         filter coefficients and decimation factors for constructing the transmit replica.
         """
-        vend = self.echodata["Vendor_specific"]
+        vend = self.echodata["Vendor_specific"].sel(channel=self.chan_sel)
         coeff = defaultdict(dict)
-        for ch_id in channel.values:
+        for ch_id in vend["channel"].values:
             # filter coefficients and decimation factor
             coeff[ch_id]["wbt_fil"] = get_vend_filter_EK80(vend, ch_id, "WBT", "coeff")
             coeff[ch_id]["pc_fil"] = get_vend_filter_EK80(vend, ch_id, "PC", "coeff")
@@ -279,7 +279,6 @@ class CalibrateEK80(CalibrateEK):
     def _get_power_from_complex(
         self,
         beam: xr.Dataset,
-        chan_sel: xr.DataArray,
         chirp: Dict,
         z_et,
         z_er,
@@ -290,9 +289,7 @@ class CalibrateEK80(CalibrateEK):
         Parameters
         ----------
         beam : xr.Dataset
-            EchoData["Sonar/Beam_group1"]
-        chan_sel : xr.DataArray
-            channels that transmit in BB mode
+            EchoData["Sonar/Beam_group1"] with selected channel subset
         chirp : dict
             a dictionary containing transmit chirp for BB channels
 
@@ -313,12 +310,10 @@ class CalibrateEK80(CalibrateEK):
 
         # Compute power
         if self.waveform_mode == "BB":
-            pc = compress_pulse(beam=beam, chirp=chirp, chan_BB=chan_sel)  # has beam dim
+            pc = compress_pulse(beam=beam, chirp=chirp)  # has beam dim
             prx = _get_prx(pc["pulse_compressed_output"])  # ensure prx is xr.DataArray
         else:
-            bs_cw = beam["backscatter_r"].sel(channel=chan_sel) + 1j * beam["backscatter_i"].sel(
-                channel=chan_sel
-            )
+            bs_cw = beam["backscatter_r"] + 1j * beam["backscatter_i"]
             prx = _get_prx(bs_cw)
 
         prx.name = "received_power"
@@ -360,13 +355,13 @@ class CalibrateEK80(CalibrateEK):
         """
         Get receiver sampling frequency from either data or default values
         """
-        vend = self.echodata["Vendor_specific"]
+        vend = self.echodata["Vendor_specific"].sel(channel=self.chan_sel)
         if "fs_receiver" in vend:
-            return vend["fs_receiver"].sel(channel=self.chan_sel)
+            return vend["fs_receiver"]
         else:
             # Most robust to loop through channel
             fs = []
-            for ch in self.chan_sel:
+            for ch in vend["channel"]:
                 tcvr_type = vend["transceiver_type"].sel(channel=ch).data.tolist().upper()
                 fs.append(self.EK80_params["fs"][tcvr_type])
             return xr.DataArray(fs, dims=["channel"], coords={"channel": vend["channel"]})
@@ -436,30 +431,24 @@ class CalibrateEK80(CalibrateEK):
             The calibrated dataset containing Sv or TS
         """
         # Select source of backscatter data
-        beam = self.echodata[complex_ed_group]
-        vend = self.echodata["Vendor_specific"]
+        beam = self.echodata[complex_ed_group].sel(channel=self.chan_sel)
+        vend = self.echodata["Vendor_specific"].sel(channel=self.chan_sel)
 
         # Get transmit signal
-        tx_coeff = self._get_filter_coeff(channel=self.chan_sel)
+        tx_coeff = self._get_filter_coeff()
         fs = self._get_fs()
 
         # Switch to use Anderson implementation for transmit chirp starting v0.6.4
-        tx, tx_time = get_transmit_signal(
-            beam=beam,
-            coeff=tx_coeff,
-            waveform_mode=self.waveform_mode,
-            channel=self.chan_sel,
-            fs=fs,
-        )
+        tx, tx_time = get_transmit_signal(beam, tx_coeff, self.waveform_mode, fs)
 
         # Params to clarity in use below
         z_er, z_et = self._get_impedance()  # transmit and receive impedance
         gain = self._get_gain()  # gain
-        absorption = self.env_params["sound_absorption"].sel(channel=self.chan_sel)
-        range_meter = self.range_meter.sel(channel=self.chan_sel)
+        absorption = self.env_params["sound_absorption"]
+        range_meter = self.range_meter  # TODO: BUG: THIS IS NOT SELECTED WITH THE RIGHT CHANNELS!
         sound_speed = self.env_params["sound_speed"]
         wavelength = sound_speed / self.freq_center
-        transmit_power = beam["transmit_power"].sel(channel=self.chan_sel)
+        transmit_power = beam["transmit_power"]
 
         # TVG compensation with modified range
         tvg_mod_range = range_mod_TVG_EK(self.echodata, self.ed_group, range_meter, sound_speed)
@@ -467,9 +456,7 @@ class CalibrateEK80(CalibrateEK):
         absorption_loss = 2 * absorption * tvg_mod_range
 
         # Get power from complex samples
-        prx = self._get_power_from_complex(
-            beam=beam, chan_sel=self.chan_sel, chirp=tx, z_et=z_et, z_er=z_er
-        )
+        prx = self._get_power_from_complex(beam=beam, chirp=tx, z_et=z_et, z_er=z_er)
 
         # Compute based on cal_type
         if cal_type == "Sv":
@@ -485,15 +472,11 @@ class CalibrateEK80(CalibrateEK):
             # Use pulse_duration in place of tau_effective for GPT channels
             # below assumesthat all transmit parameters are identical
             # and needs to be changed when allowing transmit parameters to vary by ping
-            ch_GPT = vend["transceiver_type"].sel(channel=self.chan_sel) == "GPT"
-            tau_effective[ch_GPT] = (
-                beam["transmit_duration_nominal"]
-                .sel(channel=self.chan_sel)[ch_GPT]
-                .isel(ping_time=0)
-            )
+            ch_GPT = vend["transceiver_type"] == "GPT"
+            tau_effective[ch_GPT] = beam["transmit_duration_nominal"][ch_GPT].isel(ping_time=0)
 
             # equivalent_beam_angle:
-            psifc = self._get_psifc()
+            psifc = self._get_psifc()  # TODO: THIS ONE CARRIES THE BEAM DIMENSION AROUND
 
             out = (
                 10 * np.log10(prx)

--- a/echopype/calibrate/env_params.py
+++ b/echopype/calibrate/env_params.py
@@ -244,7 +244,7 @@ def get_env_params_EK80(
                 formula_source=(
                     user_env_dict["formula_source"] if "formula_source" in user_env_dict else "FG"
                 ),
-            )
+            ),
         )
 
     # Harmonize time coordinate between Beam_groupX (ping_time) and env_params (time1)

--- a/echopype/calibrate/env_params.py
+++ b/echopype/calibrate/env_params.py
@@ -159,9 +159,7 @@ def get_env_params_EK60(echodata: EchoData, user_env_dict: Optional[Dict] = None
             "sound_absorption": "absorption_indicative",
         }
         for p_out, p_data in p_map_dict.items():
-            out_dict[p_out] = (
-                user_env_dict[p_out] if p_out in user_env_dict else echodata["Environment"][p_data]
-            )
+            out_dict[p_out] = user_env_dict.get(p_out, echodata["Environment"][p_data])
 
     # Harmonize time coordinate between Beam_groupX (ping_time) and env_params (time1)
     # Note for EK60 data is always in Sonar/Beam_group1
@@ -229,23 +227,14 @@ def get_env_params_EK80(
     else:
         # pressure is encoded as "depth" in EK80  # TODO: change depth to pressure in EK80 file?
         for p_user, p_data in zip(
-            ["temperature", "salinity", "pressure", "pH"],
-            ["temperature", "salinity", "depth", "acidity"],
+            ["temperature", "salinity", "pressure", "pH", "sound_speed"],
+            ["temperature", "salinity", "depth", "acidity", "sound_speed_indicative"],
         ):
-            out_dict[p_user] = (
-                user_env_dict[p_user]
-                if p_user in user_env_dict
-                else echodata["Environment"][p_data]
-            )
-        out_dict["sound_speed"] = (
-            user_env_dict["sound_speed"]
-            if "sound_speed" in user_env_dict
-            else echodata["Environment"]["sound_speed_indicative"]
-        )
-        out_dict["sound_absorption"] = (
-            user_env_dict["sound_absorption"]
-            if "sound_absorption" in user_env_dict
-            else uwa.calc_absorption(
+            out_dict[p_user] = user_env_dict.get(p_user, echodata["Environment"][p_data])
+
+        out_dict["sound_absorption"] = user_env_dict.get(
+            "sound_absorption",
+            uwa.calc_absorption(
                 frequency=freq,
                 temperature=out_dict["temperature"],
                 salinity=out_dict["salinity"],

--- a/echopype/echodata/simrad.py
+++ b/echopype/echodata/simrad.py
@@ -32,7 +32,9 @@ def check_input_args_combination(
 
     # BB has complex data only, but CW can have complex or power data
     if (waveform_mode == "BB") and (encode_mode == "power"):
-        raise ValueError("encode_mode='power' not allowed when waveform_mode='BB'!")
+        raise ValueError(
+            "Data from broadband ('BB') transmission must be recorded as complex samples"
+        )
 
     # make sure that we have BB and complex inputs, if pulse compression is selected
     if pulse_compression is not None:

--- a/echopype/tests/calibrate/test_calibrate_ek80.py
+++ b/echopype/tests/calibrate/test_calibrate_ek80.py
@@ -225,9 +225,7 @@ def test_ek80_BB_power_echoview(ek80_path):
     cal_obj = ep.calibrate.calibrate_ek.CalibrateEK80(
         echodata, env_params=None, cal_params=None, waveform_mode="BB", encode_mode="complex"
     )
-    cal_obj.compute_echo_range()  # compute range [m]
     beam = echodata["Sonar/Beam_group1"].sel(channel=cal_obj.chan_sel)
-    chan_sel = beam["channel"]  # only BB data exist
 
     coeff = cal_obj._get_filter_coeff()
     chirp, _ = ep.calibrate.ek80_complex.get_transmit_signal(beam, coeff, "BB", cal_obj._get_fs())

--- a/echopype/tests/calibrate/test_calibrate_ek80.py
+++ b/echopype/tests/calibrate/test_calibrate_ek80.py
@@ -35,9 +35,9 @@ def test_ek80_transmit_chirp(ek80_cal_path, ek80_ext_path):
         env_params=None, cal_params=None
     )
     fs = cal_obj._get_fs()
-    filter_coeff = cal_obj._get_filter_coeff(channel=cal_obj.chan_sel)
+    filter_coeff = cal_obj._get_filter_coeff()
     tx, tx_time = ep.calibrate.ek80_complex.get_transmit_signal(
-        ed["Sonar/Beam_group1"], filter_coeff, waveform_mode, cal_obj.chan_sel, fs
+        ed["Sonar/Beam_group1"].sel(channel=cal_obj.chan_sel), filter_coeff, waveform_mode, fs
     )
     tau_effective = ep.calibrate.ek80_complex.get_tau_effective(
         ytx_dict=tx,
@@ -168,18 +168,14 @@ def test_ek80_BB_power_Sv(ek80_cal_path, ek80_ext_path):
     )
 
     # Params needed
-    beam = cal_obj.echodata[cal_obj.ed_group]
+    beam = cal_obj.echodata[cal_obj.ed_group].sel(channel=cal_obj.chan_sel)
     z_er, z_et = cal_obj._get_impedance()  # transmit and receive impedance
     fs = cal_obj._get_fs()
-    filter_coeff = cal_obj._get_filter_coeff(channel=cal_obj.chan_sel)
-    tx, tx_time = ep.calibrate.ek80_complex.get_transmit_signal(
-        ed["Sonar/Beam_group1"], filter_coeff, waveform_mode, cal_obj.chan_sel, fs
-    )
+    filter_coeff = cal_obj._get_filter_coeff()
+    tx, tx_time = ep.calibrate.ek80_complex.get_transmit_signal(beam, filter_coeff, waveform_mode, fs)
 
     # Get power from complex samples
-    prx = cal_obj._get_power_from_complex(
-        beam=beam, chan_sel=cal_obj.chan_sel, chirp=tx, z_et=z_et, z_er=z_er
-    )
+    prx = cal_obj._get_power_from_complex(beam=beam, chirp=tx, z_et=z_et, z_er=z_er)
 
     ch_sel = "WBT 714590-15 ES70-7C"
 
@@ -230,15 +226,13 @@ def test_ek80_BB_power_echoview(ek80_path):
         echodata, env_params=None, cal_params=None, waveform_mode="BB", encode_mode="complex"
     )
     cal_obj.compute_echo_range()  # compute range [m]
-    beam = echodata["Sonar/Beam_group1"]
+    beam = echodata["Sonar/Beam_group1"].sel(channel=cal_obj.chan_sel)
     chan_sel = beam["channel"]  # only BB data exist
 
-    coeff = cal_obj._get_filter_coeff(channel=chan_sel)
-    chirp, _ = ep.calibrate.ek80_complex.get_transmit_signal(
-        beam=beam, coeff=coeff, channel=chan_sel, waveform_mode="BB", fs=cal_obj._get_fs()
-    )
+    coeff = cal_obj._get_filter_coeff()
+    chirp, _ = ep.calibrate.ek80_complex.get_transmit_signal(beam, coeff, "BB", cal_obj._get_fs())
 
-    pc = ep.calibrate.ek80_complex.compress_pulse(beam=beam, chirp=chirp, chan_BB=chan_sel)
+    pc = ep.calibrate.ek80_complex.compress_pulse(beam=beam, chirp=chirp)
     pc_mean = pc.pulse_compressed_output.sel(channel="WBT 549762-15 ES70-7C").mean(dim="beam").dropna("range_sample")
 
     # Read EchoView pc raw power output


### PR DESCRIPTION
## Overview

This PR tidies up `cal_params` related routines for calibration. It is a follow up to #944.

## Details

### Calibration-related
- do all cal param intake at init of `Calibration*` objects
- simplify syntax for getting params from user inputs or data file for `cal_params` and `env_params`
- list out cal parameters in `calibration.cal_params.CAL_PARAMS`
  - still need to resolve `gain` vs `gain_correction` in the junction of user-provided vs data-derived params
- use `equivalent_beam_angle` from `cal_params` in `_get_psifc()`
- do channel subset (`.sel(channel=chan_sel)`) in the beginning of `_cal_complex_samples`
  - remove/clean up various downstream channel subsetting
- remove redundant `compute_echo_range()` call in `CalibrateEK80` that resulted in extra channels in `self.range_meter`

### Others
- use `echodata.simrad.check_input_args_combination()` in `calibrate.api()`

