### PR TITLE
Bring more consistency in the Platform group across sensors on conversion

### DIFF
--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -142,6 +142,7 @@ class SetGroupsAZFP(SetGroupsBase):
         platform_dict = {"platform_name": "", "platform_type": "", "platform_code_ICES": ""}
         unpacked_data = self.parser_obj.unpacked_data
         time2 = self.parser_obj.ping_time
+        time1 = [time2[0]]
 
         # If tilt_x and/or tilt_y are all nan, create single-value timme2 dimension
         # and single-value (np.nan) tilt_x and tilt_y
@@ -187,7 +188,7 @@ class SetGroupsAZFP(SetGroupsBase):
                     tilt_x,
                     {
                         "long_name": "Tilt X",
-                        "units": "degree",
+                        "units": "arc_degree",
                     },
                 ),
                 "tilt_y": (
@@ -195,7 +196,7 @@ class SetGroupsAZFP(SetGroupsBase):
                     tilt_y,
                     {
                         "long_name": "Tilt Y",
-                        "units": "degree",
+                        "units": "arc_degree",
                     },
                 ),
                 **{
@@ -244,7 +245,7 @@ class SetGroupsAZFP(SetGroupsBase):
                 "time1": (
                     ["time1"],
                     # xarray and probably CF don't accept time coordinate variable with Nan values
-                    [time2[0]],
+                    time1,
                     {
                         **self._varattrs["platform_coord_default"]["time1"],
                         "comment": "Time coordinate corresponding to NMEA position data.",

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -149,6 +149,36 @@ class SetGroupsAZFP(SetGroupsBase):
 
         ds = xr.Dataset(
             {
+                "latitude": (
+                    ["time1"],
+                    [np.nan],
+                    self._varattrs["platform_var_default"]["latitude"],
+                ),
+                "longitude": (
+                    ["time1"],
+                    [np.nan],
+                    self._varattrs["platform_var_default"]["longitude"],
+                ),
+                "pitch": (
+                    ["time2"],
+                    [np.nan] * len(time2),
+                    self._varattrs["platform_var_default"]["pitch"],
+                ),
+                "roll": (
+                    ["time2"],
+                    [np.nan] * len(time2),
+                    self._varattrs["platform_var_default"]["roll"],
+                ),
+                "vertical_offset": (
+                    ["time2"],
+                    [np.nan] * len(time2),
+                    self._varattrs["platform_var_default"]["vertical_offset"],
+                ),
+                "water_level": (
+                    ["time3"],
+                    [np.nan],
+                    self._varattrs["platform_var_default"]["water_level"],
+                ),
                 "tilt_x": (
                     ["time2"],
                     unpacked_data["tilt_x"],
@@ -166,6 +196,18 @@ class SetGroupsAZFP(SetGroupsBase):
                     },
                 ),
                 **{
+                    var: (
+                        ["channel"],
+                        [np.nan] * len(self.channel_ids_sorted),
+                        self._varattrs["platform_var_default"][var],
+                    )
+                    for var in [
+                        "transducer_offset_x",
+                        "transducer_offset_y",
+                        "transducer_offset_z",
+                    ]
+                },
+                **{
                     var: ([], np.nan, self._varattrs["platform_var_default"][var])
                     for var in [
                         "MRU_offset_x",
@@ -177,15 +219,34 @@ class SetGroupsAZFP(SetGroupsBase):
                         "position_offset_x",
                         "position_offset_y",
                         "position_offset_z",
-                        "transducer_offset_x",
-                        "transducer_offset_y",
-                        "transducer_offset_z",
-                        "vertical_offset",
-                        "water_level",
                     ]
                 },
+                "frequency_nominal": (
+                    ["channel"],
+                    self.freq_sorted,
+                    {
+                        "units": "Hz",
+                        "long_name": "Transducer frequency",
+                        "valid_min": 0.0,
+                        "standard_name": "sound_frequency",
+                    },
+                ),
             },
             coords={
+                "channel": (
+                    ["channel"],
+                    self.channel_ids_sorted,
+                    self._varattrs["beam_coord_default"]["channel"],
+                ),
+                "time1": (
+                    ["time1"],
+                    # xarray and probably CF don't accept time coordinate variable with Nan values
+                    [time2[0]],
+                    {
+                        **self._varattrs["platform_coord_default"]["time1"],
+                        "comment": "Time coordinate corresponding to NMEA position data.",
+                    },
+                ),
                 "time2": (
                     ["time2"],
                     time2,
@@ -195,6 +256,19 @@ class SetGroupsAZFP(SetGroupsBase):
                         "standard_name": "time",
                         "comment": "Time coordinate corresponding to platform motion and "
                         "orientation data.",
+                    },
+                ),
+                "time3": (
+                    ["time3"],
+                    # xarray and probably CF don't accept time coordinate variable with Nan values
+                    [time2[0]],
+                    {
+                        "axis": "T",
+                        "long_name": "Timestamps for platform-related sampling environment",
+                        "standard_name": "time",
+                        "comment": "Time coordinate corresponding to platform-related "
+                        "sampling environment. Note that Platform.time3 is "
+                        "the same as Environment.time1.",
                     },
                 ),
             },

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -147,6 +147,13 @@ class SetGroupsAZFP(SetGroupsBase):
         unpacked_data = self.parser_obj.unpacked_data
         time2 = self.parser_obj.ping_time
 
+        # If tilt_x and/or tilt_y are all nan, create single-value timme2 dimension
+        # and single-value (np.nan) tilt_x and tilt_y
+        tilt_x = [np.nan] if np.isnan(unpacked_data["tilt_x"]).all() else unpacked_data["tilt_x"]
+        tilt_y = [np.nan] if np.isnan(unpacked_data["tilt_y"]).all() else unpacked_data["tilt_y"]
+        if (len(tilt_x) == 1 and np.isnan(tilt_x)) and (len(tilt_y) == 1 and np.isnan(tilt_y)):
+            time2 = [time2[0]]
+
         ds = xr.Dataset(
             {
                 "latitude": (
@@ -181,7 +188,7 @@ class SetGroupsAZFP(SetGroupsBase):
                 ),
                 "tilt_x": (
                     ["time2"],
-                    unpacked_data["tilt_x"],
+                    tilt_x,
                     {
                         "long_name": "Tilt X",
                         "units": "degree",
@@ -189,7 +196,7 @@ class SetGroupsAZFP(SetGroupsBase):
                 ),
                 "tilt_y": (
                     ["time2"],
-                    unpacked_data["tilt_y"],
+                    tilt_y,
                     {
                         "long_name": "Tilt Y",
                         "units": "degree",

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -139,11 +139,7 @@ class SetGroupsAZFP(SetGroupsBase):
 
     def set_platform(self) -> xr.Dataset:
         """Set the Platform group."""
-        platform_dict = {
-            "platform_name": self.ui_param["platform_name"],
-            "platform_type": self.ui_param["platform_type"],
-            "platform_code_ICES": self.ui_param["platform_code_ICES"],
-        }
+        platform_dict = {"platform_name": "", "platform_type": "", "platform_code_ICES": ""}
         unpacked_data = self.parser_obj.unpacked_data
         time2 = self.parser_obj.ping_time
 
@@ -182,8 +178,8 @@ class SetGroupsAZFP(SetGroupsBase):
                     self._varattrs["platform_var_default"]["vertical_offset"],
                 ),
                 "water_level": (
-                    ["time3"],
-                    [np.nan],
+                    [],
+                    np.nan,
                     self._varattrs["platform_var_default"]["water_level"],
                 ),
                 "tilt_x": (
@@ -263,19 +259,6 @@ class SetGroupsAZFP(SetGroupsBase):
                         "standard_name": "time",
                         "comment": "Time coordinate corresponding to platform motion and "
                         "orientation data.",
-                    },
-                ),
-                "time3": (
-                    ["time3"],
-                    # xarray and probably CF don't accept time coordinate variable with Nan values
-                    [time2[0]],
-                    {
-                        "axis": "T",
-                        "long_name": "Timestamps for platform-related sampling environment",
-                        "standard_name": "time",
-                        "comment": "Time coordinate corresponding to platform-related "
-                        "sampling environment. Note that Platform.time3 is "
-                        "the same as Environment.time1.",
                     },
                 ),
             },

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -278,8 +278,9 @@ class SetGroupsEK60(SetGroupsBase):
                     self._varattrs["platform_var_default"]["vertical_offset"],
                 ),
                 "water_level": (
-                    ["time3"],
-                    self.parser_obj.ping_data_dict["transducer_depth"][ch],
+                    [],
+                    # a scalar, assumed to be a constant in the source transducer_depth data
+                    self.parser_obj.ping_data_dict["transducer_depth"][ch][0],
                     self._varattrs["platform_var_default"]["water_level"],
                 ),
                 **{
@@ -315,17 +316,6 @@ class SetGroupsEK60(SetGroupsBase):
                         "standard_name": "time",
                         "comment": "Time coordinate corresponding to platform motion and "
                         "orientation data.",
-                    },
-                ),
-                "time3": (
-                    ["time3"],
-                    self.parser_obj.ping_time[ch],
-                    {
-                        "axis": "T",
-                        "long_name": "Timestamps for platform-related sampling environment",
-                        "standard_name": "time",
-                        "comment": "Time coordinate corresponding to platform-related "
-                        "sampling environment.",
                     },
                 ),
             },

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -240,12 +240,11 @@ class SetGroupsEK60(SetGroupsBase):
         # Read lat/long from NMEA datagram
         time1, msg_type, lat, lon = self._extract_NMEA_latlon()
 
-        # NMEA dataset: variables filled with nan if do not exist
-        platform_dict = {
-            "platform_name": self.ui_param["platform_name"],
-            "platform_type": self.ui_param["platform_type"],
-            "platform_code_ICES": self.ui_param["platform_code_ICES"],
-        }
+        # NMEA dataset: variables filled with np.nan if they do not exist
+        platform_dict = {"platform_name": "", "platform_type": "", "platform_code_ICES": ""}
+        # Values for the variables below having a channel (ch) dependence
+        # are identical across channels
+        ch = list(self.sorted_channel.keys())[0]
         ds = xr.Dataset(
             {
                 "latitude": (
@@ -263,6 +262,40 @@ class SetGroupsEK60(SetGroupsBase):
                     msg_type,
                     self._varattrs["platform_var_default"]["sentence_type"],
                 ),
+                "pitch": (
+                    ["time2"],
+                    self.parser_obj.ping_data_dict["pitch"][ch],
+                    self._varattrs["platform_var_default"]["pitch"],
+                ),
+                "roll": (
+                    ["time2"],
+                    self.parser_obj.ping_data_dict["roll"][ch],
+                    self._varattrs["platform_var_default"]["roll"],
+                ),
+                "vertical_offset": (
+                    ["time2"],
+                    self.parser_obj.ping_data_dict["heave"][ch],
+                    self._varattrs["platform_var_default"]["vertical_offset"],
+                ),
+                "water_level": (
+                    ["time3"],
+                    self.parser_obj.ping_data_dict["transducer_depth"][ch],
+                    self._varattrs["platform_var_default"]["water_level"],
+                ),
+                **{
+                    var: ([], np.nan, self._varattrs["platform_var_default"][var])
+                    for var in [
+                        "MRU_offset_x",
+                        "MRU_offset_y",
+                        "MRU_offset_z",
+                        "MRU_rotation_x",
+                        "MRU_rotation_y",
+                        "MRU_rotation_z",
+                        "position_offset_x",
+                        "position_offset_y",
+                        "position_offset_z",
+                    ]
+                },
             },
             coords={
                 "time1": (
@@ -272,43 +305,37 @@ class SetGroupsEK60(SetGroupsBase):
                         **self._varattrs["platform_coord_default"]["time1"],
                         "comment": "Time coordinate corresponding to NMEA position data.",
                     },
-                )
+                ),
+                "time2": (
+                    ["time2"],
+                    self.parser_obj.ping_time[ch],
+                    {
+                        "axis": "T",
+                        "long_name": "Timestamps for platform motion and orientation data",
+                        "standard_name": "time",
+                        "comment": "Time coordinate corresponding to platform motion and "
+                        "orientation data.",
+                    },
+                ),
+                "time3": (
+                    ["time3"],
+                    self.parser_obj.ping_time[ch],
+                    {
+                        "axis": "T",
+                        "long_name": "Timestamps for platform-related sampling environment",
+                        "standard_name": "time",
+                        "comment": "Time coordinate corresponding to platform-related "
+                        "sampling environment.",
+                    },
+                ),
             },
         )
