### PR TITLE
ci: Remove logging during testing [all tests ci]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,13 +81,7 @@ jobs:
       - name: Running All Tests
         shell: bash -l {0}
         run: |
-          pytest -vv -rx --numprocesses=${{ env.NUM_WORKERS }} --max-worker-restart=3 --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings |& tee ci_${{ matrix.python-version }}_test_log.log
-      - name: Upload ci test log
-        if: ${{ success() || failure() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: ci_test_log
-          path: ci_${{ matrix.python-version }}_test_log.log
+          pytest -vv -rx --numprocesses=${{ env.NUM_WORKERS }} --max-worker-restart=3 --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -88,17 +88,11 @@ jobs:
       - name: Running all Tests
         if: contains(github.event.pull_request.title, '[all tests ci]')
         run: |
-          pytest -vvv -rx --numprocesses=${{ env.NUM_WORKERS }} --max-worker-restart=3 --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings |& tee ci_${{ matrix.python-version }}_test_log.log
+          pytest -vvv -rx --numprocesses=${{ env.NUM_WORKERS }} --max-worker-restart=3 --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings
       - name: Running Tests
         if: ${{ !contains(github.event.pull_request.title, '[all tests ci]') }}
         run: |
-          python .ci_helpers/run-test.py --pytest-args="--log-cli-level=WARNING,-vvv,-rx,--numprocesses=${{ env.NUM_WORKERS }},--max-worker-restart=3,--disable-warnings" --include-cov ${{ steps.files.outputs.added_modified_renamed }} |& tee ci_${{ matrix.python-version }}_test_log.log
-      - name: Upload ci test log
-        if: ${{ success() || failure() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: ci_test_log
-          path: ci_${{ matrix.python-version }}_test_log.log
+          python .ci_helpers/run-test.py --pytest-args="--log-cli-level=WARNING,-vvv,-rx,--numprocesses=${{ env.NUM_WORKERS }},--max-worker-restart=3,--disable-warnings" --include-cov ${{ steps.files.outputs.added_modified_renamed }}
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
Removed capturing the output of pytest into a log
using 'tee'. This way the proper exit code should be propagated.

The logs are currently now looked at much anyways! :)

------

Ref: Issue #1140