### PR TITLE
Impedance type change, name change, bug fix

### DIFF
--- a/echopype/calibrate/cal_params.py
+++ b/echopype/calibrate/cal_params.py
@@ -25,16 +25,16 @@ CAL_PARAMS = {
         "angle_sensitivity_athwartship",
         "beamwidth_alongship",
         "beamwidth_athwartship",
-        "impedance_transmit",  # z_et
-        "impedance_receive",  # z_er
+        "impedance_transducer",  # z_et
+        "impedance_transceiver",  # z_er
         "receiver_sampling_frequency",
     ),
     "AZFP": ("EL", "DS", "TVR", "VTX", "equivalent_beam_angle", "Sv_offset"),
 }
 
 EK80_DEFAULT_PARAMS = {
-    "impedance_transmit": 75,
-    "impedance_receive": 1000,
+    "impedance_transducer": 75,
+    "impedance_transceiver": 1000,
     "receiver_sampling_frequency": {  # default full sampling frequency [Hz]
         "default": 1500000,
         "GPT": 500000,
@@ -203,7 +203,7 @@ def _get_interp_da(
 
     ``alternative`` can be one of the following:
 
-    - scalar (int or float): this is the case for impedance_transmit
+    - scalar (int or float): this is the case for impedance_transducer
     - xr.DataArray with coordinates channel, ping_time, and beam:
         this is the case for parameters angle_offset_alongship, angle_offset_athwartship,
                                         beamwidth_alongship, beamwidth_athwartship
@@ -431,12 +431,12 @@ def get_cal_params_EK(
             # Those without CW or BB complications
             if p == "sa_correction":  # pull from data file
                 out_dict[p] = get_vend_cal_params_power(beam=beam, vend=vend, param=p)
-            elif p == "impedance_receive":  # from data file or default dict
-                out_dict[p] = default_params[p] if p not in vend else vend["impedance_receive"]
+            elif p == "impedance_transceiver":  # from data file or default dict
+                out_dict[p] = default_params[p] if p not in vend else vend["impedance_transceiver"]
             elif p == "receiver_sampling_frequency":  # from data file or default_params
                 out_dict[p] = _get_fs()
             else:
-                # CW: params do not require interpolation, except for impedance_transmit
+                # CW: params do not require interpolation, except for impedance_transducer
                 if waveform_mode == "CW":
                     if p in PARAM_BEAM_NAME_MAP.keys():
                         p_beam = PARAM_BEAM_NAME_MAP[p]
@@ -448,7 +448,7 @@ def get_cal_params_EK(
                     elif p == "gain_correction":
                         # pull from data file narrowband table
                         out_dict[p] = get_vend_cal_params_power(beam=beam, vend=vend, param=p)
-                    elif p == "impedance_transmit":
+                    elif p == "impedance_transducer":
                         # assemble each channel from data file or default dict
                         out_dict[p] = _get_interp_da(
                             da_param=None if p not in vend else vend[p],
@@ -497,7 +497,7 @@ def get_cal_params_EK(
                             freq_center=freq_center,
                             alternative=get_vend_cal_params_power(beam=beam, vend=vend, param=p),
                         )
-                    elif p == "impedance_transmit":
+                    elif p == "impedance_transducer":
                         out_dict[p] = _get_interp_da(
                             da_param=None if p not in vend else vend[p],
                             freq_center=freq_center,

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -192,8 +192,8 @@ class CalibrateEK60(CalibrateEK):
 class CalibrateEK80(CalibrateEK):
     # Default EK80 params: these parameters are only recorded in later versions of EK80 software
     EK80_params = {}
-    EK80_params["z_et"] = 75  # transmit impedance
-    EK80_params["z_er"] = 1000  # receive impedance
+    EK80_params["z_et"] = 75  # transducer impedance
+    EK80_params["z_er"] = 1000  # transceiver impedance
     EK80_params["fs"] = {  # default full sampling frequency [Hz]
         "default": 1500000,
         "GPT": 500000,
@@ -407,6 +407,10 @@ class CalibrateEK80(CalibrateEK):
             EchoData["Sonar/Beam_group1"] with selected channel subset
         chirp : dict
             a dictionary containing transmit chirp for BB channels
+        z_et : float
+            impedance of transducer [ohm]
+        z_er : float
+            impedance of transceiver [ohm]
 
         Returns
         -------
@@ -481,8 +485,8 @@ class CalibrateEK80(CalibrateEK):
         tx, tx_time = get_transmit_signal(beam, tx_coeff, self.waveform_mode, fs)
 
         # Params to clarity in use below
-        z_er = self.cal_params["impedance_receive"]
-        z_et = self.cal_params["impedance_transmit"]
+        z_er = self.cal_params["impedance_transceiver"]
+        z_et = self.cal_params["impedance_transducer"]
         gain = self.cal_params["gain_correction"]
 
         # Transceiver gain compensation for BB mode

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -445,7 +445,10 @@ class CalibrateEK80(CalibrateEK):
         """
         Get transceiver gain compensation for BB mode.
 
-        ref: https://github.com/CI-CMG/pyEcholab/blob/RHT-EK80-Svf/echolab2/instruments/EK80.py#L4263-L4274  # noqa
+        Source: https://github.com/CRIMAC-WP4-Machine-learning/CRIMAC-Raw-To-Svf-TSf/blob/abd01f9c271bb2dbe558c80893dbd7eb0d06fe38/Core/EK80DataContainer.py#L261-L273  # noqa
+        From conversation with Lars Andersen, this correction is based on a longstanding
+        empirical formula used for fitting beampattern during calibration, based on
+        physically meaningful parameters such as the angle offset and beamwidth.
         """
         fac_along = (
             np.abs(-self.cal_params["angle_offset_alongship"])

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -395,8 +395,8 @@ class CalibrateEK80(CalibrateEK):
         self,
         beam: xr.Dataset,
         chirp: Dict,
-        z_et,
-        z_er,
+        z_et: float,
+        z_er: float,
     ) -> xr.DataArray:
         """
         Get power from complex samples.

--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -481,7 +481,7 @@ class CalibrateEK80(CalibrateEK):
         tx_coeff = get_filter_coeff(vend)
         fs = self.cal_params["receiver_sampling_frequency"]
 
-        # Switch to use Anderson implementation for transmit chirp starting v0.6.4
+        # Switch to use Andersen implementation for transmit chirp starting v0.6.4
         tx, tx_time = get_transmit_signal(beam, tx_coeff, self.waveform_mode, fs)
 
         # Params to clarity in use below

--- a/echopype/calibrate/ek80_complex.py
+++ b/echopype/calibrate/ek80_complex.py
@@ -11,7 +11,7 @@ def tapered_chirp(
     transmit_duration_nominal,
     slope,
     transmit_power,
-    implementation="Anderson",
+    implementation="Andersen",
     z_et=None,
     frequency_nominal=None,
     frequency_start=None,
@@ -22,10 +22,10 @@ def tapered_chirp(
         frequency_start = frequency_nominal
         frequency_end = frequency_nominal
 
-    if implementation == "Macaulay":
-        # z_et is required for Macaulay implementation
+    if implementation == "Matlab":
+        # z_et is required for Matlab implementation
         if z_et is None:
-            raise ValueError("z_et is needed for Macaulay implementation of transmit chirp!")
+            raise ValueError("z_et is needed for Matlab implementation of transmit chirp!")
 
         t = np.arange(0, transmit_duration_nominal, 1 / fs)
         nwtx = int(2 * np.floor(slope * t.size))  # length of tapering window
@@ -44,8 +44,8 @@ def tapered_chirp(
         )  # taper and scale linear chirp
         return y_tmp / np.max(np.abs(y_tmp)), t  # amplitude needs to be normalized
 
-    elif implementation == "Anderson":
-        # Substitute to keep original form in Anderson implementation
+    elif implementation == "Andersen":
+        # Substitute to keep original form in Andersen implementation
         # source: https://github.com/CRIMAC-WP4-Machine-learning/CRIMAC-Raw-To-Svf-TSf/blob/main/Core/Calculation.py  # noqa
         tau = transmit_duration_nominal
         f0 = frequency_start

--- a/echopype/calibrate/ek80_complex.py
+++ b/echopype/calibrate/ek80_complex.py
@@ -10,68 +10,41 @@ def tapered_chirp(
     fs,
     transmit_duration_nominal,
     slope,
-    transmit_power,
-    implementation="Andersen",
-    z_et=None,
     frequency_nominal=None,
     frequency_start=None,
     frequency_end=None,
 ):
-    """Create a baseline chirp template."""
+    """
+    Create the chirp replica following implementation from Lars Anderson.
+
+    Ref source: https://github.com/CRIMAC-WP4-Machine-learning/CRIMAC-Raw-To-Svf-TSf/blob/main/Core/Calculation.py  # noqa
+    """
     if frequency_start is None and frequency_end is None:  # CW waveform
         frequency_start = frequency_nominal
         frequency_end = frequency_nominal
 
-    if implementation == "Matlab":
-        # z_et is required for Matlab implementation
-        if z_et is None:
-            raise ValueError("z_et is needed for Matlab implementation of transmit chirp!")
+    tau = transmit_duration_nominal
+    f0 = frequency_start
+    f1 = frequency_end
 
-        t = np.arange(0, transmit_duration_nominal, 1 / fs)
-        nwtx = int(2 * np.floor(slope * t.size))  # length of tapering window
-        wtx_tmp = np.hanning(nwtx)  # hanning window
-        nwtxh = int(np.round(nwtx / 2))  # half length of the hanning window
-        wtx = np.concatenate(
-            [wtx_tmp[0:nwtxh], np.ones((t.size - nwtx)), wtx_tmp[nwtxh:]]
-        )  # assemble full tapering window
-        chirp_fac = (
-            (frequency_end - frequency_start) / transmit_duration_nominal
-        ) * t / 2 + frequency_start
-        y_tmp = (
-            np.sqrt((transmit_power / 4) * (2 * z_et))  # amplitude
-            * np.cos(2 * np.pi * chirp_fac * t)  # chirp
-            * wtx  # tapering
-        )  # taper and scale linear chirp
-        return y_tmp / np.max(np.abs(y_tmp)), t  # amplitude needs to be normalized
+    nsamples = int(np.floor(tau * fs))
+    t = np.linspace(0, nsamples - 1, num=nsamples) * 1 / fs
+    a = np.pi * (f1 - f0) / tau
+    b = 2 * np.pi * f0
+    y = np.cos(a * t * t + b * t)
+    L = int(np.round(tau * fs * slope * 2.0))  # Length of hanning window
+    w = 0.5 * (1.0 - np.cos(2.0 * np.pi * np.arange(0, L, 1) / (L - 1)))
+    N = len(y)
+    w1 = w[0 : int(len(w) / 2)]
+    w2 = w[int(len(w) / 2) : -1]
+    i0 = 0
+    i1 = len(w1)
+    i2 = N - len(w2)
+    i3 = N
+    y[i0:i1] = y[i0:i1] * w1
+    y[i2:i3] = y[i2:i3] * w2
 
-    elif implementation == "Andersen":
-        # Substitute to keep original form in Andersen implementation
-        # source: https://github.com/CRIMAC-WP4-Machine-learning/CRIMAC-Raw-To-Svf-TSf/blob/main/Core/Calculation.py  # noqa
-        tau = transmit_duration_nominal
-        f0 = frequency_start
-        f1 = frequency_end
-
-        nsamples = int(np.floor(tau * fs))
-        t = np.linspace(0, nsamples - 1, num=nsamples) * 1 / fs
-        a = np.pi * (f1 - f0) / tau
-        b = 2 * np.pi * f0
-        y = np.cos(a * t * t + b * t)
-        L = int(np.round(tau * fs * slope * 2.0))  # Length of hanning window
-        w = 0.5 * (1.0 - np.cos(2.0 * np.pi * np.arange(0, L, 1) / (L - 1)))
-        N = len(y)
-        w1 = w[0 : int(len(w) / 2)]
-        w2 = w[int(len(w) / 2) : -1]
-        i0 = 0
-        i1 = len(w1)
-        i2 = N - len(w2)
-        i3 = N
-        y[i0:i1] = y[i0:i1] * w1
-        y[i2:i3] = y[i2:i3] * w2
-
-        return y / np.max(y), t  # amplitude needs to be normalized
-
-    else:
-        raise ValueError("Input implementation type not recognized!")
+    return y / np.max(y), t  # amplitude needs to be normalized
 
 
 def filter_decimate_chirp(coeff_ch: Dict, y_ch: np.array, fs: float):
@@ -253,7 +226,6 @@ def get_transmit_signal(
             tx_param_names = [
                 "transmit_duration_nominal",
                 "slope",
-                "transmit_power",
                 "frequency_start",
                 "frequency_end",
             ]
@@ -261,7 +233,6 @@ def get_transmit_signal(
             tx_param_names = [
                 "transmit_duration_nominal",
                 "slope",
-                "transmit_power",
                 "frequency_nominal",
             ]
         tx_params = {}

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -1166,7 +1166,7 @@ class SetGroupsEK80(SetGroupsBase):
         #   - transceiver type
         table_params = [
             "transducer_frequency",
-            "impedance",  # receive impedance (z_er), different from transmit impedance (z_et)
+            "impedance",  # transceiver impedance (z_er), different from transducer impedance (z_et)
             "rx_sample_frequency",  # receiver sampling frequency
             "transceiver_type",
             "pulse_duration",
@@ -1234,13 +1234,13 @@ class SetGroupsEK80(SetGroupsBase):
 
         # Parameters that may or may not exist (due to EK80 software version)
         if "impedance" in param_dict:
-            ds_table["impedance_receive"] = xr.DataArray(
+            ds_table["impedance_transceiver"] = xr.DataArray(
                 param_dict["impedance"],
                 dims=["channel"],
                 coords={"channel": ds_table["channel"]},
                 attrs={
                     "units": "ohm",
-                    "long_name": "Receiver impedance",
+                    "long_name": "Transceiver impedance",
                 },
             )
         if "rx_sample_frequency" in param_dict:
@@ -1276,7 +1276,7 @@ class SetGroupsEK80(SetGroupsBase):
             #                 f"{config[ch]['channel_id_short']}")
             cal_params = [
                 "gain",
-                "impedance",  # transmit impedance (z_et), different from receive impedance (z_er)
+                "impedance",  # transducer impedance (z_et), different from transceiver impedance (z_er)
                 "phase",
                 "beamwidth_alongship",
                 "beamwidth_athwartship",
@@ -1308,7 +1308,7 @@ class SetGroupsEK80(SetGroupsBase):
         ds_cal = xr.merge(ds_cal)
 
         if "impedance" in ds_cal:
-            ds_cal = ds_cal.rename_vars({"impedance": "impedance_transmit"})
+            ds_cal = ds_cal.rename_vars({"impedance": "impedance_transducer"})
 
         #  Save decimation factors and filter coefficients
         coeffs = dict()

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -1276,7 +1276,7 @@ class SetGroupsEK80(SetGroupsBase):
             #                 f"{config[ch]['channel_id_short']}")
             cal_params = [
                 "gain",
-                "impedance",  # transducer impedance (z_et), different from transceiver impedance (z_er)
+                "impedance",  # transducer impedance (z_et), different from transceiver impedance (z_er)  # noqa
                 "phase",
                 "beamwidth_alongship",
                 "beamwidth_athwartship",

--- a/echopype/convert/utils/ek_raw_parsers.py
+++ b/echopype/convert/utils/ek_raw_parsers.py
@@ -851,7 +851,7 @@ class SimradXMLParser(_SimradDatagramParser):
                                     ),
                                     "gain": np.array([float(f.attrib["Gain"]) for f in f_par]),
                                     "impedance": np.array(
-                                        [int(f.attrib["Impedance"]) for f in f_par]
+                                        [float(f.attrib["Impedance"]) for f in f_par]
                                     ),
                                     "phase": np.array([float(f.attrib["Phase"]) for f in f_par]),
                                     "beamwidth_alongship": np.array(

--- a/echopype/tests/calibrate/test_cal_params.py
+++ b/echopype/tests/calibrate/test_cal_params.py
@@ -62,7 +62,7 @@ def vend_EK():
             np.array([[64, 128, 256, 512], [128, 256, 512, 1024]]),
             coords={"channel": vend["channel"], "pulse_length_bin": vend["pulse_length_bin"]}
     )
-    vend["impedance_receive"] = xr.DataArray(
+    vend["impedance_transceiver"] = xr.DataArray(
         [1000, 2000], coords={"channel": vend["channel"]}
     )
     vend["transceiver_type"] = xr.DataArray(
@@ -435,11 +435,11 @@ def test_get_cal_params_AZFP(beam_AZFP, vend_AZFP, user_dict, out_dict):
                         np.array([111, 222]), dims=["channel"],
                         coords={"channel": ["chA", "chB"]}
                     ),
-                    "impedance_transmit": xr.DataArray(
+                    "impedance_transducer": xr.DataArray(
                         np.array([[75], [75]]), dims=["channel", "ping_time"],
                         coords={"channel": ["chA", "chB"], "ping_time": [1]}
                     ),
-                    "impedance_receive": xr.DataArray(
+                    "impedance_transceiver": xr.DataArray(
                         np.array([1000, 2000]), dims=["channel"],
                         coords={"channel": ["chA", "chB"]}
                     ),
@@ -485,11 +485,11 @@ def test_get_cal_params_AZFP(beam_AZFP, vend_AZFP, user_dict, out_dict):
                         np.array([111, 222]), dims=["channel"],
                         coords={"channel": ["chA", "chB"]}
                     ),
-                    "impedance_transmit": xr.DataArray(
+                    "impedance_transducer": xr.DataArray(
                         np.array([[75], [75]]), dims=["channel", "ping_time"],
                         coords={"channel": ["chA", "chB"], "ping_time": [1]}
                     ),
-                    "impedance_receive": xr.DataArray(
+                    "impedance_transceiver": xr.DataArray(
                         np.array([1000, 2000]), dims=["channel"],
                         coords={"channel": ["chA", "chB"]}
                     ),
@@ -553,7 +553,7 @@ def test_get_cal_params_EK80_BB(beam_EK, vend_EK, freq_center, user_dict, out_di
     ("user_dict", "out_dict"),
     [
         # cal_params should not contain:
-        #   impedance_transmit, impedance_receive, receiver_sampling_frequency
+        #   impedance_transducer, impedance_transceiver, receiver_sampling_frequency
         (
             {
                 # add sa_correction here to bypass things going into get_vend_cal_params_power
@@ -596,7 +596,7 @@ def test_get_cal_params_EK80_BB(beam_EK, vend_EK, freq_center, user_dict, out_di
 )
 def test_get_cal_params_EK60(beam_EK, vend_EK, freq_center, user_dict, out_dict):
     # Remove some variables from Vendor group to mimic EK60 data
-    vend_EK = vend_EK.drop("impedance_receive").drop("transceiver_type")
+    vend_EK = vend_EK.drop("impedance_transceiver").drop("transceiver_type")
     cal_dict = get_cal_params_EK(
         waveform_mode="CW", freq_center=freq_center,
         beam=beam_EK, vend=vend_EK,

--- a/echopype/tests/calibrate/test_calibrate_ek80.py
+++ b/echopype/tests/calibrate/test_calibrate_ek80.py
@@ -22,7 +22,7 @@ def ek80_ext_path(test_path):
 
 def test_ek80_transmit_chirp(ek80_cal_path, ek80_ext_path):
     """
-    Test transmit chirp reconstruction against Anderson et al. 2021/pyEcholab implementation
+    Test transmit chirp reconstruction against Andersen et al. 2021/pyEcholab implementation
     """
     ek80_raw_path = ek80_cal_path / "2018115-D20181213-T094600.raw"  # rx impedance / rx fs / tcvr type
     ed = ep.open_raw(ek80_raw_path, sonar_model="EK80")
@@ -86,8 +86,8 @@ def test_ek80_BB_params(ek80_cal_path, ek80_ext_path):
         env_params={"formula_absorption": "FG"}, cal_params=None
     )
 
-    z_er = cal_obj.cal_params["impedance_receive"]
-    z_et = cal_obj.cal_params["impedance_transmit"]
+    z_er = cal_obj.cal_params["impedance_transceiver"]
+    z_et = cal_obj.cal_params["impedance_transducer"]
     # B_theta_phi_m = cal_obj._get_B_theta_phi_m()
     params_BB_map = {
         # param name mapping: echopype (ep) : pyecholab (pyel)
@@ -164,8 +164,8 @@ def test_ek80_BB_power_Sv(ek80_cal_path, ek80_ext_path):
 
     # Params needed
     beam = cal_obj.echodata[cal_obj.ed_beam_group].sel(channel=cal_obj.chan_sel)
-    z_er = cal_obj.cal_params["impedance_receive"]
-    z_et = cal_obj.cal_params["impedance_transmit"]
+    z_er = cal_obj.cal_params["impedance_transceiver"]
+    z_et = cal_obj.cal_params["impedance_transducer"]
     fs = cal_obj.cal_params["receiver_sampling_frequency"]
     filter_coeff = ep.calibrate.ek80_complex.get_filter_coeff(ed["Vendor_specific"].sel(channel=cal_obj.chan_sel))
     tx, tx_time = ep.calibrate.ek80_complex.get_transmit_signal(beam, filter_coeff, waveform_mode, fs)

--- a/echopype/tests/calibrate/test_ecs_integration.py
+++ b/echopype/tests/calibrate/test_ecs_integration.py
@@ -118,8 +118,8 @@ def test_ecs_intake_ek80_CW_power(ek80_path, ecs_path):
     assert np.all(ds_Sv["sound_absorption"].values == assimilated_env_params["sound_absorption"].values)
 
     # TODO: remove params that are only relevant to EK80 complex sample cals
-    #       `impedance_transmit`, `impedance_receive`, `receiver_sampling_frequency`
-    # for p_name in ["impedance_transmit", "impedance_receive", "receiver_sampling_frequency"]:
+    #       `impedance_transducer`, `impedance_transceiver`, `receiver_sampling_frequency`
+    # for p_name in ["impedance_transducer", "impedance_transceiver", "receiver_sampling_frequency"]:
     #     assert p_name not in ds_Sv
 
 
@@ -146,7 +146,6 @@ def test_ecs_intake_ek80_BB_complex(ek80_path, ecs_path):
     for p_name in ["sound_speed", "temperature", "salinity", "pressure", "pH"]:
         assert ds_Sv[p_name].identical(ecs_env[p_name])
 
-    # TODO: add back "impedance_receive" but will need to rename to "impedance_transceiver"
     for p_name in ["sa_correction", "receiver_sampling_frequency"]:
         assert ds_Sv[p_name].identical(ecs_cal_NB[p_name])
 


### PR DESCRIPTION
This PR contains the following changes:
- change the data type of impedance to `float` (addresses #1018)
- finish renaming `impedance_transmit` to `impedance_transducer` and `impedance_receive` to `impedance_transceiver` (leftover that resulted into bug from v0.7.0)
- rename transmit chirp replica construction methods: 
   - correct typo `Anderson` to `Andersen`
   - ~change `Macaulay` to `Matlab` since original code came from Andersen~
   - remove the previous `Macaulay` chirp replica implementation and only keep the one in reference to Andersen