### PR TITLE
Drop artificially created `ping_time` dimension

### DIFF
--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -364,6 +364,8 @@ class CalibrateEK80(CalibrateEK):
 
                 # Assemble parameter data array with all channels
                 # Either interpolate or pull from narrowband input
+                # The ping_time dimension has to persist for BB case,
+                # because center frequency may change across ping
                 if "ping_time" in cal_params_dict[p].coords:
                     ds_cal_BB[p] = _get_interp_da(
                         da_param=ds_cal_BB[p],  # freq-dep xr.DataArray

--- a/echopype/calibrate/ek80_complex.py
+++ b/echopype/calibrate/ek80_complex.py
@@ -288,9 +288,7 @@ def compress_pulse(backscatter: xr.DataArray, chirp: Dict) -> xr.DataArray:
     for chan in backscatter["channel"]:
         backscatter_chan = (
             backscatter.sel(channel=chan)
-            # .dropna(dim="range_sample", how="all")
             .dropna(dim="beam", how="all")
-            # .dropna(dim="ping_time")
         )
 
         tx = chirp[str(chan.values)]

--- a/echopype/consolidate/split_beam_angle.py
+++ b/echopype/consolidate/split_beam_angle.py
@@ -213,7 +213,7 @@ def get_angle_complex_samples(
                 bs=bs.sel(channel=ch_id),
                 # beam_type is not time-varying
                 beam_type=(
-                    ds_beam["beam_type"].sel(channel=ch_id).isel(ping_time=0).drop("ping_time")
+                    ds_beam["beam_type"].sel(channel=ch_id)
                 ),
                 sens=[
                     angle_params["angle_sensitivity_alongship"].sel(channel=ch_id),

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -22,11 +22,11 @@ class SetGroupsAZFP(SetGroupsBase):
     beam_only_names = set()
 
     # Variables that need only the ping_time dimension added to them.
+    # These variables do not change in typical AZFP use cases,
+    # but we keep them here for consistency with EK60/EK80 EchoData formats
     ping_time_only_names = {
         "sample_interval",
         "transmit_duration_nominal",
-        "equivalent_beam_angle",
-        "gain_correction",
     }
 
     # Variables that need beam and ping_time dimensions added to them.

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -29,23 +29,14 @@ class SetGroupsEK60(SetGroupsBase):
     # the SONAR-netCDF4 v1 convention. For the time being, we are retaining the
     # infrastructure that adds this dimension, but updating the variables lists.
 
+    # 2023-07-21 note: We are also removing the ping_time dimension for parameters
+    # that do not change across ping.
+
     # Variables that need only the beam dimension added to them.
     beam_only_names = set()
 
     # Variables that need only the ping_time dimension added to them.
-    ping_time_only_names = {
-        "beam_direction_x",
-        "beam_direction_y",
-        "beam_direction_z",
-        "beamwidth_twoway_alongship",
-        "beamwidth_twoway_athwartship",
-        "angle_offset_alongship",
-        "angle_offset_athwartship",
-        "angle_sensitivity_alongship",
-        "angle_sensitivity_athwartship",
-        "equivalent_beam_angle",
-        "gain_correction",
-    }
+    ping_time_only_names = set()
 
     # Variables that need beam and ping_time dimensions added to them.
     beam_ping_time_names = set()

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -30,19 +30,7 @@ class SetGroupsEK80(SetGroupsBase):
     beam_only_names = set()
 
     # Variables that need only the ping_time dimension added to them.
-    ping_time_only_names = {
-        "beam_type",
-        "beam_direction_x",
-        "beam_direction_y",
-        "beam_direction_z",
-        "angle_offset_alongship",
-        "angle_offset_athwartship",
-        "angle_sensitivity_alongship",
-        "angle_sensitivity_athwartship",
-        "equivalent_beam_angle",
-        "beamwidth_twoway_alongship",
-        "beamwidth_twoway_athwartship",
-    }
+    ping_time_only_names = set()
 
     # Variables that need beam and ping_time dimensions added to them.
     beam_ping_time_names = set()

--- a/echopype/tests/calibrate/test_cal_params_integration.py
+++ b/echopype/tests/calibrate/test_cal_params_integration.py
@@ -79,6 +79,8 @@ def test_cal_params_intake_EK60(ek60_path):
     cal_obj = ep.calibrate.calibrate_ek.CalibrateEK60(echodata=ed, env_params=None, cal_params=None, ecs_file=None)
 
     # Check cal params ingested from both ways
+    # Need to drop ping_time for cal_obj.cal_params since get_vend_cal_params_power are related to
+    # transmit_duration_nominal, which can vary cross ping_time 
     assert cal_obj.cal_params["gain_correction"].isel(ping_time=0).drop("ping_time").identical(cal_params_manual["gain_correction"])
 
     # Check against the final cal params in the calibration output
@@ -179,6 +181,8 @@ def test_cal_params_intake_EK80_CW_complex(ek80_cal_path):
     )
 
     # Check cal params ingested from both ways
+    # Need to drop ping_time for cal_obj.cal_params since get_vend_cal_params_power are related to
+    # transmit_duration_nominal, which can vary cross ping_time 
     assert cal_obj.cal_params["gain_correction"].isel(ping_time=0).drop("ping_time").identical(cal_params_manual["gain_correction"])
 
     # Check against the final cal params in the calibration output


### PR DESCRIPTION
This PR addresses #1057 by removing `ping_time` dimension artificially added to some variables in `set_groups_*`.

The PR also adds comments on sections of test functions where explicit `ping_time` dim drop is required.