### PR TITLE
Remove unneeded (mistaken) object return in processing level decorator function

### DIFF
--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -206,7 +206,6 @@ def add_processing_level(processing_level_code: str, is_echodata: bool = False) 
                 func(self, *args, **kwargs)
                 processing_level = PROCESSING_LEVELS[processing_level_code]
                 self["Top-level"] = self["Top-level"].assign_attrs(_attrs_dict(processing_level))
-                return self
 
             return inner
         else:


### PR DESCRIPTION
For echodata class methods, the decorator wrapper-inner function was returning `self`, when in fact no `return` statement was necessary. This had no harmful effect per se, that I can see, but it was effectively "printing out" the echodata object. This effect was visible when running `echodata.update_platform` in a Jupyter notebook.

I'll self merge. This is a simple change (removed `return self` statement) to code I wrote for the last release.