### PR TITLE
Add `mamba` recommendation into docs

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -79,7 +79,7 @@ environment for echopype development
 .. attention::
     We recommend using the ``libmamba`` solver instead of the classic solver,
     since the ``conda create`` and ``conda install`` step could take very long or fail.
-    See `instructions here <https://conda.github.io/conda-libmamba-solver/getting-started/>`_
+    See instructions `here <https://conda.github.io/conda-libmamba-solver/getting-started/>`_
     for installation and usage.
 
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -72,12 +72,20 @@ then set the source repository as the ``upstream`` git remote:
     cd echopype
     git remote add upstream https://github.com/OSOceanAcoustics/echopype.git
 
-Create a `conda <https://docs.conda.io>`_ environment for echopype development
-(replace the Python version with your preferred version):
+Below shows the steps to create a `conda <https://docs.conda.io>`_
+environment for echopype development
+(replace the Python version with your preferred version).
+
+.. attention::
+    We recommend using the ``libmamba`` solver instead of the classic solver,
+    since the ``conda create`` and ``conda install`` step could take very long or fail.
+    See `instructions here <https://conda.github.io/conda-libmamba-solver/getting-started/>`_
+    for installation and usage.
+
 
 .. code-block:: bash
 
-    # create conda environment using the supplied requirements files
+    # create a conda environment using the supplied requirements files
     # note the last one docs/requirements.txt is only required for building docs
     conda create -c conda-forge -n echopype --yes python=3.9 --file requirements.txt --file requirements-dev.txt --file docs/requirements.txt
 
@@ -92,13 +100,6 @@ Create a `conda <https://docs.conda.io>`_ environment for echopype development
     # plot is an extra set of requirements that can be used for plotting.
     # the command will install all the dependencies along with plotting dependencies.
     pip install -e ".[plot]"
-
-.. note::
-
-    Try using `mamba <https://mamba.readthedocs.io>`_ instead of ``conda``
-    if the ``conda create`` and ``conda install`` step fail or take too long.
-    ``Mamba`` is a drop-in replacement for conda environment creation and package
-    installation that is typically faster than conda.
 
 See the :doc:`installation` page to simply install the latest echopype release from conda or PyPI.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -20,6 +20,18 @@ or through conda from the `conda-forge Anaconda channel <https://anaconda.org/co
 
 Previous releases are also available on PyPI and conda.
 
+.. attention::
+   Due to the dependencies, we recommend using ``mamba`` to install echopype.
+   It can be simply done through
+
+   .. code-block:: console
+
+      $ mamba install -c conda-forge echopype
+
+   ``mamba`` can be installed by installing the ``libmamba`` solver
+   following the instruction `here <https://conda.github.io/conda-libmamba-solver/getting-started/>`_.
+
+
 For instructions on installing a development version of echopype,
 see the :doc:`contributing` page.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -18,22 +18,15 @@ or through conda from the `conda-forge Anaconda channel <https://anaconda.org/co
 
    $ conda install -c conda-forge echopype
 
-Previous releases are also available on PyPI and conda.
-
 .. attention::
-   Due to the dependencies, we recommend using ``mamba`` to install echopype.
-   It can be simply done through
-
-   .. code-block:: console
-
-      $ mamba install -c conda-forge echopype
-
-   ``mamba`` can be installed by installing the ``libmamba`` solver
-   following the instruction `here <https://conda.github.io/conda-libmamba-solver/getting-started/>`_.
-
+   We recommend using the ``libmamba`` solver instead of the classic solver.
+   See instructions `here <https://conda.github.io/conda-libmamba-solver/getting-started/>`_
+   for installation and usage.
 
 For instructions on installing a development version of echopype,
 see the :doc:`contributing` page.
+
+Previous releases are also available on PyPI and conda.
 
 
 Examples

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -23,10 +23,10 @@ or through conda from the `conda-forge Anaconda channel <https://anaconda.org/co
    See instructions `here <https://conda.github.io/conda-libmamba-solver/getting-started/>`_
    for installation and usage.
 
+Previous releases are also available on PyPI and conda.
+
 For instructions on installing a development version of echopype,
 see the :doc:`contributing` page.
-
-Previous releases are also available on PyPI and conda.
 
 
 Examples


### PR DESCRIPTION
This PR addresses #1074 by adding mamba instruction into echopype installation guide and guide for setting up a development environment.