-
-        # TODO: consider allow users to set water_level like in EK80?
-        # if self.ui_param['water_level'] is not None:
-        #     water_level = self.ui_param['water_level']
-        # else:
-        #     water_level = np.nan
-        #     print('WARNING: The water_level_draft was not in the file. Value '
-        #           'set to None.')
 
         # Loop over channels and merge all
         ds_plat = []
         for ch in self.sorted_channel.keys():
             ds_tmp = xr.Dataset(
                 {
-                    "pitch": (
-                        ["time2"],
-                        self.parser_obj.ping_data_dict["pitch"][ch],
-                        self._varattrs["platform_var_default"]["pitch"],
-                    ),
-                    "roll": (
-                        ["time2"],
-                        self.parser_obj.ping_data_dict["roll"][ch],
-                        self._varattrs["platform_var_default"]["roll"],
-                    ),
-                    "vertical_offset": (
-                        ["time2"],
-                        self.parser_obj.ping_data_dict["heave"][ch],
-                        self._varattrs["platform_var_default"]["vertical_offset"],
-                    ),
-                    "water_level": (
-                        ["time3"],
-                        self.parser_obj.ping_data_dict["transducer_depth"][ch],
-                        self._varattrs["platform_var_default"]["water_level"],
-                    ),
                     "transducer_offset_x": (
                         [],
                         self.parser_obj.config_datagram["transceivers"][ch].get("pos_x", np.nan),
@@ -324,53 +351,10 @@ class SetGroupsEK60(SetGroupsBase):
                         self.parser_obj.config_datagram["transceivers"][ch].get("pos_z", np.nan),
                         self._varattrs["platform_var_default"]["transducer_offset_z"],
                     ),
-                    **{
-                        var: ([], np.nan, self._varattrs["platform_var_default"][var])
-                        for var in [
-                            "MRU_offset_x",
-                            "MRU_offset_y",
-                            "MRU_offset_z",
-                            "MRU_rotation_x",
-                            "MRU_rotation_y",
-                            "MRU_rotation_z",
-                            "position_offset_x",
-                            "position_offset_y",
-                            "position_offset_z",
-                        ]
-                    },
-                },
-                coords={
-                    "time2": (
-                        ["time2"],
-                        self.parser_obj.ping_time[ch],
-                        {
-                            "axis": "T",
-                            "long_name": "Timestamps for platform motion and orientation data",
-                            "standard_name": "time",
-                            "comment": "Time coordinate corresponding to platform motion and "
-                            "orientation data.",
-                        },
-                    ),
-                    "time3": (
-                        ["time3"],
-                        self.parser_obj.ping_time[ch],
-                        {
-                            "axis": "T",
-                            "long_name": "Timestamps for platform-related sampling environment",
-                            "standard_name": "time",
-                            "comment": "Time coordinate corresponding to platform-related "
-                            "sampling environment.",
-                        },
-                    ),
                 },
             )
