### PR TITLE
Revert windows platform docker build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -47,7 +47,7 @@ jobs:
           context: ./
           file: ./.ci_helpers/docker/${{ matrix.image_name }}.dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64,windows/amd64
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.IMAGE_SPEC }}:${{ env.DATE_TAG }}
             ${{ env.IMAGE_SPEC }}:latest


### PR DESCRIPTION
## Overview

This PR reverts back to not trying to create docker target platform windows... seems like the upstream docker images that we build from doesn't have this target platform.