### PR TITLE
Standardize use of sonar metadata as `Sonar` global attributes vs (for EK80 only) variables

### DIFF
--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -124,7 +124,7 @@ class SetGroupsAZFP(SetGroupsBase):
             "sonar_manufacturer": "ASL Environmental Sciences",
             "sonar_model": self.sonar_model,
             "sonar_serial_number": int(self.parser_obj.unpacked_data["serial_number"]),
-            "sonar_software_name": "Based on AZFP Matlab Toolbox",
+            "sonar_software_name": "AZFP",
             "sonar_software_version": "1.4",
             "sonar_type": "echosounder",
         }

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -194,6 +194,7 @@ class SetGroupsEK80(SetGroupsBase):
             "transducer_frequency",
             "serial_number",
             "transducer_name",
+            "transducer_serial_number",
             "application_name",
             "application_version",
             "channel_id_short",
@@ -236,18 +237,11 @@ class SetGroupsEK80(SetGroupsBase):
                     "standard_name": "sound_frequency",
                 },
             ),
-            "sonar_serial_number": (
-                ["channel"],
-                var["channel_id_short"],
-                {
-                    "long_name": "Sonar serial number",
-                },
-            ),
-            "transducer_serial_number": (
+            "transceiver_serial_number": (
                 ["channel"],
                 var["serial_number"],
                 {
-                    "long_name": "Transducer serial number",
+                    "long_name": "Transceiver serial number",
                 },
             ),
             "transducer_name": (
@@ -255,6 +249,13 @@ class SetGroupsEK80(SetGroupsBase):
                 var["transducer_name"],
                 {
                     "long_name": "Transducer name",
+                },
+            ),
+            "transducer_serial_number": (
+                ["channel"],
+                var["transducer_serial_number"],
+                {
+                    "long_name": "Transducer serial number",
                 },
             ),
         }
@@ -274,6 +275,10 @@ class SetGroupsEK80(SetGroupsBase):
         sonar_attr_dict = {
             "sonar_manufacturer": "Simrad",
             "sonar_model": self.sonar_model,
+            # transducer (sonar) serial number is not reliably stored in the EK80 raw
+            # data file and would be channel-dependent. For consistency with EK60,
+            # will not try to populate sonar_serial_number from the raw datagrams
+            "sonar_serial_number": "",
             "sonar_software_name": var["application_name"][0],
             "sonar_software_version": var["application_version"][0],
             "sonar_type": "echosounder",

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -236,17 +236,27 @@ class SetGroupsEK80(SetGroupsBase):
                     "standard_name": "sound_frequency",
                 },
             ),
-            "serial_number": (["channel"], var["serial_number"]),
-            "transducer_name": (["channel"], var["transducer_name"]),
-            "sonar_serial_number": (["channel"], var["channel_id_short"]),
-            "sonar_software_name": (
+            "sonar_serial_number": (
                 ["channel"],
-                var["application_name"],
-            ),  # identical for all channels
-            "sonar_software_version": (
+                var["channel_id_short"],
+                {
+                    "long_name": "Sonar serial number",
+                },
+            ),
+            "transducer_serial_number": (
                 ["channel"],
-                var["application_version"],
-            ),  # identical for all channels
+                var["serial_number"],
+                {
+                    "long_name": "Transducer serial number",
+                },
+            ),
+            "transducer_name": (
+                ["channel"],
+                var["transducer_name"],
+                {
+                    "long_name": "Transducer name",
+                },
+            ),
         }
         ds = xr.Dataset(
             {**sonar_vars, **beam_groups_vars},
@@ -264,6 +274,8 @@ class SetGroupsEK80(SetGroupsBase):
         sonar_attr_dict = {
             "sonar_manufacturer": "Simrad",
             "sonar_model": self.sonar_model,
+            "sonar_software_name": var["application_name"][0],
+            "sonar_software_version": var["application_version"][0],
             "sonar_type": "echosounder",
         }
         ds = ds.assign_attrs(sonar_attr_dict)


### PR DESCRIPTION
Addresses all tasks in #681 involving sonar metadata in the `Sonar` group as implemented in echopype vs in the SONAR-netCDF convention.

Nearly all the changes are to EK80, where the main issue was the presence of some sonar metadata as variables rather than global attributes. Specifically:
- Changed `sonar_software_name` and `sonar_software_version` to be global attributes rather than variables
- Renamed the custom (non-convention) variable `serial_number` to `transducer_serial_number` (@leewujung please confirm if this is accurate; see https://github.com/OSOceanAcoustics/echopype/issues/681#issuecomment-1472502461)
- Added a `long_name` attribute to variables `sonar_serial_number`, `transducer_serial_number` and `transducer_name`

For AZFP, Set `sonar_software_name` to "AZFP" instead of "Based on AZFP Matlab Toolbox".