### PR TITLE
Remove automatic version conversion in `open_converted`

### DIFF
--- a/docs/source/data-format-changes.ipynb
+++ b/docs/source/data-format-changes.ipynb
@@ -41,9 +41,17 @@
         "    - Revise the dimensions of each variable to be consistent across instrument types, with dimensions deemed unnecessary dropped from some variables.\n",
         "- In the `Provenance` group: Add new attributes `combination_*` to the \"combined\" `EchoData` object, mirroring the convention-based attributes `conversion_*`.\n",
         "- In the `Vendor_specific` group: Move filter coefficients and decimation factor from attributes to variables in EK80, to facilitate consistent provenance tracking during `combine_echodata` operations.\n",
-        "- Improve the presence and use of variable attributes throughout `EchoData` groups.\n",
-        "\n",
-        "Version 0.8.0 does not incorporte the capability to read files converted by previous versions of echopype. We recommend using `open_raw` to re-convert the raw data files."
+        "- Improve the presence and use of variable attributes throughout `EchoData` groups."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e506a51d",
+      "metadata": {},
+      "source": [
+        ":::{Note}\n",
+        "Version 0.8.0 does not incorporte the capability to read files converted by previous versions of echopype. We recommend using `open_raw` to re-convert the raw data files.\n",
+        ":::"
       ]
     },
     {
@@ -91,29 +99,6 @@
         "- The Beam_groupX `beamwidth_receive_athwartship` and `beamwidth_transmit_athwartship` variables were consolidated into `beamwidth_twoway_athwartship` because the EK60 and EK80 echosounders do not store one-way transmit or receive beam widths. Likewise for `beamwidth_receive_alongship` and `beamwidth_transmit_alongship`.\n",
         "\n",
         "More details, including Pull Requests and discussions related to these changes, can be found in the [Release notes](whats-new.html#v0-6-0-2022-may-26)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "touched-concentration",
-      "metadata": {},
-      "source": [
-        "### Convert old files to v0.6.0 format"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "fuzzy-sociology",
-      "metadata": {},
-      "source": [
-        "To convert data files from v0.5.x to v0.6.0 format, simply open the old files and re-save them:\n",
-        "\n",
-        "```python\n",
-        "import echopype as ep\n",
-        "# open old v0.5.x file and convert it into a v0.6.0-format EchoData object\n",
-        "ed = ep.open_converted(\"old_format_file.nc\")\n",
-        "ed.to_netcdf(\"new_format_file.nc\")\n",
-        "```"
       ]
     },
     {

--- a/docs/source/data-format-changes.ipynb
+++ b/docs/source/data-format-changes.ipynb
@@ -50,7 +50,7 @@
       "metadata": {},
       "source": [
         ":::{Note}\n",
-        "Version 0.8.0 does not incorporte the capability to read files converted by previous versions of echopype. We recommend using `open_raw` to re-convert the raw data files.\n",
+        "Version 0.8.0 does not incorporate the capability to read files converted by previous versions of echopype. We recommend using `open_raw` to re-convert the raw data files.\n",
         ":::"
       ]
     },

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -161,9 +161,6 @@ class EchoData:
 
         echodata._set_tree(tree)
 
-        # convert to newest echopype version structure, if necessary
-        ep_version_mapper.map_ep_version(echodata)
-
         if isinstance(converted_raw_path, fsspec.FSMap):
             # Convert fsmap to Path so it can be used
             # for retrieving the path strings

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -19,7 +19,6 @@ from ..utils.io import check_file_existence, sanitize_file_path
 from ..utils.log import _init_logger
 from ..utils.prov import add_processing_level
 from .convention import sonarnetcdf_1
-from .sensor_ep_version_mapping import ep_version_mapper
 from .widgets.utils import tree_repr
 from .widgets.widgets import _load_static_files, get_template
 

--- a/echopype/tests/echodata/test_echodata_structure.py
+++ b/echopype/tests/echodata/test_echodata_structure.py
@@ -1,3 +1,16 @@
+"""
+Note 2023-08-30:
+None of the test in this module is actually run,
+and since we removed automatic version conversion in open_converted in #1143,
+the tests actually cannot run.
+However, since we kept the previous data format conversion mechanisms
+(under echodata/sensor_ep_version_mapping) intact in case we are able to
+reinstate this capability in the future, here we also keep these tests here.
+
+See https://github.com/OSOceanAcoustics/echopype/pull/1143 for associated discussions.
+"""
+
+
 from typing import Any, Dict, Optional
 from datatree import open_datatree
 import pytest

--- a/echopype/tests/echodata/test_echodata_version_convert.py
+++ b/echopype/tests/echodata/test_echodata_version_convert.py
@@ -1,13 +1,12 @@
 """
 Note 2023-08-30:
-None of the test in this module is actually run,
-and since we removed automatic version conversion in open_converted in #1143,
-the tests actually cannot run.
+None of the test in this module is actually run (they are xfailed),
+and especially since we have removed automatic version conversion in open_converted in #1143.
 However, since we kept the previous data format conversion mechanisms
 (under echodata/sensor_ep_version_mapping) intact in case we are able to
-reinstate this capability in the future, here we also keep these tests here.
+reinstate such capability in the future, we also keep these tests here.
 
-See https://github.com/OSOceanAcoustics/echopype/pull/1143 for associated discussions.
+See https://github.com/OSOceanAcoustics/echopype/pull/1143 for discussions.
 """
 
 


### PR DESCRIPTION
## Overview

This PR removes the automatic `EchoData` format conversion when using `open_converted` on already converted data from earlier versions of echopype.

This PR does not remove the previous data format conversion mechanisms (under `echodata/sensor_ep_version_mapping`) in case we are able to reinstate this capability in the future.

The documentation is also updated.


## Context

We included a converter to automatically convert v0.5.x `EchoData` format to v0.6.x `EchoData` format. However, we have not been able to create such a functionality for all later versions, including the latest v0.8.0 which included a large number of data format changes. The existence of automatic v0.5.x to v0.6.x format conversion becomes confusing in this case since no other versions of data are able to be converted automatically in the same way, and using `open_raw` to re-convert the data is necessary. 

This is discovered by @emiliom 
> we have a problem with 0.8.0. I was trying to run and update the echopype-examples notebooks, and ran into a failure with open_converted that boils down to https://github.com/OSOceanAcoustics/echopype/blob/254ee106eb580959ca85f2131168c4f17c0a285a/echopype/echodata/sensor_ep_version_mapping/ep_version_mapper.py#L22, called by https://github.com/OSOceanAcoustics/echopype/blob/254ee106eb580959ca85f2131168c4f17c0a285a/echopype/echodata/echodata.py#L165. ie, the version tag 0.8.0 raises an error. We didn't run into this during local tests b/c the version tag was still 0.7.2xxx. But I'm puzzled why it didn't come up in the CI once the version was stamped as 0.8.0.
