### PR TITLE
Implementation of data-processing-level attributes

### DIFF
--- a/echopype/commongrid/api.py
+++ b/echopype/commongrid/api.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from ..utils.prov import echopype_prov_attrs
+from ..utils.prov import echopype_prov_attrs, add_processing_level, insert_input_processing_level
 from .mvbs import get_MVBS_along_channels
 
 
@@ -35,6 +35,7 @@ def _set_MVBS_attrs(ds):
     }
 
 
+@add_processing_level("L3", inherit_sublevel=True)
 def compute_MVBS(ds_Sv, range_meter_bin=20, ping_time_bin="20S"):
     """
     Compute Mean Volume Backscattering Strength (MVBS)
@@ -138,6 +139,8 @@ def compute_MVBS(ds_Sv, range_meter_bin=20, ping_time_bin="20S"):
     prov_dict["processing_function"] = "commongrid.compute_MVBS"
     ds_MVBS = ds_MVBS.assign_attrs(prov_dict)
     ds_MVBS["frequency_nominal"] = ds_Sv["frequency_nominal"]  # re-attach frequency_nominal
+
+    ds_MVBS = insert_input_processing_level(ds_MVBS, input_ds=ds_Sv)
 
     return ds_MVBS
 

--- a/echopype/consolidate/api.py
+++ b/echopype/consolidate/api.py
@@ -9,6 +9,7 @@ from ..calibrate.ek80_complex import get_filter_coeff
 from ..echodata import EchoData
 from ..echodata.simrad import retrieve_correct_beam_group
 from ..utils.io import validate_source_ds_da
+from ..utils.prov import add_processing_level
 from .split_beam_angle import add_angle_to_ds, get_angle_complex_samples, get_angle_power_samples
 
 
@@ -128,6 +129,7 @@ def add_depth(
     return ds
 
 
+@add_processing_level("L2A")
 def add_location(ds: xr.Dataset, echodata: EchoData = None, nmea_sentence: Optional[str] = None):
     """
     Add geographical location (latitude/longitude) to the Sv dataset.

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -16,6 +16,7 @@ from ..echodata.echodata import XARRAY_ENGINE_MAP, EchoData
 from ..utils import io
 from ..utils.coding import COMPRESSION_SETTINGS
 from ..utils.log import _init_logger
+from ..utils.prov import add_processing_level
 
 BEAM_SUBGROUP_DEFAULT = "Beam_group1"
 
