### PR TITLE
Allow `apply_mask` to handle multi-channel Sv dataset

### DIFF
--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -102,7 +102,7 @@ def _validate_and_collect_mask_input(
 
             # check source_ds coordinates
             if mask[mask_ind].dims == ("ping_time", "range_sample"):
-                raise ValueError("All masks must have dimensions ()'ping_time', 'range_sample')!")
+                raise ValueError("All masks must have dimensions ('ping_time', 'range_sample')!")
 
     else:
         if not isinstance(storage_options_mask, dict):
@@ -265,8 +265,8 @@ def apply_mask(
         mask that will be applied to ``var_name``.
     var_name: str, default="Sv"
         The Sv variable name in ``source_ds`` that the mask should be applied to.
-        This variables need to have coorindates ``ping_time`` and ``range_sample``,
-        and can optionally also ave coordinate ``channel``.
+        This variable needs to have coordinates ``ping_time`` and ``range_sample``,
+        and can optionally also have coordinate ``channel``.
         In the case of a multi-channel Sv data variable, the ``mask`` will be broadcast
         to all channels.
     fill_value: int, float, np.ndarray, or xr.DataArray, default=np.nan

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -102,9 +102,10 @@ def _validate_and_collect_mask_input(
 
             # check source_ds coordinates
             # sequence matters, so fix the tuple form
-            if (
-                mask[mask_ind].dims != ("ping_time", "range_sample")
-                and mask[mask_ind].dims != ("channel", "ping_time", "range_sample")
+            if mask[mask_ind].dims != ("ping_time", "range_sample") and mask[mask_ind].dims != (
+                "channel",
+                "ping_time",
+                "range_sample",
             ):
                 raise ValueError("All masks must have dimensions ('ping_time', 'range_sample')!")
 

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -100,13 +100,13 @@ def _validate_and_collect_mask_input(
                     mask_val, engine=file_type, chunks={}, **storage_options_mask[mask_ind]
                 )
 
-            # check source_ds coordinates
-            # sequence matters, so fix the tuple form
-            if mask[mask_ind].dims != ("ping_time", "range_sample") and mask[mask_ind].dims != (
-                "channel",
-                "ping_time",
-                "range_sample",
-            ):
+            # check mask coordinates
+            # the coordinate sequence matters, so fix the tuple form
+            allowed_dims = [
+                ("ping_time", "range_sample"),
+                ("channel", "ping_time", "range_sample"),
+            ]
+            if mask[mask_ind].dims not in allowed_dims:
                 raise ValueError("All masks must have dimensions ('ping_time', 'range_sample')!")
 
     else:

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -33,7 +33,7 @@ def _validate_source_ds(source_ds, storage_options_ds):
     # Check source_ds coordinates
     if "ping_time" not in source_ds or "range_sample" not in source_ds:
         raise ValueError("'source_ds' must have coordinates 'ping_time' and 'range_sample'!")
-    
+
     return source_ds
 
 
@@ -99,7 +99,7 @@ def _validate_and_collect_mask_input(
                 mask[mask_ind] = xr.open_dataarray(
                     mask_val, engine=file_type, chunks={}, **storage_options_mask[mask_ind]
                 )
-            
+
             # check source_ds coordinates
             if mask[mask_ind].dims == ("ping_time", "range_sample"):
                 raise ValueError("All masks must have dimensions ()'ping_time', 'range_sample')!")
@@ -175,11 +175,14 @@ def _check_var_name_fill_value(
 
         source_ds_shape = (
             source_ds[var_name].isel(channel=0).shape
-            if "channel" in source_ds[var_name].coords else source_ds[var_name].shape
+            if "channel" in source_ds[var_name].coords
+            else source_ds[var_name].shape
         )
 
         if fill_value.shape != source_ds_shape:
-            raise ValueError(f"If fill_value is an array it must be of the same shape as {var_name}!")
+            raise ValueError(
+                f"If fill_value is an array it must be of the same shape as {var_name}!"
+            )
 
     return fill_value
 
@@ -284,7 +287,7 @@ def apply_mask(
     xr.Dataset
         A Dataset with the same format of ``source_ds`` with the mask(s) applied to ``var_name``
     """
-    
+
     # Validate the source_ds
     source_ds = _validate_source_ds(source_ds, storage_options_ds)
 
@@ -308,6 +311,7 @@ def apply_mask(
     #               along the ping_time and range_sample dimensions
     def get_ch_shape(da):
         return da.isel(channel=0).shape if "channel" in da.coords else da.shape
+
     source_ds_shape = get_ch_shape(source_ds[var_name])
     final_mask_shape = get_ch_shape(final_mask)
 

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -168,7 +168,7 @@ def _check_var_name_fill_value(
     if isinstance(fill_value, xr.DataArray):
         fill_value_shape = get_ch_shape(fill_value)
     elif isinstance(fill_value, np.ndarray):
-        fill_value_shape = fill_value_shape.squeeze().shape
+        fill_value_shape = fill_value.squeeze().shape
 
     source_ds_shape = get_ch_shape(source_ds[var_name])
 
@@ -292,6 +292,8 @@ def apply_mask(
     # xr.where(keep_attrs=True) is not functioning correctly)
     if isinstance(fill_value, xr.DataArray):
         fill_value = fill_value.data.squeeze()  # squeeze out length=1 channel dimension
+    elif isinstance(fill_value, np.ndarray):
+        fill_value = fill_value.squeeze()  # squeeze out length=1 channel dimension
 
     # Obtain final mask to be applied to var_name
     if isinstance(mask, list):

--- a/echopype/tests/mask/test_mask.py
+++ b/echopype/tests/mask/test_mask.py
@@ -132,13 +132,13 @@ def get_mock_source_ds_apply_mask(n: int, n_chan: int, is_delayed: bool) -> xr.D
     # create mock var1 and var2 DataArrays
     mock_var1_da = xr.DataArray(data=np.stack(mock_var_data),
                                 coords={"channel": ("channel", chan_vals, {"long_name": "channel name"}),
-                                        "x": np.arange(n), "y": np.arange(n)},
-                                attrs={"long_name": "variable 1"})
+                                        "ping_time": np.arange(n), "range_sample": np.arange(n)},
+                                attrs={"long_name": "coord 1"})
     mock_var2_da = xr.DataArray(data=np.stack(mock_var_data),
                                 coords={"channel": ("channel", chan_vals, {"long_name": "channel name"}),
-                                        "x": np.arange(n),
-                                        "y": np.arange(n)},
-                                attrs={"long_name": "variable 2"})
+                                        "ping_time": np.arange(n),
+                                        "range_sample": np.arange(n)},
+                                attrs={"long_name": "coord 2"})
 
     # create mock Dataset
     mock_ds = xr.Dataset(data_vars={"var1": mock_var1_da, "var2": mock_var2_da})
@@ -504,7 +504,7 @@ def test_check_var_name_fill_value(n: int, n_chan: int, var_name: str,
     [
         (2, 1, "var1", np.identity(2), None, np.nan, False, np.array([[1, np.nan], [np.nan, 1]])),
         (2, 1, "var1", np.identity(2), None, 2.0, False, np.array([[1, 2.0], [2.0, 1]])),
-        (2, 1, "var1", np.identity(2), None, np.array([[[np.nan, np.nan], [np.nan, np.nan]]]),
+        (2, 1, "var1", np.identity(2), None, np.array([[np.nan, np.nan], [np.nan, np.nan]]),
          False, np.array([[1, np.nan], [np.nan, 1]])),
         (2, 1, "var1", np.identity(2), None, xr.DataArray(data=np.array([[[np.nan, np.nan], [np.nan, np.nan]]]),
                                                           coords={"channel": ["chan1"],

--- a/echopype/tests/mask/test_mask.py
+++ b/echopype/tests/mask/test_mask.py
@@ -502,27 +502,44 @@ def test_check_var_name_fill_value(n: int, n_chan: int, var_name: str,
 @pytest.mark.parametrize(
     ("n", "n_chan", "var_name", "mask", "mask_file", "fill_value", "is_delayed", "var_masked_truth"),
     [
+        # single_mask_default_fill
         (2, 1, "var1", np.identity(2), None, np.nan, False, np.array([[1, np.nan], [np.nan, 1]])),
+        # single_mask_float_fill
         (2, 1, "var1", np.identity(2), None, 2.0, False, np.array([[1, 2.0], [2.0, 1]])),
+        # single_mask_np_array_fill
         (2, 1, "var1", np.identity(2), None, np.array([[[np.nan, np.nan], [np.nan, np.nan]]]),
          False, np.array([[1, np.nan], [np.nan, 1]])),
+        # single_mask_DataArray_fill
         (2, 1, "var1", np.identity(2), None, xr.DataArray(data=np.array([[[np.nan, np.nan], [np.nan, np.nan]]]),
                                                           coords={"channel": ["chan1"],
                                                                   "ping_time": [0, 1],
                                                                   "range_sample": [0, 1]}),
          False, np.array([[1, np.nan], [np.nan, 1]])),
+        # list_mask_all_np
         (2, 1, "var1", [np.identity(2), np.array([[0, 1], [0, 1]])], [None, None], 2.0,
          False, np.array([[2.0, 2.0], [2.0, 1]])),
+        # single_mask_ds_delayed
         (2, 1, "var1", np.identity(2), None, 2.0, True, np.array([[1, 2.0], [2.0, 1]])),
+        # single_mask_as_path
         (2, 1, "var1", np.identity(2), "test.zarr", 2.0, True, np.array([[1, 2.0], [2.0, 1]])),
+        # list_mask_all_path
         (2, 1, "var1", [np.identity(2), np.array([[0, 1], [0, 1]])], ["test0.zarr", "test1.zarr"], 2.0,
          False, np.array([[2.0, 2.0], [2.0, 1]])),
+        # list_mask_some_path
         (2, 1, "var1", [np.identity(2), np.array([[0, 1], [0, 1]])], ["test0.zarr", None], 2.0,
          False, np.array([[2.0, 2.0], [2.0, 1]])),
     ],
-    ids=["single_mask_default_fill", "single_mask_float_fill", "single_mask_np_array_fill",
-         "single_mask_DataArray_fill", "list_mask_all_np", "single_mask_ds_delayed",
-         "single_mask_as_path", "list_mask_all_path", "list_mask_some_path"]
+    ids=[
+        "single_mask_default_fill",
+        "single_mask_float_fill",
+        "single_mask_np_array_fill",
+        "single_mask_DataArray_fill",
+        "list_mask_all_np",
+        "single_mask_ds_delayed",
+        "single_mask_as_path",
+        "list_mask_all_path",
+        "list_mask_some_path"
+    ]
 )
 def test_apply_mask(n: int, n_chan: int, var_name: str,
                     mask: Union[np.ndarray, List[np.ndarray]],

--- a/echopype/tests/mask/test_mask.py
+++ b/echopype/tests/mask/test_mask.py
@@ -504,7 +504,7 @@ def test_check_var_name_fill_value(n: int, n_chan: int, var_name: str,
     [
         (2, 1, "var1", np.identity(2), None, np.nan, False, np.array([[1, np.nan], [np.nan, 1]])),
         (2, 1, "var1", np.identity(2), None, 2.0, False, np.array([[1, 2.0], [2.0, 1]])),
-        (2, 1, "var1", np.identity(2), None, np.array([[np.nan, np.nan], [np.nan, np.nan]]),
+        (2, 1, "var1", np.identity(2), None, np.array([[[np.nan, np.nan], [np.nan, np.nan]]]),
          False, np.array([[1, np.nan], [np.nan, 1]])),
         (2, 1, "var1", np.identity(2), None, xr.DataArray(data=np.array([[[np.nan, np.nan], [np.nan, np.nan]]]),
                                                           coords={"channel": ["chan1"],

--- a/echopype/tests/mask/test_mask.py
+++ b/echopype/tests/mask/test_mask.py
@@ -420,7 +420,7 @@ def test_validate_and_collect_mask_input(
 
     # create coordinates that will be used by all DataArrays created
     coords = {"channel": ("channel", chan_vals, {"long_name": "channel name"}),
-              "x": np.arange(n), "y": np.arange(n)}
+              "ping_time": np.arange(n), "range_sample": np.arange(n)}
 
     # create input mask and obtain temporary directory, if it was created
     mask, _ = create_input_mask(mask_np, mask_file, coords, n_chan)

--- a/echopype/tests/mask/test_mask.py
+++ b/echopype/tests/mask/test_mask.py
@@ -149,7 +149,6 @@ def create_input_mask(
     mask: Union[np.ndarray, List[np.ndarray]],
     mask_file: Optional[Union[str, List[str]]],
     mask_coords: Union[xr.core.coordinates.DataArrayCoordinates, dict],
-    n_chan: int
 ):
     """
     A helper function that correctly constructs the mask input, so it can be
@@ -164,8 +163,6 @@ def create_input_mask(
         with file name ``mask_file``. This will then be used in ``apply_mask``.
     mask_coords: xr.core.coordinates.DataArrayCoordinates or dict
         The DataArray coordinates that should be used for each mask DataArray created
-    n_chan: int
-        Determines the size of the ``channel`` coordinate
     """
 
     # initialize temp_dir
@@ -185,8 +182,7 @@ def create_input_mask(
         for mask_ind in range(len(mask)):
 
             # form DataArray from given mask data
-            mask_da = xr.DataArray(data=[mask[mask_ind] for i in range(n_chan)],
-                                   coords=mask_coords, name='mask_' + str(mask_ind))
+            mask_da = xr.DataArray(data=[mask[mask_ind]], coords=mask_coords, name='mask_' + str(mask_ind))
 
             if mask_file[mask_ind] is None:
 
@@ -208,8 +204,7 @@ def create_input_mask(
     elif isinstance(mask, np.ndarray):
 
         # form DataArray from given mask data
-        mask_da = xr.DataArray(data=[mask for i in range(n_chan)],
-                               coords=mask_coords, name='mask_0')
+        mask_da = xr.DataArray(data=[mask], coords=mask_coords, name='mask_0')
 
         if mask_file is None:
 
@@ -422,7 +417,7 @@ def test_validate_and_collect_mask_input(
               "ping_time": np.arange(n), "range_sample": np.arange(n)}
 
     # create input mask and obtain temporary directory, if it was created
-    mask, _ = create_input_mask(mask_np, mask_file, coords, n_chan)
+    mask, _ = create_input_mask(mask_np, mask_file, coords)
 
     mask_out = _validate_and_collect_mask_input(mask=mask, storage_options_mask=storage_options_mask)
 
@@ -580,7 +575,7 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
     mock_ds = get_mock_source_ds_apply_mask(n, n_chan, is_delayed)
 
     # create input mask and obtain temporary directory, if it was created
-    mask, temp_dir = create_input_mask(mask, mask_file, mock_ds.coords, n_chan)
+    mask, temp_dir = create_input_mask(mask, mask_file, mock_ds.coords)
 
     # create DataArray form of the known truth value
     var_masked_truth = xr.DataArray(data=np.stack([var_masked_truth for i in range(n_chan)]),

--- a/echopype/tests/utils/test_processinglevels_integration.py
+++ b/echopype/tests/utils/test_processinglevels_integration.py
@@ -101,7 +101,7 @@ def test_raw_to_mvbs(
         freqAB = list(out_ds.frequency_nominal.values[:2])
         freqdiff_da = ep.mask.frequency_differencing(source_Sv=out_ds, freqAB=freqAB, operator=">", diff=5)
 
-        # Apply maks to multi-channel Sv
+        # Apply mask to multi-channel Sv
         return ep.mask.apply_mask(source_ds=out_ds, var_name="Sv", mask=freqdiff_da)
 
     # On Sv w/o noise removal

--- a/echopype/tests/utils/test_processinglevels_integration.py
+++ b/echopype/tests/utils/test_processinglevels_integration.py
@@ -101,10 +101,8 @@ def test_raw_to_mvbs(
         freqAB = list(out_ds.frequency_nominal.values[:2])
         freqdiff_da = ep.mask.frequency_differencing(source_Sv=out_ds, freqAB=freqAB, operator=">", diff=5)
 
-        # Create a new, single-channel Sv variable in ds to pass to apply_mask.
-        # The resulting masked Sv will be single-channel.
-        out_ds["Sv_ch0"] = out_ds["Sv"].isel(channel=0).squeeze()
-        return ep.mask.apply_mask(source_ds=out_ds, var_name="Sv_ch0", mask=freqdiff_da)
+        # Apply maks to multi-channel Sv
+        return ep.mask.apply_mask(source_ds=out_ds, var_name="Sv", mask=freqdiff_da)
 
     # On Sv w/o noise removal
     ds = _freqdiff_applymask(Sv_ds)
@@ -117,6 +115,6 @@ def test_raw_to_mvbs(
     # ---- Compute MVBS
     # compute_MVBS expects a variable named "Sv"
     # No product level is assigned because at present compute_MVBS drops the lat/lon data associated with the input Sv dataset
-    ds = ds.rename_vars(name_dict={"Sv": "Sv_unmasked", "Sv_ch0": "Sv"})
+    # ds = ds.rename_vars(name_dict={"Sv": "Sv_unmasked", "Sv_ch0": "Sv"})
     mvbs_ds = ep.commongrid.compute_MVBS(ds, range_meter_bin=30, ping_time_bin='1min')
     _absence_test(mvbs_ds)


### PR DESCRIPTION
This PR generalizes the `apply_mask` implementation so that it can accept multi-channel Sv datasets.

Main changes include:
- restrict `source_ds[var_name]` to must have dimensions `('ping_time', 'range_sample')`
- restrict each entry in `mask` to must have dimensions `('ping_time', 'range_sample')`
- move checks of `source_ds` to a new private function `_validate_source_ds` 
`_check_var_name_fill_value` to return `fill_value` with sanitized dimensions
- fix tests in `utils/test_processinglevels_integration.py::test_raw_to_mvbs`