### PR TITLE
Add missing, mandatory `Beam_groupX` variables

### DIFF
--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -382,6 +382,24 @@ class SetGroupsAZFP(SetGroupsBase):
                         "valid_min": 0.0,
                     },
                 ),
+                "beam_stabilisation": (
+                    [],
+                    np.array(0, np.byte),
+                    {
+                        "long_name": "Beam stabilisation applied (or not)",
+                        "flag_values": [0, 1],
+                        "flag_meanings": ["not stabilised", "stabilised"],
+                    },
+                ),
+                "non_quantitative_processing": (
+                    [],
+                    np.array(0, np.int16),
+                    {
+                        "long_name": "Presence or not of non-quantitative processing applied to the backscattering data (sonar specific)",  # noqa
+                        "flag_values": [0],
+                        "flag_meanings": ["None"],
+                    },
+                ),
             },
             coords={
                 "channel": (

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -395,9 +395,19 @@ class SetGroupsAZFP(SetGroupsBase):
                     [],
                     np.array(0, np.int16),
                     {
-                        "long_name": "Presence or not of non-quantitative processing applied to the backscattering data (sonar specific)",  # noqa
+                        "long_name": "Presence or not of non-quantitative processing applied"
+                        " to the backscattering data (sonar specific)",
                         "flag_values": [0],
                         "flag_meanings": ["None"],
+                    },
+                ),
+                "sample_time_offset": (
+                    [],
+                    0.0,
+                    {
+                        "long_name": "Time offset that is subtracted from the timestamp"
+                        " of each sample",
+                        "units": "s",
                     },
                 ),
             },

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -598,7 +598,8 @@ class SetGroupsEK60(SetGroupsBase):
                     [],
                     np.array(0, np.int16),
                     {
-                        "long_name": "Presence or not of non-quantitative processing applied to the backscattering data (sonar specific)",  # noqa
+                        "long_name": "Presence or not of non-quantitative processing applied"
+                        " to the backscattering data (sonar specific)",
                         "flag_values": [0],
                         "flag_meanings": ["None"],
                     },
@@ -663,10 +664,17 @@ class SetGroupsEK60(SetGroupsBase):
                         "flag_meanings": ["power only", "angle only", "power and angle"],
                     },
                 ),
-                "range_sample_offset": (
+                "sample_time_offset": (
                     ["ping_time"],
-                    np.array(self.parser_obj.ping_data_dict["offset"][ch], dtype=np.int32),
-                    {"long_name": "First sample number"},
+                    (
+                        np.array(self.parser_obj.ping_data_dict["offset"][ch])
+                        * np.array(self.parser_obj.ping_data_dict["sample_interval"][ch])
+                    ),
+                    {
+                        "long_name": "Time offset that is subtracted from the timestamp"
+                        " of each sample",
+                        "units": "s",
+                    },
                 ),
                 "channel_mode": (
                     ["ping_time"],

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -585,6 +585,24 @@ class SetGroupsEK60(SetGroupsBase):
                     ["channel"],
                     beam_params["gpt_software_version"],
                 ),
+                "beam_stabilisation": (
+                    [],
+                    np.array(0, np.byte),
+                    {
+                        "long_name": "Beam stabilisation applied (or not)",
+                        "flag_values": [0, 1],
+                        "flag_meanings": ["not stabilised", "stabilised"],
+                    },
+                ),
+                "non_quantitative_processing": (
+                    [],
+                    np.array(0, np.int16),
+                    {
+                        "long_name": "Presence or not of non-quantitative processing applied to the backscattering data (sonar specific)",  # noqa
+                        "flag_values": [0],
+                        "flag_meanings": ["None"],
+                    },
+                ),
             },
             coords={
                 "channel": (

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -605,7 +605,8 @@ class SetGroupsEK80(SetGroupsBase):
                     [],
                     np.array(0, np.int16),
                     {
-                        "long_name": "Presence or not of non-quantitative processing applied to the backscattering data (sonar specific)",  # noqa
+                        "long_name": "Presence or not of non-quantitative processing applied"
+                        " to the backscattering data (sonar specific)",
                         "flag_values": [0],
                         "flag_meanings": ["None"],
                     },
@@ -939,10 +940,17 @@ class SetGroupsEK80(SetGroupsBase):
                         "flag_meanings": ["CW", "FM", "FMD"],
                     },
                 ),
-                "range_sample_offset": (
+                "sample_time_offset": (
                     ["ping_time"],
-                    np.array(self.parser_obj.ping_data_dict["offset"][ch], dtype=int),
-                    {"long_name": "First sample number"},
+                    (
+                        np.array(self.parser_obj.ping_data_dict["offset"][ch])
+                        * np.array(self.parser_obj.ping_data_dict["sample_interval"][ch])
+                    ),
+                    {
+                        "long_name": "Time offset that is subtracted from the timestamp"
+                        " of each sample",
+                        "units": "s",
+                    },
                 ),
             },
             coords={

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -592,6 +592,24 @@ class SetGroupsEK80(SetGroupsBase):
                     ["channel"],
                     beam_params["transceiver_software_version"],
                 ),
+                "beam_stabilisation": (
+                    [],
+                    np.array(0, np.byte),
+                    {
+                        "long_name": "Beam stabilisation applied (or not)",
+                        "flag_values": [0, 1],
+                        "flag_meanings": ["not stabilised", "stabilised"],
+                    },
+                ),
+                "non_quantitative_processing": (
+                    [],
+                    np.array(0, np.int16),
+                    {
+                        "long_name": "Presence or not of non-quantitative processing applied to the backscattering data (sonar specific)",  # noqa
+                        "flag_values": [0],
+                        "flag_meanings": ["None"],
+                    },
+                ),
             },
             coords={
                 "channel": (

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -43,7 +43,6 @@ EXPECTED_VAR_DTYPE = {
     "cal_channel_id": np.str_,
     "beam": np.str_,
     "channel_mode": np.byte,
-    "range_sample_offset": np.int32,
     "beam_stabilisation": np.byte,
     "non_quantitative_processing": np.int16,
 }  # channel name  # beam name

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -44,6 +44,8 @@ EXPECTED_VAR_DTYPE = {
     "beam": np.str_,
     "channel_mode": np.byte,
     "range_sample_offset": np.int32,
+    "beam_stabilisation": np.byte,
+    "non_quantitative_processing": np.int16,
 }  # channel name  # beam name
 
 PREFERRED_CHUNKS = "preferred_chunks"


### PR DESCRIPTION
Addresses #1097. Adds mandatory variables

- [x] `beam_stabilisation`, as a scalar
- [x] `non_quantitative_processing`, as a scalar
- [x] `sample_time_offset`: Will replace `range_sample_offset`, at least for EK60 & EK80. See https://github.com/OSOceanAcoustics/echopype/issues/1097#issuecomment-1656418738, and note that this change revisits issue #951