-
             # Attach channel dimension/coordinate
             ds_tmp = ds_tmp.expand_dims({"channel": [self.sorted_channel[ch]]})
-            ds_tmp["channel"] = ds_tmp["channel"].assign_attrs(
-                self._varattrs["beam_coord_default"]["channel"]
-            )
-
             ds_tmp["frequency_nominal"] = (
                 ["channel"],
                 [self.parser_obj.config_datagram["transceivers"][ch]["frequency"]],
@@ -389,6 +373,9 @@ class SetGroupsEK60(SetGroupsBase):
         #  pitch/roll/heave are the same for all freq channels
         #  consider only saving those from the first channel
         ds_plat = xr.merge(ds_plat)
+        ds_plat["channel"] = ds_plat["channel"].assign_attrs(
+            self._varattrs["beam_coord_default"]["channel"]
+        )
 
         # Merge with NMEA data
         ds = xr.merge([ds, ds_plat], combine_attrs="override")

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -241,6 +241,11 @@ class SetGroupsEK60(SetGroupsBase):
         time1, msg_type, lat, lon = self._extract_NMEA_latlon()
 
         # NMEA dataset: variables filled with nan if do not exist
+        platform_dict = {
+            "platform_name": self.ui_param["platform_name"],
+            "platform_type": self.ui_param["platform_type"],
+            "platform_code_ICES": self.ui_param["platform_code_ICES"],
+        }
         ds = xr.Dataset(
             {
                 "latitude": (
@@ -253,7 +258,11 @@ class SetGroupsEK60(SetGroupsBase):
                     lon,
                     self._varattrs["platform_var_default"]["longitude"],
                 ),
-                "sentence_type": (["time1"], msg_type),
+                "sentence_type": (
+                    ["time1"],
+                    msg_type,
+                    self._varattrs["platform_var_default"]["sentence_type"],
+                ),
             },
             coords={
                 "time1": (
@@ -354,11 +363,6 @@ class SetGroupsEK60(SetGroupsBase):
                         },
                     ),
                 },
-                attrs={
-                    "platform_code_ICES": self.ui_param["platform_code_ICES"],
-                    "platform_name": self.ui_param["platform_name"],
-                    "platform_type": self.ui_param["platform_type"],
-                },
             )
 
             # Attach channel dimension/coordinate
