### PR TITLE
EK60, add mandatory `transmit_type` as a scalar

### DIFF
--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -585,6 +585,17 @@ class SetGroupsEK60(SetGroupsBase):
                     ["channel"],
                     beam_params["gpt_software_version"],
                 ),
+                "transmit_type": (
+                    [],
+                    "CW",
+                    {
+                        "long_name": "Type of transmitted pulse",
+                        "flag_values": ["CW"],
+                        "flag_meanings": [
+                            "Continuous Wave",
+                        ],
+                    },
+                ),
             },
             coords={
                 "channel": (


### PR DESCRIPTION
See https://github.com/OSOceanAcoustics/echopype/issues/1100#issuecomment-1657239544
