### PR TITLE
Fix CW-based beamwidth scaling

### DIFF
--- a/echopype/calibrate/cal_params.py
+++ b/echopype/calibrate/cal_params.py
@@ -466,10 +466,13 @@ def get_cal_params_EK(
                         if p in [
                             "angle_sensitivity_alongship",
                             "angle_sensitivity_athwartship",
+                        ]:
+                            BB_factor = freq_center / beam["frequency_nominal"]
+                        elif p in [
                             "beamwidth_alongship",
                             "beamwidth_athwartship",
                         ]:
-                            BB_factor = freq_center / beam["frequency_nominal"]
+                            BB_factor = beam["frequency_nominal"] / freq_center
                         else:
                             BB_factor = 1
 


### PR DESCRIPTION
This PR addresses #997.

Just to have things all in one place, we do not need to alter the test file `test_calibrate_ek80.py`, because (from my comment in #997):
> Turns out for that particular file used in `test_calibrate_ek80.py`, there was no need to scale CW-based cal parameters (stored in the `Sonar/Beam_groupX` group) because those cal parameters happen to exist in a frequency-dependent form (stored in the `Vendor-specific` group) for the BB channels. (To elaborate: scaling is only needed if a particular parameter is not available in the frequency-dependent form and needs to be estimated from CW-based values.)

