### PR TITLE
Update `codespell`, exclude `test_data` folder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.2.4
     hooks:
       - id: codespell
         # Checks spelling in `docs/source` and `echopype` dirs ONLY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,4 +39,4 @@ repos:
       - id: codespell
         # Checks spelling in `docs/source` and `echopype` dirs ONLY
         # Ignores `.ipynb` files and `_build` folders
-        args: ["--skip=*.ipynb,docs/source/_build", "-w", "docs/source", "echopype"]
+        args: ["--skip=*.ipynb,docs/source/_build,echopype/test_data", "-w", "docs/source", "echopype"]

--- a/docs/source/processing-levels.md
+++ b/docs/source/processing-levels.md
@@ -1,4 +1,4 @@
-# Proposed Echosounder Data Proccesing Levels (DRAFT)
+# Proposed Echosounder Data Processing Levels (DRAFT)
 
 The decades-long experience from the satellite remote sensing community has shown that a set of robust and well-articulated definitions of "data processing levels" [1]–[5] can lead directly to broad and highly productive use of data. Processing level designations also provide important context for data interpretation [6]. However, no such community agreement exists for active acoustic data. The ambiguity associated with the interoperability and inter-comparability of processed sonar data products has hindered efficient collaboration and integrative use of the rapidly growing data archive across research institutions and agencies.
 

--- a/docs/source/whats-new.md
+++ b/docs/source/whats-new.md
@@ -33,10 +33,11 @@ This release includes new features to interface with Echoview ECS files for comp
 ## Bug fixes
 - Fix scaling bug for `beamwidth_alongship` and `beamwidth_athwartship` from CW-based parameters to values corresponding to center frequency of broadband transmit signals (#998)
 
-## Tests
+## Tests and infrastructure
 - Add more comprehensive tests for `add_location` (#1000)
 - Add test for splitbeam angle `ek80_CW_power` case (#994)
 - Add unit and integration tests for `env_params` intake for calibration (#985)
+- Exclude `test_data` folder in `codespell` pre-commit hook (#1016)
 
 
 


### PR DESCRIPTION
This PR:
- excludes `test_data` folder from `codespell`
- updates `codespell` to v2.2.4
