### PR TITLE
Fix bug to pass in `env_params` from parent class method for EK60

### DIFF
--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -132,7 +132,7 @@ class CalibrateEK60(CalibrateEK):
         self.sonar_type = "EK60"
 
         # Get env_params
-        self.env_params = get_env_params_EK60(echodata=echodata, user_env_dict=env_params)
+        self.env_params = get_env_params_EK60(echodata=echodata, user_env_dict=self.env_params)
         self.waveform_mode = "CW"
         self.encode_mode = "power"
 


### PR DESCRIPTION
This PR fixes the bug that user-provided env params are not correctly taken in in `CalibrateEK60`. 