@@ -388,6 +392,7 @@ class SetGroupsEK60(SetGroupsBase):
 
         # Merge with NMEA data
         ds = xr.merge([ds, ds_plat], combine_attrs="override")
+        ds = ds.assign_attrs(platform_dict)
 
         return set_time_encodings(ds)
 

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -318,18 +318,15 @@ class SetGroupsEK80(SetGroupsBase):
         time2 = np.array(time2) if time2 is not None else [np.nan]
 
         # Assemble variables into a dataset: variables filled with nan if do not exist
+        platform_dict = {
+            "platform_name": self.ui_param["platform_name"],
+            "platform_type": self.ui_param["platform_type"],
+            "platform_code_ICES": self.ui_param["platform_code_ICES"],
+        }
         ds = xr.Dataset(
             {
-                "frequency_nominal": (
-                    ["channel"],
-                    freq,
-                    {
-                        "units": "Hz",
-                        "long_name": "Transducer frequency",
-                        "valid_min": 0.0,
-                        "standard_name": "sound_frequency",
-                    },
-                ),
+                "latitude": (["time1"], lat, self._varattrs["platform_var_default"]["latitude"]),
+                "longitude": (["time1"], lon, self._varattrs["platform_var_default"]["longitude"]),
                 "pitch": (
                     ["time2"],
                     np.array(self.parser_obj.mru.get("pitch", [np.nan])),
@@ -345,9 +342,16 @@ class SetGroupsEK80(SetGroupsBase):
                     np.array(self.parser_obj.mru.get("heave", [np.nan])),
                     self._varattrs["platform_var_default"]["vertical_offset"],
                 ),
-                "latitude": (["time1"], lat, self._varattrs["platform_var_default"]["latitude"]),
-                "longitude": (["time1"], lon, self._varattrs["platform_var_default"]["longitude"]),
-                "sentence_type": (["time1"], msg_type),
+                "water_level": (
+                    ["time3"],
+                    [water_level],
+                    self._varattrs["platform_var_default"]["water_level"],
+                ),
+                "sentence_type": (
+                    ["time1"],
+                    msg_type,
+                    self._varattrs["platform_var_default"]["sentence_type"],
+                ),
                 "drop_keel_offset": (
                     ["time3"],
                     [self.parser_obj.environment["drop_keel_offset"]]
@@ -358,6 +362,12 @@ class SetGroupsEK80(SetGroupsBase):
                     ["time3"],
                     [self.parser_obj.environment["drop_keel_offset_is_manual"]]
                     if "drop_keel_offset_is_manual" in self.parser_obj.environment
+                    else [np.nan],
+                ),
+                "water_level_draft_is_manual": (
+                    ["time3"],
+                    [self.parser_obj.environment["water_level_draft_is_manual"]]
+                    if "water_level_draft_is_manual" in self.parser_obj.environment
                     else [np.nan],
                 ),
                 "transducer_offset_x": (
@@ -390,21 +400,6 @@ class SetGroupsEK80(SetGroupsBase):
                     ],
                     self._varattrs["platform_var_default"]["transducer_offset_z"],
                 ),
-                "water_level": (
-                    ["time3"],
-                    [water_level],
-                    {
-                        "long_name": "z-axis distance from the platform coordinate system "
-                        "origin to the sonar transducer",
-                        "units": "m",
-                    },
-                ),
-                "water_level_draft_is_manual": (
-                    ["time3"],
-                    [self.parser_obj.environment["water_level_draft_is_manual"]]
-                    if "water_level_draft_is_manual" in self.parser_obj.environment
-                    else [np.nan],
-                ),
                 **{
                     var: ([], np.nan, self._varattrs["platform_var_default"][var])
                     for var in [
@@ -419,12 +414,30 @@ class SetGroupsEK80(SetGroupsBase):
                         "position_offset_z",
                     ]
                 },
+                "frequency_nominal": (
+                    ["channel"],
+                    freq,
+                    {
+                        "units": "Hz",
+                        "long_name": "Transducer frequency",
+                        "valid_min": 0.0,
+                        "standard_name": "sound_frequency",
+                    },
+                ),
             },
             coords={
                 "channel": (
                     ["channel"],
                     self.sorted_channel["power_complex"],
                     self._varattrs["beam_coord_default"]["channel"],
+                ),
+                "time1": (
+                    ["time1"],
+                    time1,
+                    {
+                        **self._varattrs["platform_coord_default"]["time1"],
+                        "comment": "Time coordinate corresponding to NMEA position data.",
+                    },
                 ),
                 "time2": (
                     ["time2"],
@@ -451,22 +464,9 @@ class SetGroupsEK80(SetGroupsBase):
                         "the same as Environment.time1.",
                     },
                 ),
