### PR TITLE
Move some Vendor-specific group attributes to data variables

### DIFF
--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -473,18 +473,26 @@ class SetGroupsAZFP(SetGroupsBase):
                 # parameters with channel dimension from XML file
                 "XML_transmit_duration_nominal": (["channel"], tdn),  # tdn comes from parameters
                 "XML_gain_correction": (["channel"], parameters["gain"][self.freq_ind_sorted]),
-                "XML_digitization_rate": (["channel"], parameters["dig_rate"][self.freq_ind_sorted]),  # noqa
-                "XML_lockout_index": (["channel"], parameters["lockout_index"][self.freq_ind_sorted]),  # noqa
+                "XML_digitization_rate": (
+                    ["channel"],
+                    parameters["dig_rate"][self.freq_ind_sorted],
+                ),  # noqa
+                "XML_lockout_index": (
+                    ["channel"],
+                    parameters["lockout_index"][self.freq_ind_sorted],
+                ),  # noqa
                 "DS": (["channel"], parameters["DS"][self.freq_ind_sorted]),
                 "EL": (["channel"], parameters["EL"][self.freq_ind_sorted]),
                 "TVR": (["channel"], parameters["TVR"][self.freq_ind_sorted]),
                 "VTX": (["channel"], parameters["VTX"][self.freq_ind_sorted]),
                 "Sv_offset": (["channel"], Sv_offset),
                 "number_of_samples_digitized_per_pings": (
-                    ["channel"], parameters["range_samples"][self.freq_ind_sorted],  # noqa
+                    ["channel"],
+                    parameters["range_samples"][self.freq_ind_sorted],  # noqa
                 ),
                 "number_of_digitized_samples_averaged_per_pings": (
-                    ["channel"], parameters["range_averaging_samples"][self.freq_ind_sorted],  # noqa
+                    ["channel"],
+                    parameters["range_averaging_samples"][self.freq_ind_sorted],  # noqa
                 ),
                 # parameters with dim len=0 from XML file
                 "XML_sensors_flag": parameters["sensors_flag"],

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -476,11 +476,11 @@ class SetGroupsAZFP(SetGroupsBase):
                 "XML_digitization_rate": (
                     ["channel"],
                     parameters["dig_rate"][self.freq_ind_sorted],
-                ),  # noqa
+                )
                 "XML_lockout_index": (
                     ["channel"],
                     parameters["lockout_index"][self.freq_ind_sorted],
-                ),  # noqa
+                )
                 "DS": (["channel"], parameters["DS"][self.freq_ind_sorted]),
                 "EL": (["channel"], parameters["EL"][self.freq_ind_sorted]),
                 "TVR": (["channel"], parameters["TVR"][self.freq_ind_sorted]),
@@ -488,11 +488,11 @@ class SetGroupsAZFP(SetGroupsBase):
                 "Sv_offset": (["channel"], Sv_offset),
                 "number_of_samples_digitized_per_pings": (
                     ["channel"],
-                    parameters["range_samples"][self.freq_ind_sorted],  # noqa
+                    parameters["range_samples"][self.freq_ind_sorted],
                 ),
                 "number_of_digitized_samples_averaged_per_pings": (
                     ["channel"],
-                    parameters["range_averaging_samples"][self.freq_ind_sorted],  # noqa
+                    parameters["range_averaging_samples"][self.freq_ind_sorted],
                 ),
                 # parameters with dim len=0 from XML file
                 "XML_sensors_flag": parameters["sensors_flag"],

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -476,11 +476,11 @@ class SetGroupsAZFP(SetGroupsBase):
                 "XML_digitization_rate": (
                     ["channel"],
                     parameters["dig_rate"][self.freq_ind_sorted],
-                )
+                ),
                 "XML_lockout_index": (
                     ["channel"],
                     parameters["lockout_index"][self.freq_ind_sorted],
-                )
+                ),
                 "DS": (["channel"], parameters["DS"][self.freq_ind_sorted]),
                 "EL": (["channel"], parameters["EL"][self.freq_ind_sorted]),
                 "TVR": (["channel"], parameters["TVR"][self.freq_ind_sorted]),

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -424,16 +424,7 @@ class SetGroupsAZFP(SetGroupsBase):
                         "standard_name": "sound_frequency",
                     },
                 ),
