### PR TITLE
Standardize backscatter_r/i long_name, and correct units

### DIFF
--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -265,7 +265,7 @@ class SetGroupsAZFP(SetGroupsBase):
                         "long_name": self._varattrs["beam_var_default"]["backscatter_r"][
                             "long_name"
                         ],  # noqa
-                        "units": "dB",
+                        "units": "count",
                     },
                 ),
                 "equivalent_beam_angle": (

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -261,7 +261,12 @@ class SetGroupsAZFP(SetGroupsBase):
                 "backscatter_r": (
                     ["channel", "ping_time", "range_sample"],
                     N,
-                    {"long_name": "Backscatter power", "units": "dB"},
+                    {
+                        "long_name": self._varattrs["beam_var_default"]["backscatter_r"][
+                            "long_name"
+                        ],  # noqa
+                        "units": "dB",
+                    },
                 ),
                 "equivalent_beam_angle": (
                     ["channel"],

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -264,7 +264,7 @@ class SetGroupsAZFP(SetGroupsBase):
                     {
                         "long_name": self._varattrs["beam_var_default"]["backscatter_r"][
                             "long_name"
-                        ],  # noqa
+                        ],
                         "units": "count",
                     },
                 ),

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -542,7 +542,7 @@ class SetGroupsBase(abc.ABC):
             name="backscatter_r",
             attrs={
                 "long_name": self._varattrs["beam_var_default"]["backscatter_r"]["long_name"],
-                "units": "V",
+                "units": "dB",
             },
         )
 
@@ -552,7 +552,7 @@ class SetGroupsBase(abc.ABC):
             name="backscatter_i",
             attrs={
                 "long_name": self._varattrs["beam_var_default"]["backscatter_i"]["long_name"],
-                "units": "V",
+                "units": "dB",
             },
         )
 

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -403,7 +403,10 @@ class SetGroupsBase(abc.ABC):
                 ),
             },
             name="backscatter_r",
-            attrs={"long_name": "Backscatter power", "units": "dB"},
+            attrs={
+                "long_name": self._varattrs["beam_var_default"]["backscatter_r"]["long_name"],
+                "units": "dB",
+            },
         )
 
         return backscatter_r
@@ -537,14 +540,20 @@ class SetGroupsBase(abc.ABC):
             data=complex_r,
             coords=array_coords,
             name="backscatter_r",
-            attrs={"long_name": "Real part of backscatter power", "units": "V"},
+            attrs={
+                "long_name": self._varattrs["beam_var_default"]["backscatter_r"]["long_name"],
+                "units": "V",
+            },
         )
 
         backscatter_i = xr.DataArray(
             data=complex_i,
             coords=array_coords,
             name="backscatter_i",
-            attrs={"long_name": "Imaginary part of backscatter power", "units": "V"},
+            attrs={
+                "long_name": self._varattrs["beam_var_default"]["backscatter_i"]["long_name"],
+                "units": "V",
+            },
         )
 
         return backscatter_r, backscatter_i

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -681,7 +681,12 @@ class SetGroupsEK60(SetGroupsBase):
                 var_dict["backscatter_r"] = (
                     ["ping_time", "range_sample"],
                     self.parser_obj.ping_data_dict["power"][ch],
-                    {"long_name": "Backscatter power", "units": "dB"},
+                    {
+                        "long_name": self._varattrs["beam_var_default"]["backscatter_r"][
+                            "long_name"
+                        ],  # noqa
+                        "units": "dB",
+                    },
                 )
 
                 ds_tmp = xr.Dataset(

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -684,7 +684,7 @@ class SetGroupsEK60(SetGroupsBase):
                     {
                         "long_name": self._varattrs["beam_var_default"]["backscatter_r"][
                             "long_name"
-                        ],  # noqa
+                        ],
                         "units": "dB",
                     },
                 )

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -724,12 +724,22 @@ class SetGroupsEK80(SetGroupsBase):
                 "backscatter_r": (
                     ["ping_time", "range_sample", "beam"],
                     np.real(data),
-                    {"long_name": "Real part of backscatter power", "units": "V"},
+                    {
+                        "long_name": self._varattrs["beam_var_default"]["backscatter_r"][
+                            "long_name"
+                        ],  # noqa
+                        "units": "V",
+                    },
                 ),
                 "backscatter_i": (
                     ["ping_time", "range_sample", "beam"],
                     np.imag(data),
-                    {"long_name": "Imaginary part of backscatter power", "units": "V"},
+                    {
+                        "long_name": self._varattrs["beam_var_default"]["backscatter_i"][
+                            "long_name"
+                        ],
+                        "units": "V",
+                    },
                 ),
             },
             coords={
@@ -823,7 +833,12 @@ class SetGroupsEK80(SetGroupsBase):
                 "backscatter_r": (
                     ["ping_time", "range_sample"],
                     self.parser_obj.ping_data_dict["power"][ch],
-                    {"long_name": "Backscatter power", "units": "dB"},
+                    {
+                        "long_name": self._varattrs["beam_var_default"]["backscatter_r"][
+                            "long_name"
+                        ],
+                        "units": "dB",
+                    },
                 ),
             },
             coords={

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -727,7 +727,7 @@ class SetGroupsEK80(SetGroupsBase):
                     {
                         "long_name": self._varattrs["beam_var_default"]["backscatter_r"][
                             "long_name"
-                        ],  # noqa
+                        ],
                         "units": "dB",
                     },
                 ),

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -728,7 +728,7 @@ class SetGroupsEK80(SetGroupsBase):
                         "long_name": self._varattrs["beam_var_default"]["backscatter_r"][
                             "long_name"
                         ],  # noqa
-                        "units": "V",
+                        "units": "dB",
                     },
                 ),
                 "backscatter_i": (
@@ -738,7 +738,7 @@ class SetGroupsEK80(SetGroupsBase):
                         "long_name": self._varattrs["beam_var_default"]["backscatter_i"][
                             "long_name"
                         ],
-                        "units": "V",
+                        "units": "dB",
                     },
                 ),
             },

--- a/echopype/echodata/convention/1.0.yml
+++ b/echopype/echodata/convention/1.0.yml
@@ -70,6 +70,11 @@ variable_and_varattributes:
       long_name: Along-range sample number, base 0
     beam:
       long_name: Beam name
+  beam_var_default:
+    backscatter_r:
+      long_name: Raw backscatter measurements (real part)
+    backscatter_i:
+      long_name: Raw backscatter measurements (imaginary part)
   platform_coord_default:
     time1:
       axis: T


### PR DESCRIPTION
Addresses #643.

- Standard `long_name` attribute in `backscatter_r` and `backscatter_i` variables for all instruments (except ad2cp) to use the SONAR-netCDF v1 strings. Now being set in single place, in the `long_name` attribute strings in the `echodata/convention/1.0.yml` file.
- Set AZFP `backscatter_r` `units` string to "count", per recent discussion with @leewujung and in #643
- For EK80, correct wrong unit `backscatter_r` / `backscatter_i` assignment being made in some cases, where the unit was set to "V" rather than "dB". @leewujung  please double check this!

Note: I used `# noqa` for a couple of long lines, but black apparently ignored it. I guess we should remove the `# noqa` flags?

-------

Side note: in my local test runs, I had two failures: 
```
FAILED echopype/tests/calibrate/test_cal_params.py::test_get_cal_params_EK80_BB[in_da_freq_dep_with_scaling] (line 549)
  - AssertionError: assert False

FAILED echopype/tests/utils/test_utils_log.py::test_init_logger (line 25)
  - AssertionError: assert 4 == 2
```
I've had these failures happen sporadically since March! I don't know why.