### PR TITLE
Handling problematic NMEA messages when setting lat/lon in Platform group

### DIFF
--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -1,6 +1,6 @@
 import abc
-from typing import List, Set, Tuple
 import warnings
+from typing import List, Set, Tuple
 
 import dask.array
 import numpy as np

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -1,5 +1,6 @@
 import abc
 from typing import List, Set, Tuple
+import warnings
 
 import dask.array
 import numpy as np
@@ -179,11 +180,19 @@ class SetGroupsBase(abc.ABC):
         for x in nmea_msg:
             try:
                 lat.append(x.latitude if hasattr(x, "latitude") else np.nan)
-            except:
+            except ValueError as ve:
+                warnings.warn(
+                    "At least one latitude entry is problematic and "
+                    f"are assigned None in the converted data: {str(ve)}"
+                )
                 lat.append(np.nan)
             try:
                 lon.append(x.longitude if hasattr(x, "longitude") else np.nan)
-            except:
+            except ValueError as ve:
+                warnings.warn(
+                    f"At least one longitude entry is problematic and "
+                    f"are assigned None in the converted data: {str(ve)}"
+                )
                 lon.append(np.nan)
         msg_type = (
             np.array([x.sentence_type if hasattr(x, "sentence_type") else np.nan for x in nmea_msg])

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -176,24 +176,27 @@ class SetGroupsBase(abc.ABC):
                 pynmea2.ParseError,
             ):
                 nmea_msg.append(None)
-        lat, lon = [], []
-        for x in nmea_msg:
-            try:
-                lat.append(x.latitude if hasattr(x, "latitude") else np.nan)
-            except ValueError as ve:
-                warnings.warn(
-                    "At least one latitude entry is problematic and "
-                    f"are assigned None in the converted data: {str(ve)}"
-                )
-                lat.append(np.nan)
-            try:
-                lon.append(x.longitude if hasattr(x, "longitude") else np.nan)
-            except ValueError as ve:
-                warnings.warn(
-                    f"At least one longitude entry is problematic and "
-                    f"are assigned None in the converted data: {str(ve)}"
-                )
-                lon.append(np.nan)
+        if nmea_msg:
+            lat, lon = [], []
+            for x in nmea_msg:
+                try:
+                    lat.append(x.latitude if hasattr(x, "latitude") else np.nan)
+                except ValueError as ve:
+                    lat.append(np.nan)
+                    warnings.warn(
+                        "At least one latitude entry is problematic and "
+                        f"are assigned None in the converted data: {str(ve)}"
+                    )
+                try:
+                    lon.append(x.longitude if hasattr(x, "longitude") else np.nan)
+                except ValueError as ve:
+                    lon.append(np.nan)
+                    warnings.warn(
+                        f"At least one longitude entry is problematic and "
+                        f"are assigned None in the converted data: {str(ve)}"
+                    )
+        else:
+            lat, lon = [np.nan], [np.nan]
         msg_type = (
             np.array([x.sentence_type if hasattr(x, "sentence_type") else np.nan for x in nmea_msg])
             if nmea_msg

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -198,7 +198,7 @@ class SetGroupsBase(abc.ABC):
         else:
             lat, lon = [np.nan], [np.nan]
         msg_type = (
-            np.array([x.sentence_type if hasattr(x, "sentence_type") else np.nan for x in nmea_msg])
+            [x.sentence_type if hasattr(x, "sentence_type") else np.nan for x in nmea_msg]
             if nmea_msg
             else [np.nan]
         )

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -175,16 +175,16 @@ class SetGroupsBase(abc.ABC):
                 pynmea2.ParseError,
             ):
                 nmea_msg.append(None)
-        lat = (
-            np.array([x.latitude if hasattr(x, "latitude") else np.nan for x in nmea_msg])
-            if nmea_msg
-            else [np.nan]
-        )
-        lon = (
-            np.array([x.longitude if hasattr(x, "longitude") else np.nan for x in nmea_msg])
-            if nmea_msg
-            else [np.nan]
-        )
+        lat, lon = [], []
+        for x in nmea_msg:
+            try:
+                lat.append(x.latitude if hasattr(x, "latitude") else np.nan)
+            except:
+                lat.append(np.nan)
+            try:
+                lon.append(x.longitude if hasattr(x, "longitude") else np.nan)
+            except:
+                lon.append(np.nan)
         msg_type = (
             np.array([x.sentence_type if hasattr(x, "sentence_type") else np.nan for x in nmea_msg])
             if nmea_msg


### PR DESCRIPTION
We just encountered a few files that contain problematic NMEA strings in the GPS lat/lon messages. This PR adds error handling and set those entries to NaN. The ill-formed NMEA messages look like below:

<img width="247" alt="Screenshot 2023-06-23 at 6 47 40 PM" src="https://github.com/OSOceanAcoustics/echopype/assets/15334215/aa9fcfee-190e-4034-a81d-7dda74c9746c">

