### PR TITLE
Skip `test_processinglevels_integration.py` on windows platform

### DIFF
--- a/echopype/tests/utils/test_processinglevels_integration.py
+++ b/echopype/tests/utils/test_processinglevels_integration.py
@@ -6,6 +6,9 @@ import xarray as xr
 import echopype as ep
 
 
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Test data not available on windows tests")
+
+
 @pytest.mark.parametrize(
     ["sonar_model", "path_model", "raw_and_xml_paths", "extras"],
     [
@@ -14,14 +17,14 @@ import echopype as ep
             "EK60",
             ("Winter2017-D20170115-T150122.raw", None),
             {},
-            marks=pytest.mark.skipif(sys.platform == "win32", reason="Test data not available on windows tests"),
+            # marks=pytest.mark.skipif(sys.platform == "win32", reason="Test data not available on windows tests"),
         ),
         pytest.param(
             "AZFP",
             "AZFP",
             ("17082117.01A", "17041823.XML"),
             {"longitude": -60.0, "latitude": 45.0, "salinity": 27.9, "pressure": 59},
-            marks=pytest.mark.skipif(sys.platform == "win32", reason="Test data not available on windows tests"),
+            # marks=pytest.mark.skipif(sys.platform == "win32", reason="Test data not available on windows tests"),
         ),
     ],
 )

--- a/echopype/tests/utils/test_processinglevels_integration.py
+++ b/echopype/tests/utils/test_processinglevels_integration.py
@@ -8,17 +8,25 @@ import echopype as ep
 @pytest.mark.parametrize(
     ["sonar_model", "path_model", "raw_and_xml_paths", "extras"],
     [
-        (
+        pytest.param(
             "EK60",
             "EK60",
             ("Winter2017-D20170115-T150122.raw", None),
             {},
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="Temporarily xfailing this due to the windows-utils.yaml GH action failure."
+            ),
         ),
-        (
+        pytest.param(
             "AZFP",
             "AZFP",
             ("17082117.01A", "17041823.XML"),
             {"longitude": -60.0, "latitude": 45.0, "salinity": 27.9, "pressure": 59},
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="Temporarily xfailing this due to the windows-utils.yaml GH action failure."
+            ),
         ),
     ],
 )

--- a/echopype/tests/utils/test_processinglevels_integration.py
+++ b/echopype/tests/utils/test_processinglevels_integration.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 
 import numpy as np
@@ -13,20 +14,14 @@ import echopype as ep
             "EK60",
             ("Winter2017-D20170115-T150122.raw", None),
             {},
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason="Temporarily xfailing this due to the windows-utils.yaml GH action failure."
-            ),
+            marks=pytest.mark.skipif(sys.platform == "win32", reason="Test data not available on windows tests"),
         ),
         pytest.param(
             "AZFP",
             "AZFP",
             ("17082117.01A", "17041823.XML"),
             {"longitude": -60.0, "latitude": 45.0, "salinity": 27.9, "pressure": 59},
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason="Temporarily xfailing this due to the windows-utils.yaml GH action failure."
-            ),
+            marks=pytest.mark.skipif(sys.platform == "win32", reason="Test data not available on windows tests"),
         ),
     ],
 )


### PR DESCRIPTION
This PR uses pytest.skipif to skip the module `tests/utils/test_processinglevels_integration.py` when the platform is windows.

We still need to figure out a strategy for windows testing.