### PR TITLE
Move filter coefficients and decimation factor to variables

### DIFF
--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -1353,7 +1353,7 @@ class SetGroupsEK80(SetGroupsBase):
         return ds
 
     @staticmethod
-    def _add_cd(
+    def _add_filter_params(
         dataset: xr.Dataset, coeffs_and_decimation: Dict[str, Dict[str, List[Union[int, NDArray]]]]
     ) -> xr.Dataset:
         """
@@ -1400,6 +1400,6 @@ class SetGroupsEK80(SetGroupsBase):
                     }
                     dims = ["channel"]
                 # Set the xarray data dictionary
-                coeffs_xr_data[f"{cd_type} {key}"] = (dims, data, attrs)
+                coeffs_xr_data[f"{cd_type}_{key}"] = (dims, data, attrs)
 
         return dataset.assign(coeffs_xr_data)

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -1334,7 +1334,7 @@ class SetGroupsEK80(SetGroupsBase):
                 )
             # filter coeffs and decimation factor for pulse compression (PC)
             if self.parser_obj.fil_df and (ch in self.parser_obj.fil_coeffs.keys()):
-                coeffs_vals = self.parser_obj.fil_coeffs[ch][1]
+                coeffs_vals = self.parser_obj.fil_coeffs[ch][2]
                 coeffs_and_decimation[PULSE_COMPRESS][FILTER_IMAG].append(np.imag(coeffs_vals))
                 coeffs_and_decimation[PULSE_COMPRESS][FILTER_REAL].append(np.real(coeffs_vals))
                 coeffs_and_decimation[PULSE_COMPRESS][DECIMATION].append(

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -1,14 +1,21 @@
 from collections import defaultdict
-from typing import List
+from typing import Dict, List, Union
 
 import numpy as np
 import xarray as xr
+from numpy.typing import NDArray
 
 from ..utils.coding import set_time_encodings
 from ..utils.log import _init_logger
 from .set_groups_base import SetGroupsBase
 
 logger = _init_logger(__name__)
+
+WIDE_BAND_TRANS = "WBT"
+PULSE_COMPRESS = "PC"
+FILTER_IMAG = "filter_i"
+FILTER_REAL = "filter_r"
+DECIMATION = "decimation"
 
 
 class SetGroupsEK80(SetGroupsBase):
@@ -1311,31 +1318,88 @@ class SetGroupsEK80(SetGroupsBase):
             ds_cal = ds_cal.rename_vars({"impedance": "impedance_transducer"})
 
         #  Save decimation factors and filter coefficients
-        coeffs = dict()
-        decimation_factors = dict()
+        coeffs_and_decimation = {
+            t: {FILTER_IMAG: [], FILTER_REAL: [], DECIMATION: []}
+            for t in [WIDE_BAND_TRANS, PULSE_COMPRESS]
+        }
+
         for ch in self.sorted_channel["all"]:
             # filter coeffs and decimation factor for wide band transceiver (WBT)
             if self.parser_obj.fil_coeffs and (ch in self.parser_obj.fil_coeffs.keys()):
-                coeffs[f"{ch} WBT filter"] = self.parser_obj.fil_coeffs[ch][1]
-                decimation_factors[f"{ch} WBT decimation"] = self.parser_obj.fil_df[ch][1]
+                coeffs_vals = self.parser_obj.fil_coeffs[ch][1]
+                coeffs_and_decimation[WIDE_BAND_TRANS][FILTER_IMAG].append(np.imag(coeffs_vals))
+                coeffs_and_decimation[WIDE_BAND_TRANS][FILTER_REAL].append(np.real(coeffs_vals))
+                coeffs_and_decimation[WIDE_BAND_TRANS][DECIMATION].append(
+                    self.parser_obj.fil_df[ch][1]
+                )
             # filter coeffs and decimation factor for pulse compression (PC)
             if self.parser_obj.fil_df and (ch in self.parser_obj.fil_coeffs.keys()):
-                coeffs[f"{ch} PC filter"] = self.parser_obj.fil_coeffs[ch][2]
-                decimation_factors[f"{ch} PC decimation"] = self.parser_obj.fil_df[ch][2]
+                coeffs_vals = self.parser_obj.fil_coeffs[ch][1]
+                coeffs_and_decimation[PULSE_COMPRESS][FILTER_IMAG].append(np.imag(coeffs_vals))
+                coeffs_and_decimation[PULSE_COMPRESS][FILTER_REAL].append(np.real(coeffs_vals))
+                coeffs_and_decimation[PULSE_COMPRESS][DECIMATION].append(
+                    self.parser_obj.fil_df[ch][2]
+                )
 
         # Assemble everything into a Dataset
         ds = xr.merge([ds_table, ds_cal])
 
-        # Save filter coefficients as real and imaginary parts as attributes
-        for k, v in coeffs.items():
-            ds.attrs[k + "_r"] = np.real(v)
-            ds.attrs[k + "_i"] = np.imag(v)
-
-        # Save decimation factors as attributes
-        for k, v in decimation_factors.items():
-            ds.attrs[k] = v
+        # Add the coeffs and decimation
+        ds = ds.pipe(self._add_cd, coeffs_and_decimation)
 
         # Save the entire config XML in vendor group in case of info loss
         ds.attrs["config_xml"] = self.parser_obj.config_datagram["xml"]
 
         return ds
+
+    @staticmethod
+    def _add_cd(
+        dataset: xr.Dataset, coeffs_and_decimation: Dict[str, Dict[str, List[Union[int, NDArray]]]]
+    ) -> xr.Dataset:
+        """
+        Assembles filter coefficient and decimation factors and add to the dataset
+
+        Parameters
+        ----------
+        dataset : xr.Dataset
+            xarray dataset where the filter coefficient and decimation factors will be added
+        coeffs_and_decimation : dict
+            dictionary holding the filter coefficient and decimation factors
+
+        Returns
+        -------
+        xr.Dataset
+            The modified dataset with filter coefficient and decimation factors included
+        """
+        attribute_values = {
+            FILTER_IMAG: "filter coefficients (imaginary part)",
+            FILTER_REAL: "filter coefficients (real part)",
+            DECIMATION: "decimation factor",
+            WIDE_BAND_TRANS: "Wideband transceiver",
+            PULSE_COMPRESS: "Pulse compression",
+        }
+
+        coeffs_xr_data = {}
+        for cd_type, values in coeffs_and_decimation.items():
+            for key, data in values.items():
+                if "filter" in key:
+                    attrs = {"long_name": f"{attribute_values[cd_type]} {attribute_values[key]}"}
+                    # filter_i and filter_r
+                    max_len = np.max([len(a) for a in data])
+                    # Pad arrays
+                    data = np.asarray(
+                        [
+                            np.pad(a, (0, max_len - len(a)), "constant", constant_values=np.nan)
+                            for a in data
+                        ]
+                    )
+                    dims = ["channel", f"{cd_type}_filter_n"]
+                else:
+                    attrs = {
+                        "long_name": f"{attribute_values[cd_type]} {attribute_values[DECIMATION]}"
+                    }
+                    dims = ["channel"]
+                # Set the xarray data dictionary
+                coeffs_xr_data[f"{cd_type} {key}"] = (dims, data, attrs)
+
+        return dataset.assign(coeffs_xr_data)

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -5,6 +5,7 @@ from scipy.io import loadmat
 from echopype import open_raw
 
 from echopype.testing import TEST_DATA_FOLDER
+from echopype.convert.set_groups_ek80 import WIDE_BAND_TRANS, PULSE_COMPRESS, FILTER_IMAG, FILTER_REAL, DECIMATION
 
 
 @pytest.fixture
@@ -415,10 +416,8 @@ def test_convert_ek80_no_fil_coeff(ek80_path):
     """Make sure we can convert EK80 file with empty filter coefficients."""
     echodata = open_raw(raw_file=ek80_path.joinpath('D20210330-T123857.raw'), sonar_model='EK80')
 
-    ch_ids = list(echodata["Sonar/Beam_group1"]["channel"].values)
+    vendor_spec_ds = echodata["Vendor_specific"]
 
-    for ch_id in ch_ids:
-        assert f"{ch_id} WBT filter_r" not in echodata["Vendor_specific"].attrs.keys()
-        assert f"{ch_id} WBT filter_i" not in echodata["Vendor_specific"].attrs.keys()
-        assert f"{ch_id} PC filter_r" not in echodata["Vendor_specific"].attrs.keys()
-        assert f"{ch_id} PC filter_i" not in echodata["Vendor_specific"].attrs.keys()
+    for t in [WIDE_BAND_TRANS, PULSE_COMPRESS]:
+        for p in [FILTER_REAL, FILTER_IMAG, DECIMATION]:
+            assert f"{t}_{p}" not in vendor_spec_ds


### PR DESCRIPTION
## Overview

This PR moves the filter coefficient and decimation factors within the `Vendor specific` group from being in the `Attributes` to data variables for `EK80` sonar model as seen in the screenshot below.

<img width="869" alt="Screenshot 2023-05-18 at 4 44 45 PM" src="https://github.com/OSOceanAcoustics/echopype/assets/17802172/a72618b5-1beb-4f72-925a-9089bea581c7">
