### PR TITLE
Encoding changes in to_zarr

### DIFF
--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -208,6 +208,9 @@ def set_zarr_encodings(
                 chunks = _get_auto_chunk(val, chunk_size=chunk_size)
 
             encoding[name]["chunks"] = chunks
+        if PREFERRED_CHUNKS in encoding[name]:
+            # Remove 'preferred_chunks', use chunks only instead
+            encoding[name].pop(PREFERRED_CHUNKS)
 
     return encoding
 

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -13,6 +13,7 @@ import fsspec
 import xarray as xr
 from fsspec import FSMap
 from fsspec.implementations.local import LocalFileSystem
+from dask.array import Array as DaskArray
 
 from ..utils.coding import set_storage_encodings
 from ..utils.log import _init_logger
@@ -61,7 +62,8 @@ def save_file(ds, path, mode, engine, group=None, compression_settings=None, **k
     elif engine == "zarr":
         # Ensure that encoding and chunks match
         for var, enc in encoding.items():
-            ds[var] = ds[var].chunk(enc.get("chunks", {}))
+            if isinstance(ds[var].data, DaskArray):
+                ds[var] = ds[var].chunk(enc.get("chunks", {}))
         ds.to_zarr(store=path, mode=mode, group=group, encoding=encoding, **kwargs)
     else:
         raise ValueError(f"{engine} is not a supported save format")

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -11,9 +11,9 @@ from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
 
 import fsspec
 import xarray as xr
+from dask.array import Array as DaskArray
 from fsspec import FSMap
 from fsspec.implementations.local import LocalFileSystem
-from dask.array import Array as DaskArray
 
 from ..utils.coding import set_storage_encodings
 from ..utils.log import _init_logger


### PR DESCRIPTION
- Reintroduced code to explicitly eliminate preferred chunks once more, due to the reoccurrence of preferred chunks in the encoding dictionary.
- Ensuring chunk alignment and encoding only when dealing with DaskArray objects.