-                "XML_transmit_duration_nominal": (["channel"], tdn),
-                "XML_gain_correction": (["channel"], parameters["gain"][self.freq_ind_sorted]),
-                "XML_digitization_rate": (
-                    ["channel"],
-                    parameters["dig_rate"][self.freq_ind_sorted],
-                ),
-                "XML_lockout_index": (
-                    ["channel"],
-                    parameters["lockout_index"][self.freq_ind_sorted],
-                ),
+                # unpacked ping by ping data from 01A file
                 "digitization_rate": (["channel"], unpacked_data["dig_rate"][self.freq_ind_sorted]),
                 "lockout_index": (
                     ["channel"],
@@ -466,22 +457,58 @@ class SetGroupsAZFP(SetGroupsBase):
                 "battery_main": (["ping_time"], unpacked_data["battery_main"]),
                 "battery_tx": (["ping_time"], unpacked_data["battery_tx"]),
                 "profile_number": (["ping_time"], unpacked_data["profile_number"]),
+                # unpacked ping by ping ancillary data from 01A file
                 "temperature_counts": (["ping_time"], anc[:, 4]),
                 "tilt_x_count": (["ping_time"], anc[:, 0]),
                 "tilt_y_count": (["ping_time"], anc[:, 1]),
+                # unpacked data with dim len=0 from 01A file
+                "profile_flag": unpacked_data["profile_flag"],
+                "burst_interval": unpacked_data["burst_int"],
+                "ping_per_profile": unpacked_data["ping_per_profile"],
+                "average_pings_flag": unpacked_data["avg_pings"],
+                "spare_channel": unpacked_data["spare_chan"],
+                "ping_period": unpacked_data["ping_period"],
+                "phase": unpacked_data["phase"],
+                "number_of_channels": unpacked_data["num_chan"],
+                # parameters with channel dimension from XML file
+                "XML_transmit_duration_nominal": (["channel"], tdn),  # tdn comes from parameters
+                "XML_gain_correction": (["channel"], parameters["gain"][self.freq_ind_sorted]),
+                "XML_digitization_rate": (["channel"], parameters["dig_rate"][self.freq_ind_sorted]),  # noqa
+                "XML_lockout_index": (["channel"], parameters["lockout_index"][self.freq_ind_sorted]),  # noqa
                 "DS": (["channel"], parameters["DS"][self.freq_ind_sorted]),
                 "EL": (["channel"], parameters["EL"][self.freq_ind_sorted]),
                 "TVR": (["channel"], parameters["TVR"][self.freq_ind_sorted]),
                 "VTX": (["channel"], parameters["VTX"][self.freq_ind_sorted]),
                 "Sv_offset": (["channel"], Sv_offset),
                 "number_of_samples_digitized_per_pings": (
-                    ["channel"],
-                    parameters["range_samples"][self.freq_ind_sorted],
+                    ["channel"], parameters["range_samples"][self.freq_ind_sorted],  # noqa
                 ),
                 "number_of_digitized_samples_averaged_per_pings": (
-                    ["channel"],
-                    parameters["range_averaging_samples"][self.freq_ind_sorted],
+                    ["channel"], parameters["range_averaging_samples"][self.freq_ind_sorted],  # noqa
                 ),
+                # parameters with dim len=0 from XML file
+                "XML_sensors_flag": parameters["sensors_flag"],
+                "XML_burst_interval": parameters["burst_interval"],
+                "XML_sonar_serial_number": parameters["serial_number"],
+                "number_of_frequency": parameters["num_freq"],
+                "number_of_pings_per_burst": parameters["pings_per_burst"],
+                "average_burst_pings_flag": parameters["average_burst_pings"],
+                # temperature coefficients from XML file
+                "temperature_ka": parameters["ka"],
+                "temperature_kb": parameters["kb"],
+                "temperature_kc": parameters["kc"],
+                "temperature_A": parameters["A"],
+                "temperature_B": parameters["B"],
+                "temperature_C": parameters["C"],
+                # tilt coefficients from XML file
+                "tilt_X_a": parameters["X_a"],
+                "tilt_X_b": parameters["X_b"],
+                "tilt_X_c": parameters["X_c"],
+                "tilt_X_d": parameters["X_d"],
+                "tilt_Y_a": parameters["Y_a"],
+                "tilt_Y_b": parameters["Y_b"],
+                "tilt_Y_c": parameters["Y_c"],
+                "tilt_Y_d": parameters["Y_d"],
             },
             coords={
                 "channel": (
@@ -503,38 +530,6 @@ class SetGroupsAZFP(SetGroupsBase):
                     list(range(len(unpacked_data["ancillary"][0]))),
                 ),
                 "ad_len": (["ad_len"], list(range(len(unpacked_data["ad"][0])))),
-            },
-            attrs={
-                "XML_sensors_flag": parameters["sensors_flag"],
-                "XML_burst_interval": parameters["burst_interval"],
-                "XML_sonar_serial_number": parameters["serial_number"],
-                "profile_flag": unpacked_data["profile_flag"],
-                "burst_interval": unpacked_data["burst_int"],
-                "ping_per_profile": unpacked_data["ping_per_profile"],
-                "average_pings_flag": unpacked_data["avg_pings"],
-                "spare_channel": unpacked_data["spare_chan"],
-                "ping_period": unpacked_data["ping_period"],
-                "phase": unpacked_data["phase"],
-                "number_of_channels": unpacked_data["num_chan"],
-                "number_of_frequency": parameters["num_freq"],
-                "number_of_pings_per_burst": parameters["pings_per_burst"],
-                "average_burst_pings_flag": parameters["average_burst_pings"],
-                # Temperature coefficients
-                "temperature_ka": parameters["ka"],
-                "temperature_kb": parameters["kb"],
-                "temperature_kc": parameters["kc"],
-                "temperature_A": parameters["A"],
-                "temperature_B": parameters["B"],
-                "temperature_C": parameters["C"],
-                # Tilt coefficients
-                "tilt_X_a": parameters["X_a"],
-                "tilt_X_b": parameters["X_b"],
-                "tilt_X_c": parameters["X_c"],
-                "tilt_X_d": parameters["X_d"],
-                "tilt_Y_a": parameters["Y_a"],
-                "tilt_Y_b": parameters["Y_b"],
-                "tilt_Y_c": parameters["Y_c"],
-                "tilt_Y_d": parameters["Y_d"],
             },
         )
         return set_time_encodings(ds)

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -1338,7 +1338,7 @@ class SetGroupsEK80(SetGroupsBase):
         ds = ds.pipe(self._add_filter_params, coeffs_and_decimation)
 
         # Save the entire config XML in vendor group in case of info loss
-        ds.attrs["config_xml"] = self.parser_obj.config_datagram["xml"]
+        ds["config_xml"] = self.parser_obj.config_datagram["xml"]
 
         return ds
 


### PR DESCRIPTION
This PR moves some Vendor-specific group attributes to data variables to make it more efficient to lazy-load and combine echodata objects, and potentially on the writing speed to cloud. This addresses #1055 and potentially #640 (AZFP) and #1045 (though the goal changed, EK80).

The changes include:
- EK80: move `xml_config` which is the entire XML string from an attribute to a data variable
- AZFP: move all Vendor-specific group attributes to data variables
  - some of these variables come from the XML associated with the 01A file
  - some of these variables come from the unpacked ping by ping data
  - a common feature of these variables is that they are *not* time-varying (which is probably why we saved them as attributes in the first place)

I've tested `combine_echodata` with the new format and these are combined correctly -- that all these variables remain data variables without a dimension (constants). The combine would error out if any of these variables change across the echodata objects to be combined, which is the desired behavior since those echodata objects should not be combined.