### PR TITLE
Fix test failure due to `ecs_file` requirement

### DIFF
--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -456,13 +456,13 @@ def test_nan_range_entries(range_check_files):
     if sonar_model == "EK80":
         ds_Sv = echopype.calibrate.compute_Sv(echodata, waveform_mode='BB', encode_mode='complex')
         cal_obj = CalibrateEK80(
-            echodata, env_params=None, cal_params=None, waveform_mode="BB", encode_mode="complex",
+            echodata, env_params=None, cal_params=None, ecs_file=None, waveform_mode="BB", encode_mode="complex",
         )
         range_output = cal_obj.range_meter
         nan_locs_backscatter_r = ~echodata["Sonar/Beam_group1"].backscatter_r.isel(beam=0).drop("beam").isnull()
     else:
         ds_Sv = echopype.calibrate.compute_Sv(echodata)
-        cal_obj = CalibrateEK60(echodata, env_params={}, cal_params=None)
+        cal_obj = CalibrateEK60(echodata, env_params={}, cal_params=None, ecs_file=None)
         range_output = cal_obj.range_meter
         nan_locs_backscatter_r = ~echodata["Sonar/Beam_group1"].backscatter_r.isel(beam=0).drop("beam").isnull()
 

--- a/echopype/tests/visualize/test_plot.py
+++ b/echopype/tests/visualize/test_plot.py
@@ -225,6 +225,7 @@ def test_water_level_echodata(water_level, expect_warning, caplog):
         echodata=echodata,
         env_params=range_kwargs.get("env_params", {}),
         cal_params=None,
+        ecs_file=None,
     )
     range_in_meter = cal_obj.range_meter
 

--- a/echopype/visualize/api.py
+++ b/echopype/visualize/api.py
@@ -157,12 +157,14 @@ def create_echogram(
                         echodata=data,
                         env_params=range_kwargs.get("env_params", {}),
                         cal_params=None,
+                        ecs_file=None,
                     )
                 else:
                     cal_obj = CalibrateEK80(
                         echodata=data,
                         env_params=range_kwargs.get("env_params", {}),
                         cal_params=None,
+                        ecs_file=None,
                         waveform_mode=range_kwargs.get("waveform_mode", "CW"),
                         encode_mode=range_kwargs.get("encode_mode", "power"),
                     )


### PR DESCRIPTION
This PR addresses the need for having `ecs_file` as an input argument in `CalibrateEK60/80`, and fixes the test failures after #996 was merged.