-                "time1": (
-                    ["time1"],
-                    time1,
-                    {
-                        **self._varattrs["platform_coord_default"]["time1"],
-                        "comment": "Time coordinate corresponding to NMEA position data.",
-                    },
-                ),
-            },
-            attrs={
-                "platform_code_ICES": self.ui_param["platform_code_ICES"],
-                "platform_name": self.ui_param["platform_name"],
-                "platform_type": self.ui_param["platform_type"],
-                # TODO: check what this 'drop_keel_offset' is
             },
         )
+        ds = ds.assign_attrs(platform_dict)
         return set_time_encodings(ds)
 
     def _assemble_ds_ping_invariant(self, params, data_type):

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -318,15 +318,16 @@ class SetGroupsEK80(SetGroupsBase):
         time2 = np.array(time2) if time2 is not None else [np.nan]
 
         # Assemble variables into a dataset: variables filled with nan if do not exist
-        platform_dict = {
-            "platform_name": self.ui_param["platform_name"],
-            "platform_type": self.ui_param["platform_type"],
-            "platform_code_ICES": self.ui_param["platform_code_ICES"],
-        }
+        platform_dict = {"platform_name": "", "platform_type": "", "platform_code_ICES": ""}
         ds = xr.Dataset(
             {
                 "latitude": (["time1"], lat, self._varattrs["platform_var_default"]["latitude"]),
                 "longitude": (["time1"], lon, self._varattrs["platform_var_default"]["longitude"]),
+                "sentence_type": (
+                    ["time1"],
+                    msg_type,
+                    self._varattrs["platform_var_default"]["sentence_type"],
+                ),
                 "pitch": (
                     ["time2"],
                     np.array(self.parser_obj.mru.get("pitch", [np.nan])),
@@ -343,32 +344,21 @@ class SetGroupsEK80(SetGroupsBase):
                     self._varattrs["platform_var_default"]["vertical_offset"],
                 ),
                 "water_level": (
-                    ["time3"],
-                    [water_level],
+                    [],
+                    water_level,
                     self._varattrs["platform_var_default"]["water_level"],
                 ),
-                "sentence_type": (
-                    ["time1"],
-                    msg_type,
-                    self._varattrs["platform_var_default"]["sentence_type"],
-                ),
                 "drop_keel_offset": (
-                    ["time3"],
-                    [self.parser_obj.environment["drop_keel_offset"]]
-                    if hasattr(self.parser_obj.environment, "drop_keel_offset")
-                    else [np.nan],
+                    [],
+                    self.parser_obj.environment.get("drop_keel_offset", np.nan),
                 ),
                 "drop_keel_offset_is_manual": (
-                    ["time3"],
-                    [self.parser_obj.environment["drop_keel_offset_is_manual"]]
-                    if "drop_keel_offset_is_manual" in self.parser_obj.environment
-                    else [np.nan],
+                    [],
+                    self.parser_obj.environment.get("drop_keel_offset_is_manual", np.nan),
                 ),
                 "water_level_draft_is_manual": (
-                    ["time3"],
-                    [self.parser_obj.environment["water_level_draft_is_manual"]]
-                    if "water_level_draft_is_manual" in self.parser_obj.environment
-                    else [np.nan],
+                    [],
+                    self.parser_obj.environment.get("water_level_draft_is_manual", np.nan),
                 ),
                 "transducer_offset_x": (
                     ["channel"],
@@ -448,20 +438,6 @@ class SetGroupsEK80(SetGroupsBase):
                         "standard_name": "time",
                         "comment": "Time coordinate corresponding to platform motion and "
                         "orientation data.",
-                    },
-                ),
-                "time3": (
-                    ["time3"],
-                    [self.parser_obj.environment["timestamp"]]
-                    if "timestamp" in self.parser_obj.environment
-                    else np.datetime64("NaT"),
-                    {
-                        "axis": "T",
-                        "long_name": "Timestamps for platform-related sampling environment",
-                        "standard_name": "time",
-                        "comment": "Time coordinate corresponding to platform-related "
-                        "sampling environment. Note that Platform.time3 is "
-                        "the same as Environment.time1.",
                     },
                 ),
             },

