### PR TITLE
test: Remove NASC import causing failure

### DIFF
--- a/echopype/tests/commongrid/test_nasc.py
+++ b/echopype/tests/commongrid/test_nasc.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from echopype import open_raw
 from echopype.calibrate import compute_Sv
-from echopype.commongrid import compute_NASC
+# from echopype.commongrid import compute_NASC
 from echopype.commongrid.nasc import (
     get_distance_from_latlon,
     get_depth_bin_info,


### PR DESCRIPTION
Commented out import for 'compute_NASC' causing the only error in CI at the moment seen in https://github.com/OSOceanAcoustics/echopype/actions/runs/6032689378/job/16368234856#step:11:1539 and https://github.com/OSOceanAcoustics/echopype/actions/runs/6032689378/job/16368234931#step:11:1539