### PR TITLE
Rename `fs_receiver` in Vendor-specific group

### DIFF
--- a/echopype/calibrate/cal_params.py
+++ b/echopype/calibrate/cal_params.py
@@ -395,9 +395,11 @@ def get_cal_params_EK(
 
     # Private function to get fs
     def _get_fs():
-        if "fs_receiver" in vend:
-            return vend["fs_receiver"]
+        # If receiver_sampling_frequency recorded, use it
+        if "receiver_sampling_frequency" in vend:
+            return vend["receiver_sampling_frequency"]
         else:
+            # If receiver_sampling_frequency not recorded, use default value
             # loop through channel since transceiver can vary
             fs = []
             for ch in vend["channel"]:

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -1259,7 +1259,7 @@ class SetGroupsEK80(SetGroupsBase):
                 },
             )
         if "rx_sample_frequency" in param_dict:
-            ds_table["fs_receiver"] = xr.DataArray(
+            ds_table["receiver_sampling_frequency"] = xr.DataArray(
                 param_dict["rx_sample_frequency"].astype(float),
                 dims=["channel"],
                 coords={"channel": ds_table["channel"]},


### PR DESCRIPTION
This PR rename the data variable `fs_receiver` in the Vendor-specific group to `receiver_sampling_frequency`. This should have been changed around the time of #1019, but somehow didn't get fixed.