### PR TITLE
Update windows-utils.yaml

### DIFF
--- a/.github/workflows/windows-utils.yaml
+++ b/.github/workflows/windows-utils.yaml
@@ -66,4 +66,4 @@ jobs:
             python -m pip install -e .
         - name: Running all Tests
           run: |
-            pytest -k 'not test_raw_to_mvbs' -vvv -rx --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings echopype/tests/utils |& tee ci_${{ matrix.python-version }}_test_log.log
+            pytest -k "not test_raw_to_mvbs" -vvv -rx --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings echopype/tests/utils |& tee ci_${{ matrix.python-version }}_test_log.log

--- a/.github/workflows/windows-utils.yaml
+++ b/.github/workflows/windows-utils.yaml
@@ -66,4 +66,4 @@ jobs:
             python -m pip install -e .
         - name: Running all Tests
           run: |
-            pytest -vvv -rx --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings echopype/tests/utils |& tee ci_${{ matrix.python-version }}_test_log.log
+            pytest -k 'not test_raw_to_mvbs' -vvv -rx --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings echopype/tests/utils |& tee ci_${{ matrix.python-version }}_test_log.log


### PR DESCRIPTION
Remove `test_raw_to_mvbs` in `test_processinglevels_integration.py` from the `windows-utils.yaml` CI test. Unlike other `utils` tests, this one uses a data file and that was causing a failure, like [this one](https://github.com/OSOceanAcoustics/echopype/actions/runs/4515367995/jobs/7952579646)

We'll revisit this in the near future.