### PR TITLE
AZFP parser error catch to handle case of raw file with no temperature

### DIFF
--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -112,9 +112,14 @@ class ParseAZFP(ParseBase):
             and the counts from ancillary
             """
             v_in = 2.5 * (counts / 65535)
+            # Occurs when temperature sensor is not active (eg, glider deployments)
+            if self.parameters["kc"] - v_in <= 0:
+                return np.nan
+
             R = (self.parameters["ka"] + self.parameters["kb"] * v_in) / (
                 self.parameters["kc"] - v_in
             )
+
             # fmt: off
             T = 1 / (
                 self.parameters["A"]


### PR DESCRIPTION
Addresses remaining issue in #198, where an AZFP raw file without temperature data leads to a failure during `open_raw`. As diagnosed there, the failure comes about in `parser_azfp.compute_temp` due to invalid `R` values passed to `math.log`. A test has been added that will catch cases of the `R` denominator being <= 0 and return `np.nan` instead.

This has been tested with an AZFP file (and corresponding XML) provided by @dsmossman. 

Remaining tasks:
- [ ] Add AZFP test file to our test data
- [ ] Add a test