### PR TITLE
Update docker build for arm64 mac silicon chips

### DIFF
--- a/.ci_helpers/docker/http.dockerfile
+++ b/.ci_helpers/docker/http.dockerfile
@@ -1,3 +1,4 @@
 FROM httpd:2.4
+ARG TARGETPLATFORM
 
 COPY echopype/test_data /usr/local/apache2/htdocs/data

--- a/.ci_helpers/docker/minioci.dockerfile
+++ b/.ci_helpers/docker/minioci.dockerfile
@@ -1,4 +1,5 @@
 FROM minio/minio
+ARG TARGETPLATFORM
 
 # Install git
 RUN microdnf install git

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -47,6 +47,7 @@ jobs:
           context: ./
           file: ./.ci_helpers/docker/${{ matrix.image_name }}.dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.IMAGE_SPEC }}:${{ env.DATE_TAG }}
             ${{ env.IMAGE_SPEC }}:latest


### PR DESCRIPTION
## Overview

This PR should enable running docker images on the new Apple silicon chips.