### PR TITLE
Refactor AZFP parser code

### DIFF
--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -190,7 +190,8 @@ class ParseAZFP(ParseBase):
         if not is_valid:
             return np.nan
         else:
-            N = self.unpacked_data["ancillary"][ping_num][0]
+            idx = 0 if xy == "X" else 1
+            N = self.unpacked_data["ancillary"][ping_num][idx]
             a = self.parameters[f"{xy}_a"]
             b = self.parameters[f"{xy}_b"]
             c = self.parameters[f"{xy}_c"]

--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -258,7 +258,7 @@ class ParseAZFP(ParseBase):
                         )
                         # compute x tilt from unpacked_data[ii]['ancillary][0]
                         self.unpacked_data["tilt_x"].append(
-                            self._compute_tilt(ping_num, "Y", tilt_x_is_valid)
+                            self._compute_tilt(ping_num, "X", tilt_x_is_valid)
                         )
                         # Compute y tilt from unpacked_data[ii]['ancillary][1]
                         self.unpacked_data["tilt_y"].append(

--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -1,4 +1,3 @@
-import math
 import os
 import xml.dom.minidom
 from collections import defaultdict
@@ -171,8 +170,8 @@ class ParseAZFP(ParseBase):
         # fmt: off
         T = 1 / (
             self.parameters["A"]
-            + self.parameters["B"] * (math.log(R))
-            + self.parameters["C"] * (math.log(R) ** 3)
+            + self.parameters["B"] * (np.log(R))
+            + self.parameters["C"] * (np.log(R) ** 3)
         ) - 273
         # fmt: on
         return T
@@ -231,7 +230,7 @@ class ParseAZFP(ParseBase):
 
         # Set flags for presence of valid parameters for temperature and tilt
         def _test_valid_params(params):
-            if all([math.isclose(self.parameters[p], 0) for p in params]):
+            if all([np.isclose(self.parameters[p], 0) for p in params]):
                 return False
             else:
                 return True
@@ -269,14 +268,14 @@ class ParseAZFP(ParseBase):
                         )
                         # Compute cos tilt magnitude from tilt x and y values
                         self.unpacked_data["cos_tilt_mag"].append(
-                            math.cos(
+                            np.cos(
                                 (
-                                    math.sqrt(
+                                    np.sqrt(
                                         self.unpacked_data["tilt_x"][ping_num] ** 2
                                         + self.unpacked_data["tilt_y"][ping_num] ** 2
                                     )
                                 )
-                                * math.pi
+                                * np.pi
                                 / 180
                             )
                         )

--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -160,12 +160,10 @@ class ParseAZFP(ParseBase):
         """
         if not is_valid:
             return np.nan
-        
+
         counts = self.unpacked_data["ancillary"][ping_num][4]
         v_in = 2.5 * (counts / 65535)
-        R = (self.parameters["ka"] + self.parameters["kb"] * v_in) / (
-            self.parameters["kc"] - v_in
-        )
+        R = (self.parameters["ka"] + self.parameters["kb"] * v_in) / (self.parameters["kc"] - v_in)
 
         # fmt: off
         T = 1 / (

--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -175,8 +175,7 @@ class ParseAZFP(ParseBase):
                         # Compute temperature from unpacked_data[ii]['ancillary][4]
                         self.unpacked_data["temperature"].append(
                             compute_temp(
-                                self.unpacked_data["ancillary"][ping_num][4],
-                                temperature_is_valid
+                                self.unpacked_data["ancillary"][ping_num][4], temperature_is_valid
                             )
                         )
                         # compute x tilt from unpacked_data[ii]['ancillary][0]
@@ -187,7 +186,7 @@ class ParseAZFP(ParseBase):
                                 self.parameters["X_b"],
                                 self.parameters["X_c"],
                                 self.parameters["X_d"],
-                                tilt_x_is_valid
+                                tilt_x_is_valid,
                             )
                         )
                         # Compute y tilt from unpacked_data[ii]['ancillary][1]
@@ -198,7 +197,7 @@ class ParseAZFP(ParseBase):
                                 self.parameters["Y_b"],
                                 self.parameters["Y_c"],
                                 self.parameters["Y_d"],
-                                tilt_y_is_valid
+                                tilt_y_is_valid,
                             )
                         )
                         # Compute cos tilt magnitude from tilt x and y values

--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -150,7 +150,7 @@ class ParseAZFP(ParseBase):
 
     def _compute_temperature(self, ping_num, is_valid):
         """
-        Computes temperature in celsius.
+        Compute temperature in celsius.
 
         Parameters
         ----------
@@ -179,7 +179,7 @@ class ParseAZFP(ParseBase):
 
     def _compute_tilt(self, ping_num, xy, is_valid):
         """
-        Computes the instrument tilt.
+        Compute instrument tilt.
 
         Parameters
         ----------
@@ -200,8 +200,24 @@ class ParseAZFP(ParseBase):
             d = self.parameters[f"{xy}_d"]
             return a + b * N + c * N**2 + d * N**3
 
-    def _compute_battery(N):
+    def _compute_battery(self, ping_num, battery_type):
+        """
+        Compute battery voltage.
+
+        Parameters
+        ----------
+        ping_num
+            ping number
+        type
+            either "main" or "tx"
+        """
         USL5_BAT_CONSTANT = (2.5 / 65536.0) * (86.6 + 475.0) / 86.6
+
+        if battery_type == "main":
+            N = self.unpacked_data["ancillary"][ping_num][2]
+        elif battery_type == "tx":
+            N = self.unpacked_data["ad"][ping_num][0]
+
         return N * USL5_BAT_CONSTANT
 
     def parse_raw(self):
@@ -266,11 +282,11 @@ class ParseAZFP(ParseBase):
                         )
                         # Calculate voltage of main battery pack
                         self.unpacked_data["battery_main"].append(
-                            self._compute_battery(self.unpacked_data["ancillary"][ping_num][2])
+                            self._compute_battery(ping_num, battery_type="main")
                         )
                         # If there is a Tx battery pack
                         self.unpacked_data["battery_tx"].append(
-                            self._compute_battery(self.unpacked_data["ad"][ping_num][0])
+                            self._compute_battery(ping_num, battery_type="tx")
                         )
                     else:
                         break

--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -112,9 +112,14 @@ class ParseAZFP(ParseBase):
             and the counts from ancillary
             """
             v_in = 2.5 * (counts / 65535)
+            # Occurs when temperature sensor is not active (eg, glider deployments)
+            if self.parameters["kc"] - v_in <= 0:
+                return np.nan
+
             R = (self.parameters["ka"] + self.parameters["kb"] * v_in) / (
                 self.parameters["kc"] - v_in
             )
+
             # fmt: off
             T = 1 / (
                 self.parameters["A"]

--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -106,16 +106,15 @@ class ParseAZFP(ParseBase):
         """
 
         # Start of computation subfunctions
-        def compute_temp(counts):
+        def compute_temp(counts, is_valid):
             """
             Returns the temperature in celsius given from xml data
             and the counts from ancillary
             """
-            v_in = 2.5 * (counts / 65535)
-            # Occurs when temperature sensor is not active (eg, glider deployments)
-            if self.parameters["kc"] - v_in <= 0:
+            if not is_valid:
                 return np.nan
 
+            v_in = 2.5 * (counts / 65535)
             R = (self.parameters["ka"] + self.parameters["kb"] * v_in) / (
                 self.parameters["kc"] - v_in
             )
@@ -129,8 +128,11 @@ class ParseAZFP(ParseBase):
             # fmt: on
             return T
 
-        def compute_tilt(N, a, b, c, d):
-            return a + b * N + c * N**2 + d * N**3
+        def compute_tilt(N, a, b, c, d, is_valid):
+            if not is_valid:
+                return np.nan
+            else:
+                return a + b * N + c * N**2 + d * N**3
 
         def compute_battery(N):
             USL5_BAT_CONSTANT = (2.5 / 65536.0) * (86.6 + 475.0) / 86.6
@@ -143,6 +145,17 @@ class ParseAZFP(ParseBase):
         # Read xml file into dict
         self.load_AZFP_xml()
         fmap = fsspec.get_mapper(self.source_file, **self.storage_options)
+
+        # Set flags for presence of valid parameters for temperature and tilt
+        def _test_valid_params(params):
+            if all([math.isclose(self.parameters[p], 0) for p in params]):
+                return False
+            else:
+                return True
+
+        temperature_is_valid = _test_valid_params(["ka", "kb", "kc"])
+        tilt_x_is_valid = _test_valid_params(["X_a", "X_b", "X_c"])
+        tilt_y_is_valid = _test_valid_params(["Y_a", "Y_b", "Y_c"])
 
         with fmap.fs.open(fmap.root, "rb") as file:
             ping_num = 0
@@ -161,7 +174,10 @@ class ParseAZFP(ParseBase):
                             self._print_status()
                         # Compute temperature from unpacked_data[ii]['ancillary][4]
                         self.unpacked_data["temperature"].append(
-                            compute_temp(self.unpacked_data["ancillary"][ping_num][4])
+                            compute_temp(
+                                self.unpacked_data["ancillary"][ping_num][4],
+                                temperature_is_valid
+                            )
                         )
                         # compute x tilt from unpacked_data[ii]['ancillary][0]
                         self.unpacked_data["tilt_x"].append(
@@ -171,6 +187,7 @@ class ParseAZFP(ParseBase):
                                 self.parameters["X_b"],
                                 self.parameters["X_c"],
                                 self.parameters["X_d"],
+                                tilt_x_is_valid
                             )
                         )
                         # Compute y tilt from unpacked_data[ii]['ancillary][1]
@@ -181,6 +198,7 @@ class ParseAZFP(ParseBase):
                                 self.parameters["Y_b"],
                                 self.parameters["Y_c"],
                                 self.parameters["Y_d"],
+                                tilt_y_is_valid
                             )
                         )
                         # Compute cos tilt magnitude from tilt x and y values

--- a/echopype/tests/convert/test_convert_azfp.py
+++ b/echopype/tests/convert/test_convert_azfp.py
@@ -65,7 +65,7 @@ def test_convert_azfp_01a_matlab_raw(azfp_path):
         np.array(
             [ds_matlab_output['Output'][0]['N'][fidx] for fidx in range(4)]
         ),
-        echodata["Sonar/Beam_group1"].backscatter_r.isel(beam=0).drop('beam').values,
+        echodata["Sonar/Beam_group1"].backscatter_r.isel(beam=0).drop_vars('beam').values,
     )
 
     # Test vendor group
@@ -133,7 +133,7 @@ def test_convert_azfp_01a_raw_echoview(azfp_path):
     echodata = open_raw(
         raw_file=azfp_01a_path, sonar_model='AZFP', xml_path=azfp_xml_path
     )
-    assert np.array_equal(test_power, echodata["Sonar/Beam_group1"].backscatter_r.isel(beam=0).drop('beam'))
+    assert np.array_equal(test_power, echodata["Sonar/Beam_group1"].backscatter_r.isel(beam=0).drop_vars('beam')) # noqa
 
     # check convention-required variables in the Platform group
     check_platform_required_vars(echodata)
@@ -159,8 +159,8 @@ def test_convert_azfp_01a_different_ranges(azfp_path):
     check_platform_required_vars(echodata)
 
 
-def test_convert_azfp_01a_notemperature(azfp_path):
-    """Test converting file with no temperature data."""
+def test_convert_azfp_01a_notemperature_notilt(azfp_path):
+    """Test converting file with no valid temperature or tilt data."""
     azfp_01a_path = azfp_path / 'rutgers_glider_notemperature/22052500.01A'
     azfp_xml_path = azfp_path / 'rutgers_glider_notemperature/22052501.XML'
 
@@ -170,4 +170,10 @@ def test_convert_azfp_01a_notemperature(azfp_path):
 
     # Temperature variable is present in the Environment group and its values are all nan
     assert "temperature" in echodata["Environment"]
-    assert echodata["Environment"].temperature.isnull().all()
+    assert echodata["Environment"]["temperature"].isnull().all()
+
+    # Tilt variables are present in the Platform group and their values are all nan
+    assert "tilt_x" in echodata["Platform"]
+    assert "tilt_y" in echodata["Platform"]
+    assert echodata["Platform"]["tilt_x"].isnull().all()
+    assert echodata["Platform"]["tilt_y"].isnull().all()

--- a/echopype/tests/convert/test_convert_azfp.py
+++ b/echopype/tests/convert/test_convert_azfp.py
@@ -161,3 +161,17 @@ def test_convert_azfp_01a_different_ranges(azfp_path):
 
     # check convention-required variables in the Platform group
     check_platform_required_vars(echodata)
+
+
+def test_convert_azfp_01a_notemperature(azfp_path):
+    """Test converting file with no temperature data."""
+    azfp_01a_path = str(azfp_path.joinpath('rutgers_glider_notemperature', '22052500.01A'))
+    azfp_xml_path = str(azfp_path.joinpath('rutgers_glider_notemperature', '22052501.XML'))
+
+    echodata = open_raw(
+        raw_file=azfp_01a_path, sonar_model='AZFP', xml_path=azfp_xml_path
+    )
+
+    # Temperature variable is present in the Environment group and its values are all nan
+    assert "temperature" in echodata["Environment"]
+    assert echodata["Environment"].temperature.isnull().all()

--- a/echopype/tests/convert/test_convert_azfp.py
+++ b/echopype/tests/convert/test_convert_azfp.py
@@ -40,14 +40,10 @@ def check_platform_required_vars(echodata):
 
 def test_convert_azfp_01a_matlab_raw(azfp_path):
     """Compare parsed raw data with Matlab outputs."""
-    azfp_01a_path = str(azfp_path.joinpath('17082117.01A'))
-    azfp_xml_path = str(azfp_path.joinpath('17041823.XML'))
-    azfp_matlab_data_path = str(
-        azfp_path.joinpath('from_matlab', '17082117_matlab_Data.mat')
-    )
-    azfp_matlab_output_path = str(
-        azfp_path.joinpath('from_matlab', '17082117_matlab_Output_Sv.mat')
-    )
+    azfp_01a_path = azfp_path / '17082117.01A'
+    azfp_xml_path = azfp_path / '17041823.XML'
+    azfp_matlab_data_path = azfp_path / 'from_matlab/17082117_matlab_Data.mat'
+    azfp_matlab_output_path = azfp_path / 'from_matlab/17082117_matlab_Output_Sv.mat'
 
     # Convert file
     echodata = open_raw(
@@ -118,12 +114,12 @@ def test_convert_azfp_01a_matlab_derived():
 
 def test_convert_azfp_01a_raw_echoview(azfp_path):
     """Compare parsed power data (count) with csv exported by EchoView."""
-    azfp_01a_path = str(azfp_path.joinpath('17082117.01A'))
-    azfp_xml_path = str(azfp_path.joinpath('17041823.XML'))
+    azfp_01a_path = azfp_path / '17082117.01A'
+    azfp_xml_path = azfp_path / '17041823.XML'
 
     # Read csv files exported by EchoView
     azfp_csv_path = [
-        azfp_path.joinpath('from_echoview', '17082117-raw%d.csv' % freq)
+        azfp_path / f"from_echoview/17082117-raw{freq}.csv"
         for freq in [38, 125, 200, 455]
     ]
     channels = []
@@ -145,8 +141,8 @@ def test_convert_azfp_01a_raw_echoview(azfp_path):
 
 def test_convert_azfp_01a_different_ranges(azfp_path):
     """Test converting files with different range settings across frequency."""
-    azfp_01a_path = str(azfp_path.joinpath('17031001.01A'))
-    azfp_xml_path = str(azfp_path.joinpath('17030815.XML'))
+    azfp_01a_path = azfp_path / '17031001.01A'
+    azfp_xml_path = azfp_path / '17030815.XML'
 
     # Convert file
     echodata = open_raw(
@@ -165,8 +161,8 @@ def test_convert_azfp_01a_different_ranges(azfp_path):
 
 def test_convert_azfp_01a_notemperature(azfp_path):
     """Test converting file with no temperature data."""
-    azfp_01a_path = str(azfp_path.joinpath('rutgers_glider_notemperature', '22052500.01A'))
-    azfp_xml_path = str(azfp_path.joinpath('rutgers_glider_notemperature', '22052501.XML'))
+    azfp_01a_path = azfp_path / 'rutgers_glider_notemperature/22052500.01A'
+    azfp_xml_path = azfp_path / 'rutgers_glider_notemperature/22052501.XML'
 
     echodata = open_raw(
         raw_file=azfp_01a_path, sonar_model='AZFP', xml_path=azfp_xml_path


### PR DESCRIPTION
This PR refactors `parse_raw`:
- move `compute_*` subfunctions to separate private functions under `ParseAZFP` as `._compute_*`
- refactor input arguments for `ParseAZFP._compute_*` to keep `parse_raw` clean
- move XML and header constants and field specification to be class attributes for `ParseAZFP`
- change use of `math` to just use `np`

@emiliom : I'll merge `dev` once #1020 is merged so the history here looks nice, but it should be pretty easy for you to see what I have done here.