@@ -306,6 +307,7 @@ def _check_file(
     return str(raw_file), str(xml)
 
 
+@add_processing_level("L1A", is_echodata=True)
 def open_raw(
     raw_file: "PathHint",
     sonar_model: "SonarModelsHint",

--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -1,11 +1,14 @@
 from datetime import datetime as dt
+import functools
 from pathlib import Path
+
 from typing import Dict, List, Tuple, Union
+from typing_extensions import Literal
 
 import numpy as np
-from _echopype_version import version as ECHOPYPE_VERSION
 from numpy.typing import NDArray
-from typing_extensions import Literal
+import xarray as xr
+from _echopype_version import version as ECHOPYPE_VERSION
 
 from .log import _init_logger
 
@@ -143,3 +146,144 @@ def source_files_vars(
     }
 
     return files_vars
+
+
+# L0 is not actually used by echopype but is included for completeness
+PROCESSING_LEVELS = dict(
+    L0="Level 0",
+    L1A="Level 1A",
+    L1B="Level 1B",
+    L2A="Level 2A",
+    L2B="Level 2B",
+    L3A="Level 3A",
+    L3B="Level 3B",
+    L4="Level 4",
+)
+
+# TODO:
+#   - New decorator function that inserts processing-level global attributes, if appropriate.
+#     Product level attributes will be added only if lat-lon coordinates (and depth for >= L2?) are present.
+#     Attributes: processing_level, processing_level_url
+#   - DONE. Dict mapping a processing level code (eg, "L1A") to the longer text that will be inserted in the attr
+#   - DONE. Function that each function will use to read its "input" xr.dataset processing_level (if it exists)
+#     and pass it on to the output xr.dataset as input_processing_level for use by the decorator
+#   - DONE. For L2 & L3, the "input" dataset will typically already have a processing_level attribute;
+#     read and propagate the sub-level code (A & B).
+#   - (EXTERNAL) Associate (ie, document) processing level code with each relevant function listed in
+#     https://github.com/OSOceanAcoustics/echopype/pull/817#issuecomment-1474564449
+#   - echodata.update_platform should result in the addition of a processing level attr.
+#     But as a class method, doing this may be trickier. The challenge is how to pass "self" to the decorator
+#     function/wrapper. Consider wrapping add_processing_level in another function, and using that
+#     as the class-method decorator?
+
+# DEVELOPMENT PLAN:
+# 1. Create initial version of the dictionary
+# 2. DONE. First create decorator that doesn't check for lat-lon coords. Start by applying it to
+#    consolidate.add_laton? (but my version is the old one, until WJ approves; or merge my add_latlon branch?)
+# 3. Add testing for valid lat-lon
+# 4. Add compute_MVBS handler: If the input Sv ds has a processing_level, read it;
+#    if processing_level is present, extract its sublevel (A or B) and propagate it
+
+
+def add_processing_level(processing_level_code, is_echodata=False, inherit_sublevel=False):
+    """
+    Wraps functions or methods that return either an xr.Dataset or an echodata object
+
+    Parameters
+    ----------
+    processing_level_code : str
+        Data processing level code, either with or without sublevel code.
+        eg, L1A, L2B, L3
+    is_echodata : bool
+        Flag specifying if the decorated function returns an EchoData object (optional)
+    inherit_sublevel : bool
+        Flag specifying if the processing sublevel will be inherited from
+        the "input" dataset (optional)
+
+    Returns
+    -------
+    An xr.Dataset or EchoData object with processing level attributes
+    inserted if appropriate, or unchanged otherwise.
+    """
+
+    def inner(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            # PASS ARGS TO func. How about self, for methods like echodata.update_platform?
+            dataobj = func(*args, **kwargs)
+
+            # TODO: ADD conventions attr, with "ACDD-1.3" entry?? Or maybe skip for now?
+
+            def _attrs_dict(processing_level):
+                return {
+                    "processing_level": processing_level,
+                    "processing_level_url": "https://echopype.readthedocs.io/processing_levels",
+                }
+
+            if is_echodata:
+                ed = dataobj
+
+                if "longitude" in ed["Platform"] and not ed["Platform"]["longitude"].isnull().all():
+                    # The decorator is passed the exact, final level code, with sublevel
+                    processing_level = PROCESSING_LEVELS[processing_level_code]
+                    ed['Top-level'] = ed['Top-level'].assign_attrs(_attrs_dict(processing_level))
+
+                return ed
+            elif isinstance(dataobj, xr.Dataset):
+                ds = dataobj
+
+                # TODO: Raise a ValueError if this is False
+                if processing_level_code in PROCESSING_LEVELS:
+                    # The decorator is passed the exact, final level code, with sublevel
+                    processing_level = PROCESSING_LEVELS[processing_level_code]
+                elif inherit_sublevel and "input_processing_level" in ds.attrs.keys():
+                    # The decorator is passed a level code without sublevel (eg, L3).
+                    # The decorated function's "input" dataset's sublevel (A or B) will
+                    # be propagated to the function's output dataset. For L2 and L3
+                    sublevel = ds.attrs["input_processing_level"][-1]
+                    processing_level = PROCESSING_LEVELS[processing_level_code + sublevel]
+                    del ds.attrs["input_processing_level"]
+                else:
+                    # Processing level attributes will not be inserted
+                    return ds
+
+                ds = ds.assign_attrs(_attrs_dict(processing_level))
+                return ds
+            else:
+                return dataobj
+        return wrapper
+    return inner
+
+
+def insert_input_processing_level(ds, input_ds):
+    """
+    Copy processing_level attribute from input xr.Dataset, if it exists,
+    and write it out as input_processing_level
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The xr.Dataset returned by the decorated function
+    input_ds : xr.Dataset
+        The xr.Dataset that is the "input" to the decorated function
+
+    Returns
+    -------
+    ds with input_processing_level attribute inserted if appropriate,
+    a renamed copy of the processing_level attribute from input_ds if present.
+    """
+    if "processing_level" in input_ds.attrs.keys():
+        return ds.assign_attrs({"input_processing_level": input_ds.attrs["processing_level"]})
+    else:
+        return ds
+
+
+# def decorator(arg1, arg2):
+#     def inner_function(function):
+#         @functools.wraps(function)
+#         def wrapper(*args, **kwargs):
+#             print("Arguments passed to decorator %s and %s" % (arg1, arg2))
+#             function(*args, **kwargs)
+#
+#         return wrapper
+#     return inner_function


### PR DESCRIPTION
Draft, rough, partial implementation of data-processing-level attribute insertion, addressing #980.  I've got a "representative" core working now, that handles:
- Assign L1A on the Top-level group of the EchoData object returned by  `open_raw`, but only if Platform lat-lon data are present.
- Add L2A on `consolidate.add_location`.
- Add L3A or L3B on `commongrid.compute_MVBS`. It looks for an existing `processing_level` attribute in the input `Sv` dataset. If it's not present, nothing is added. Otherwise, L3A or L3B are assigned based on the input `Sv` being L2A or L2B, respectively.

Two attributes are inserted: `processing_level` and `processing_level_url`. The `processing_level` value currently looks like this: "Level 1A". For EchoData object (Level 1A), the attributes are inserted into the Top-level group dataset.

The functionality is implemented as a decorator function, `add_processing_level`, with two optional arguments in addition to the required processing level code. There is also a complementary function `insert_input_processing_level` that must be called in the decorated function to enable sublevel "propagation" -- eg, L2A > L3A, L2B > L3B.

See https://github.com/uw-echospace/data-processing-levels/blob/main/data_processing_levels.md for the draft description of data processing levels (and discussions about it [here](https://github.com/uw-echospace/data-processing-levels/issues/4)), and https://github.com/OSOceanAcoustics/echopype/pull/817#issuecomment-1474564449 for a listing of data processing functions that will ultimately receive this feature.

The code is full of comments for myself at this point, though mostly outside actual functions. I'll set it as draft. As is, it should give you a good idea of how it works and what it covers.

No tests yet, though I've run it locally, manually, on a couple of specific cases. Tomorrow.