--- a/echopype/echodata/convention/1.0.yml
+++ b/echopype/echodata/convention/1.0.yml
@@ -141,8 +141,10 @@ variable_and_varattributes:
       long_name: z-axis distance from the platform coordinate system origin to the sonar transducer
       units: m
     vertical_offset:
-      long_name: Platform vertical offset from nominal
+      long_name: Platform vertical offset from nominal water level
       units: m
     water_level:
-      long_name: z-axis distance from the platform coordinate system origin to the sonar transducer
+      long_name: Distance from the platform coordinate system origin to the nominal water level along the z-axis
       units: m
+    sentence_type:
+      long_name: NMEA sentence type

--- a/echopype/tests/convert/test_convert_azfp.py
+++ b/echopype/tests/convert/test_convert_azfp.py
@@ -16,7 +16,7 @@ import pytest
 def azfp_path(test_path):
     return test_path["AZFP"]
 
-def check_platform_required_vars(echodata):
+def check_platform_required_scalar_vars(echodata):
     # check convention-required variables in the Platform group
     for var in [
         "MRU_offset_x",
@@ -28,11 +28,6 @@ def check_platform_required_vars(echodata):
         "position_offset_x",
         "position_offset_y",
         "position_offset_z",
-        "transducer_offset_x",
-        "transducer_offset_y",
-        "transducer_offset_z",
-        "vertical_offset",
-        "water_level",
     ]:
         assert var in echodata["Platform"]
         assert np.isnan(echodata["Platform"][var])
