### PR TITLE
chore(python): Bump python min to 3.9 [all tests ci]

### DIFF
--- a/.ci_helpers/py3.8.yaml
+++ b/.ci_helpers/py3.8.yaml
@@ -1,8 +1,0 @@
-name: echopype
-channels:
-  - conda-forge
-dependencies:
-  - python=3.8
-  - pip
-  - pip:
-    - -r ../requirements.txt

--- a/.ci_helpers/user_environment.yml
+++ b/.ci_helpers/user_environment.yml
@@ -2,7 +2,7 @@ name: echopype
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3.9
   - ipykernel
   - echopype
   - dask

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
         runs-on: [ubuntu-latest]
         experimental: [false]
         # TODO: Uncomment when netcdf is unpinned

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
         runs-on: [ubuntu-latest]
         experimental: [false]
         # TODO: Uncomment when netcdf is unpinned

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
   jobs:
     pre_build:
       # Generate the Sphinx configuration for this Jupyter Book so it builds.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,7 +5,7 @@ Installation and Examples
 Installation
 ------------
 
-Echopype is available and tested for Python>=3.8. The latest release
+Echopype is available and tested for Python>=3.9. The latest release
 can be installed from `PyPI <https://pypi.org/project/echopype/>`_:
 
 .. code-block:: console

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
@@ -29,7 +28,7 @@ platforms = any
 py_modules =
     _echopype_version
 include_package_data = True
-python_requires = >=3.8
+python_requires = >=3.9
 setup_requires =
     setuptools_scm
 


### PR DESCRIPTION
Bumping python requirement to >=3.9 following xarray.

Ref: #1144