### PR TITLE
feat: pin netcdf to >1.6 and add explicit encoding [all tests ci]

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -66,7 +66,7 @@ jobs:
       # We only want to install this on one run, because otherwise we'll have
       # duplicate annotations.
       - name: Install error reporter
-        if: ${{ matrix.runs-on }} == 'ubuntu-latest' and ${{ matrix.python-version }} == '3.9'
+        if: ${{ matrix.python-version == '3.9' }}
         run: |
           python -m pip install pytest-github-actions-annotate-failures
       - name: Install echopype

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -63,6 +63,12 @@ jobs:
       - name: Install dev tools
         run: |
           micromamba install -c conda-forge -n ${{ env.CONDA_ENV }} --yes --file requirements-dev.txt
+      # We only want to install this on one run, because otherwise we'll have
+      # duplicate annotations.
+      - name: Install error reporter
+        if: ${{ matrix.runs-on }} == 'ubuntu-latest' and ${{ matrix.python-version }} == '3.9'
+        run: |
+          python -m pip install pytest-github-actions-annotate-failures
       - name: Install echopype
         run: |
           python -m pip install -e .[plot]

--- a/echopype/tests/convert/test_convert_source_target_locs.py
+++ b/echopype/tests/convert/test_convert_source_target_locs.py
@@ -12,15 +12,16 @@ import os
 import fsspec
 import xarray as xr
 import pytest
+from datatree import open_datatree
 from tempfile import TemporaryDirectory
 from echopype import open_raw
 from echopype.utils.coding import DEFAULT_ENCODINGS
 
 
 def _check_file_group(data_file, engine, groups):
-    for g in groups:
-        ds = xr.open_dataset(data_file, engine=engine, group=g)
-
+    tree = open_datatree(data_file, engine=engine)
+    for group in groups:
+        ds = tree[f"/{group}"].ds
         assert isinstance(ds, xr.Dataset) is True
 
 

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -1,5 +1,5 @@
 from re import search
-from typing import Tuple
+from typing import Any, Dict, Tuple
 
 import numpy as np
 import xarray as xr
@@ -211,18 +211,38 @@ def set_zarr_encodings(
     return encoding
 
 
-def set_netcdf_encodings(ds: xr.Dataset, compression_settings: dict) -> dict:
+def set_netcdf_encodings(
+    ds: xr.Dataset,
+    compression_settings: Dict[str, Any] = {},
+) -> Dict[str, Dict[str, Any]]:
     """
-    Obtains all variable encodings based on netcdf default values
-    """
+    Obtains all variables encodings based on netcdf default values
 
-    # TODO: below is the encoding we were using for netcdf, we need to make
-    #  sure that the encoding is appropriate for all data variables
-    encoding = (
-        {var: compression_settings for var in ds.data_vars}
-        if compression_settings is not None
-        else {}
-    )
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The dataset object to generate encoding for
+    compression_settings : dict
+        The compression settings dictionary
+
+    Returns
+    -------
+    dict
+        The final encoding values for dataset variables
+    """
+    encoding = dict()
+    for name, val in ds.variables.items():
+        encoding[name] = {**val.encoding}
+        if np.issubdtype(val.dtype, np.str_):
+            encoding[name].update(
+                {
+                    "zlib": False,
+                }
+            )
+        elif compression_settings:
+            encoding[name].update(compression_settings)
+        else:
+            encoding[name].update(COMPRESSION_SETTINGS["netcdf4"])
 
     return encoding
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 dask[array,distributed]
 jinja2
-# https://github.com/Unidata/netcdf4-python/issues/1175#issuecomment-1173142506
-netCDF4<1.6
+netCDF4>1.6
 numpy
 pynmea2
 pytz


### PR DESCRIPTION
## Overview

This PR unpins the netCDF4 version and set it to `>1.6` so that we are getting the latest. Also, the `set_netcdf_encodings` utils has been updated so that we set `zlib=False` for strings... it looks like the older netcdf4 is already doing this under the hood. 