@@ -95,7 +90,7 @@ def test_convert_azfp_01a_matlab_raw(azfp_path):
     )
 
     # check convention-required variables in the Platform group
-    check_platform_required_vars(echodata)
+    check_platform_required_scalar_vars(echodata)
 
 
 def test_convert_azfp_01a_matlab_derived():
@@ -106,7 +101,7 @@ def test_convert_azfp_01a_matlab_derived():
     #  - derived temperature
 
     # # check convention-required variables in the Platform group
-    # check_platform_required_vars(echodata)
+    # check_platform_required_scalar_vars(echodata)
 
     pytest.xfail("Tests for converting AZFP and comparing it"
                  + " against Matlab derived data have not been implemented yet.")
@@ -136,7 +131,7 @@ def test_convert_azfp_01a_raw_echoview(azfp_path):
     assert np.array_equal(test_power, echodata["Sonar/Beam_group1"].backscatter_r.isel(beam=0).drop_vars('beam')) # noqa
 
     # check convention-required variables in the Platform group
-    check_platform_required_vars(echodata)
+    check_platform_required_scalar_vars(echodata)
 
 
 def test_convert_azfp_01a_different_ranges(azfp_path):
@@ -156,7 +151,7 @@ def test_convert_azfp_01a_different_ranges(azfp_path):
     ).shape == (360, 135, 1)
 
     # check convention-required variables in the Platform group
