### PR TITLE
ci: switch github action for get-changed-files

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -80,7 +80,7 @@ jobs:
           curl http://localhost:8080/data/
       - name: Finding changed files
         id: files
-        uses: lsetiawan/get-changed-files@pr_target
+        uses: Ana06/get-changed-files@v2.2.0
         with:
           format: 'csv'
       - name: Print Changed files


### PR DESCRIPTION
## Overview

This PR updates the github action `get-changed-files` to `Ana06/get-changed-files@v2.2.0` since that's more maintained than my current fork.