### PR TITLE
AZFP: add missing mandatory Beam_group1 variables

### DIFF
--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -340,6 +340,19 @@ class SetGroupsAZFP(SetGroupsBase):
                         "standard_name": "sound_frequency",
                     },
                 ),
+                # TODO: Add channel dim, to match ek60 and ek80?
+                "beam_type": (
+                    [],
+                    0,
+                    {
+                        "long_name": "Beam type",
+                        "flag_values": [0, 1],
+                        "flag_meanings": [
+                            "Single beam",
+                            "Split aperture beam",
+                        ],
+                    },
+                ),
                 "backscatter_r": (
                     ["channel", "ping_time", "range_sample"],
                     N,
@@ -380,6 +393,17 @@ class SetGroupsAZFP(SetGroupsBase):
                         "long_name": "Nominal bandwidth of transmitted pulse",
                         "units": "s",
                         "valid_min": 0.0,
+                    },
+                ),
+                "transmit_type": (
+                    [],
+                    "CW",
+                    {
+                        "long_name": "Type of transmitted pulse",
+                        "flag_values": ["CW"],
+                        "flag_meanings": [
+                            "Continuous Wave",
+                        ],
                     },
                 ),
             },

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -352,6 +352,20 @@ class SetGroupsAZFP(SetGroupsBase):
                         ],
                     },
                 ),
+                **{
+                    f"beam_direction_{var}": (
+                        ["channel"],
+                        [np.nan] * len(self.channel_ids_sorted),
+                        {
+                            "long_name": f"{var}-component of the vector that gives the pointing "
+                            "direction of the beam, in sonar beam coordinate "
+                            "system",
+                            "units": "1",
+                            "valid_range": (-1.0, 1.0),
+                        },
+                    )
+                    for var in ["x", "y", "z"]
+                },
                 "backscatter_r": (
                     ["channel", "ping_time", "range_sample"],
                     np.array(N, dtype=np.float32),

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -340,10 +340,9 @@ class SetGroupsAZFP(SetGroupsBase):
                         "standard_name": "sound_frequency",
                     },
                 ),
-                # TODO: Add channel dim, to match ek60 and ek80?
                 "beam_type": (
-                    [],
-                    0,
+                    ["channel"],
+                    [0] * len(self.channel_ids_sorted),
                     {
                         "long_name": "Beam type",
                         "flag_values": [0, 1],


### PR DESCRIPTION
Addresses #1100

- [x] beam_type
- [x] transmit_type
- [x] beam_direction_x/y/z