-    check_platform_required_vars(echodata)
+    check_platform_required_scalar_vars(echodata)
 
 
 def test_convert_azfp_01a_notemperature_notilt(azfp_path):

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -58,23 +58,23 @@ def check_env_xml(echodata):
     assert "sound_velocity_profile_depth"
     assert np.array_equal(echodata["Environment"]["sound_velocity_profile_depth"], [1, 1000])
 
-    # check plat vars
+    # check a subset of plat vars
     plat_vars = {
-        "drop_keel_offset": [np.nan],
+        "drop_keel_offset": [np.nan, 0, 7.5],
         "drop_keel_offset_is_manual": [0, 1],
         "water_level": [0],
         "water_level_draft_is_manual": [0, 1]
     }
     for plat_var, expected_plat_var_values in plat_vars.items():
         assert plat_var in echodata["Platform"]
-        assert echodata["Platform"][plat_var].dims == ("time3",)
         if np.isnan(expected_plat_var_values).all():
             assert np.isnan(echodata["Platform"][plat_var]).all()
         else:
-            assert all([env_var_value in expected_plat_var_values for env_var_value in echodata["Platform"][plat_var]])
+            assert echodata["Platform"][plat_var] in expected_plat_var_values
 
     # check plat dims
-    assert "time3" in echodata["Platform"]
+    assert "time1" in echodata["Platform"]
+    assert "time2" in echodata["Platform"]
 
 
 def test_convert(ek80_new_file, dump_output_dir):

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -58,7 +58,9 @@ def check_env_xml(echodata):
     assert "sound_velocity_profile_depth"
     assert np.array_equal(echodata["Environment"]["sound_velocity_profile_depth"], [1, 1000])
 
-    # check a subset of plat vars
+    # check a subset of platform variables. plat_vars specifies a list of possible, expected scalar values 
+    # for each variable. The variables from the EchoData object are tested against this dictionary
+    # to verify their presence and their scalar values
     plat_vars = {
         "drop_keel_offset": [np.nan, 0, 7.5],
         "drop_keel_offset_is_manual": [0, 1],


### PR DESCRIPTION
I went through the behavior of each sensor type (EK60, EK80, AZFP) during conversion (`open_raw`) for the `Platform` group. There were a number of inconsistencies, some of which have been mentioned before in #740 and #1003. This PR also broadly addresses #1051, or creates a more consistent starting point for `update_platform`.

I've addressed most of the inconsistencies:

- AZFP now produces largely the same set of variables as the other two sensors, though most of them are empty (nan). The exceptions are `sentence_type`, a non-convention variable found in EK60 and EK80; and `tilt_x` and `tilt_y`, non-convention variables only used with AZFP.
- Modified the dimensionality of several variables in AZFP to match that in EK80.
- Fixed some incorrect or missing `long_name` attributes, either through edits to `convention/1.0.yml` or via code changes.
- Fixed an issue with EK60 where the global `platform_*` attributes were being dropped after initial inclusion.

I also made some cosmetic edits to all three sensor types to use similar code patterns and order of variables and coordinates, to improve clarity and consistency across sensors.

I ran manual tests but didn't run the test suite locally. If the CI exposes some new errors resulting from these changes, I'll update the PR.

Some open areas for improvement (but possibly not for 0.7.2):
- In EK80, several variables are being populated with 0.0 where I suspect they should be Nan. I think this is happening in the parser code, but I only focused on the `set_group_*` modules.
- EK60 adds the `channel` dimension to a number of variables for which EK80 doesn't, and EK80 adheres more closely to the convention with respect to variable dimensionality. I think the presence of the extra channel dimension is a mistake, but wanted to first double check with @leewujung before removing that dimension.
- The convention specifies that `water_level` is a scalar and does not have a time dimension; time variability is found in `vertical_offset` instead, which in a ship corresponds to heave. But we've been assigning a `time3` dimension to `water_level`.
- More broadly, it looks like the convention doesn't *require* the creation of *empty* (all Nan) variables when their "obligation" flag is not "Mandatory" (M). See this [protracted discussion](https://github.com/ices-publications/SONAR-netCDF4/issues/26) and [my own recent question at the end](https://github.com/ices-publications/SONAR-netCDF4/issues/26#issuecomment-1555397003). It'll be up to us to decide whether to adopt a general practice for these cases. For reference, *none* of the variables in the Platform group are "Mandatory"!