### PR TITLE
Fix object dtype and cast to string

### DIFF
--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -14,7 +14,7 @@ from zarr.errors import GroupNotFoundError, PathNotFoundError
 if TYPE_CHECKING:
     from ..core import EngineHint, FileFormatHint, PathHint, SonarModelsHint
 
-from ..utils.coding import set_time_encodings
+from ..utils.coding import sanitize_dtypes, set_time_encodings
 from ..utils.io import check_file_existence, sanitize_file_path
 from ..utils.log import _init_logger
 from ..utils.prov import add_processing_level
@@ -218,7 +218,8 @@ class EchoData:
     @staticmethod
     def __get_dataset(node: DataTree) -> Optional[xr.Dataset]:
         if node.has_data or node.has_attrs:
-            return node.ds
+            # validate and clean dtypes
+            return sanitize_dtypes(node.ds)
         return None
 
     def __get_node(self, key: Optional[str]) -> DataTree:

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -38,7 +38,11 @@ DEFAULT_ENCODINGS = {
 }
 
 
-EXPECTED_VAR_DTYPE = {"channel": np.str_, "cal_channel_id": np.str_, "beam": np.str_}  # channel name  # beam name
+EXPECTED_VAR_DTYPE = {
+    "channel": np.str_,
+    "cal_channel_id": np.str_,
+    "beam": np.str_,
+}  # channel name  # beam name
 
 PREFERRED_CHUNKS = "preferred_chunks"
 

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -54,8 +54,6 @@ def sanitize_dtypes(ds: xr.Dataset) -> xr.Dataset:
 
     if isinstance(ds, xr.Dataset):
         for name, var in ds.variables.items():
-            if np.issubdtype(var.dtype, np.object_):
-                print(f"{name}: dtype {var.dtype}")
             if name in EXPECTED_VAR_DTYPE:
                 expected_dtype = EXPECTED_VAR_DTYPE[name]
             elif np.issubdtype(var.dtype, np.object_):

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -52,8 +52,15 @@ def sanitize_dtypes(ds: xr.Dataset) -> xr.Dataset:
         for name, var in ds.variables.items():
             if name in EXPECTED_VAR_DTYPE:
                 expected_dtype = EXPECTED_VAR_DTYPE[name]
-                if not np.issubdtype(var.dtype, expected_dtype):
-                    ds[name] = var.astype(expected_dtype)
+            elif np.issubdtype(var.dtype, np.object_):
+                # Defaulting to strings dtype for object data types
+                expected_dtype = np.str_
+            else:
+                # For everything else, this should be the same
+                expected_dtype = var.dtype
+
+            if not np.issubdtype(var.dtype, expected_dtype):
+                ds[name] = var.astype(expected_dtype)
     return ds
 
 

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -38,7 +38,7 @@ DEFAULT_ENCODINGS = {
 }
 
 
-EXPECTED_VAR_DTYPE = {"channel": np.str_, "beam": np.str_}  # channel name  # beam name
+EXPECTED_VAR_DTYPE = {"channel": np.str_, "cal_channel_id": np.str_, "beam": np.str_}  # channel name  # beam name
 
 PREFERRED_CHUNKS = "preferred_chunks"
 
@@ -50,6 +50,8 @@ def sanitize_dtypes(ds: xr.Dataset) -> xr.Dataset:
 
     if isinstance(ds, xr.Dataset):
         for name, var in ds.variables.items():
+            if np.issubdtype(var.dtype, np.object_):
+                print(f"{name}: dtype {var.dtype}")
             if name in EXPECTED_VAR_DTYPE:
                 expected_dtype = EXPECTED_VAR_DTYPE[name]
             elif np.issubdtype(var.dtype, np.object_):

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -13,7 +13,7 @@ import xarray as xr
 from fsspec import FSMap
 from fsspec.implementations.local import LocalFileSystem
 
-from ..utils.coding import sanitize_dtypes, set_storage_encodings
+from ..utils.coding import set_storage_encodings
 from ..utils.log import _init_logger
 
 if TYPE_CHECKING:
@@ -51,8 +51,6 @@ def save_file(ds, path, mode, engine, group=None, compression_settings=None, **k
     If ``compression_settings`` are set, compress all variables with those settings
     """
 
-    # validate and fix dtype
-    ds = sanitize_dtypes(ds)
     # set zarr or netcdf specific encodings for each variable in ds
     encoding = set_storage_encodings(ds, compression_settings, engine)
 


### PR DESCRIPTION
## Overview

This PR fixes issues with some variable being an `object` data type, which caused issues during file writing. This PR defaults the `object` data type to be casted to string.