### PR TITLE
Remove Pandas<2 pinning [all tests ci]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@ pynmea2
 pytz
 scipy
 xarray
-# https://github.com/pydata/xarray/pull/7650
-pandas<2
+pandas
 zarr
 fsspec
 s3fs


### PR DESCRIPTION
We pinned Pandas to <2 (PR #1027) due to xarray not supporting Pandas 2 at the time. But that xarray limitation was removed in April (see https://github.com/pydata/xarray/pull/7785, https://github.com/pydata/xarray/pull/7650).