### PR TITLE
Handling of non-positive values causing log10 warnings on EK calibration

### DIFF
--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -17,6 +17,7 @@ logger = _init_logger(__name__)
 # Small positive number, to use in place of zero
 EPS = 1e-5
 
+
 class CalibrateEK(CalibrateBase):
     def __init__(self, echodata: EchoData, env_params, cal_params):
         super().__init__(echodata, env_params, cal_params)

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -14,9 +14,6 @@ from .range import compute_range_EK, range_mod_TVG_EK
 
 logger = _init_logger(__name__)
 
-# Small positive number, to use in place of zero
-EPS = 1e-5
-
 
 class CalibrateEK(CalibrateBase):
     def __init__(self, echodata: EchoData, env_params, cal_params):
@@ -68,7 +65,7 @@ class CalibrateEK(CalibrateBase):
         tvg_mod_range = range_mod_TVG_EK(
             self.echodata, self.ed_group, self.range_meter, sound_speed
         )
-        tvg_mod_range = tvg_mod_range.where(tvg_mod_range > 0, EPS)
+        tvg_mod_range = tvg_mod_range.where(tvg_mod_range > 0, np.nan)
 
         spreading_loss = 20 * np.log10(tvg_mod_range)
         absorption_loss = 2 * absorption * tvg_mod_range
@@ -380,14 +377,14 @@ class CalibrateEK80(CalibrateEK):
 
         # TVG compensation with modified range
         tvg_mod_range = range_mod_TVG_EK(self.echodata, self.ed_group, range_meter, sound_speed)
-        tvg_mod_range = tvg_mod_range.where(tvg_mod_range > 0, EPS)
+        tvg_mod_range = tvg_mod_range.where(tvg_mod_range > 0, np.nan)
 
         spreading_loss = 20 * np.log10(tvg_mod_range)
         absorption_loss = 2 * absorption * tvg_mod_range
 
         # Get power from complex samples
         prx = self._get_power_from_complex(beam=beam, chirp=tx, z_et=z_et, z_er=z_er)
-        prx = prx.where(prx > 0, EPS)
+        prx = prx.where(prx > 0, np.nan)
 
         # Compute based on cal_type
         if cal_type == "Sv":

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -14,6 +14,8 @@ from .range import compute_range_EK, range_mod_TVG_EK
 
 logger = _init_logger(__name__)
 
+# Small positive number, to use in place of zero
+EPS = 1e-5
 
 class CalibrateEK(CalibrateBase):
     def __init__(self, echodata: EchoData, env_params, cal_params):
@@ -65,6 +67,8 @@ class CalibrateEK(CalibrateBase):
         tvg_mod_range = range_mod_TVG_EK(
             self.echodata, self.ed_group, self.range_meter, sound_speed
         )
+        tvg_mod_range = tvg_mod_range.where(tvg_mod_range > 0, EPS)
+
         spreading_loss = 20 * np.log10(tvg_mod_range)
         absorption_loss = 2 * absorption * tvg_mod_range
 
@@ -375,11 +379,14 @@ class CalibrateEK80(CalibrateEK):
 
         # TVG compensation with modified range
         tvg_mod_range = range_mod_TVG_EK(self.echodata, self.ed_group, range_meter, sound_speed)
+        tvg_mod_range = tvg_mod_range.where(tvg_mod_range > 0, EPS)
+
         spreading_loss = 20 * np.log10(tvg_mod_range)
         absorption_loss = 2 * absorption * tvg_mod_range
 
         # Get power from complex samples
         prx = self._get_power_from_complex(beam=beam, chirp=tx, z_et=z_et, z_er=z_er)
+        prx = prx.where(prx > 0, EPS)
 
         # Compute based on cal_type
         if cal_type == "Sv":


### PR DESCRIPTION
Handle values <= 0 (0 and negative values) in calibration compute to eliminate log10 warnings. For the dataarrays causing these warnings, sets non-negative values to a slightly positive non-zero value.

Addresses #737

Note: when I ran the test suite locally there were a bunch of errors unrelated to the warnings addressed here. I'm going to assume there's some other mess in my test setup or some temporary glitch, and let the CI tests take a crack. All the log10 warnings in `test_range_integration.py` are gone.