### PR TITLE
Remove `preprocess` from subpackages to test in run-test [all tests ci]

### DIFF
--- a/.ci_helpers/run-test.py
+++ b/.ci_helpers/run-test.py
@@ -33,7 +33,6 @@ MODULES_TO_TEST = {
     "echodata": {},
     "mask": {},
     "metrics": {},
-    "preprocess": {},
     "utils": {},
     "visualize": {},
 }


### PR DESCRIPTION
See #1076.