### PR TITLE
Fix call to register EK500 colormap

### DIFF
--- a/echopype/visualize/cm.py
+++ b/echopype/visualize/cm.py
@@ -68,7 +68,7 @@ for cmapname in cmapnames:
 
     if 'over' in colors_d:
         reg_map.set_over(colors_d['over'])
-    mpl.cm.register_cmap(cmap=reg_map)
+    mpl.colormaps.register(cmap=reg_map)
 
     # Register the reversed map
     reg_map_r = mpl.colors.ListedColormap(
@@ -79,7 +79,7 @@ for cmapname in cmapnames:
 
     if 'over' in colors_d:
         reg_map_r.set_under(colors_d['over'])
-    mpl.cm.register_cmap(cmap=reg_map_r)
+    mpl.colormaps.register(cmap=reg_map_r)
 
 # make colormaps available to call
 locals().update(cmap_d)

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,5 +35,5 @@ setup_requires =
 
 [options.extras_require]
 plot =
-    matplotlib
+    matplotlib>=3.7
     cmocean


### PR DESCRIPTION
This PR fixes the call to register the EK500 colormap per the recent deprecation warning:
> The register_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps.register(name)`` instead.