### PR TITLE
Fix/nasc

### DIFF
--- a/echopype/commongrid/api.py
+++ b/echopype/commongrid/api.py
@@ -336,14 +336,14 @@ def compute_NASC(
                 ]
                 num_pings_in_cut_cell, num_depth_vals_in_cut_cell = Sv_cut.shape
                 r = ds_Sv_depth[:, depth_idx == depth_bin_idx[ch_seq]][0]
-                # t -> height in [m] between two consecutive samples
+                # get height of samples -> t
                 # derived from the difference between the corresponding consecutive depths
                 t = np.r_[np.diff(r), np.nan]
                 t = np.vstack([t] * num_pings_in_cut_cell)
                 sv = 10 ** (Sv_cut / 10)
                 # per -> the percentage of not nan samples
                 per = np.mean(np.logical_not(np.isnan(sv))) * 100
-                # num_pings_in_cut_cell * num_depth_vals_in_cut_cell = number of samples in cut cell
+                # num_pings_in_cut_cell * num_depth_vals_in_cut_cell = no. of samples in cut cell
                 sv_mean_depth_2nasc.append(
                     (
                         np.nanmean(sv * t)

--- a/echopype/tests/commongrid/test_nasc.py
+++ b/echopype/tests/commongrid/test_nasc.py
@@ -1,22 +1,18 @@
-import pytest
+import math
 
 import numpy as np
+import pytest
 
 from echopype import open_raw
 from echopype.calibrate import compute_Sv
 from echopype.commongrid import compute_NASC
-from echopype.commongrid.nasc import (
-    get_distance_from_latlon,
-    get_depth_bin_info,
-    get_dist_bin_info,
-    get_distance_from_latlon,
-)
-from echopype.consolidate import add_location, add_depth
+from echopype.commongrid.nasc import get_distance_from_latlon
+from echopype.consolidate import add_depth, add_location
 
 
 @pytest.fixture
 def ek60_path(test_path):
-    return test_path['EK60']
+    return test_path["EK60"]
 
 
 def test_compute_NASC(ek60_path):
@@ -32,7 +28,15 @@ def test_compute_NASC(ek60_path):
 
     # Check dimensions
     da_NASC = ds_NASC["NASC"]
+    decimal_places = 5
+    tolerance = 10 ** (-decimal_places)
+    da_NASC = ds_NASC["NASC"]
+    nasc_min = da_NASC.min()
+    nasc_max = da_NASC.max()
+
     assert da_NASC.dims == ("channel", "distance", "depth")
     assert np.all(ds_NASC["channel"].values == ds_Sv["channel"].values)
     assert da_NASC["depth"].size == np.ceil(ds_Sv["depth"].max() / cell_depth)
     assert da_NASC["distance"].size == np.ceil(dist_nmi.max() / cell_dist)
+    assert math.isclose(nasc_max, 1.40873285e08, rel_tol=tolerance)
+    assert math.isclose(nasc_min, 0.29729349, rel_tol=tolerance)


### PR DESCRIPTION
## NASC (Nautical Area Scattering Coefficient) Computation Correction

This PR is opened to propose a solution for https://github.com/OSOceanAcoustics/echopype/pull/1136

### Changes Made:

1. **Conversion Factors:** Conversion factors have been incorporated to facilitate the conversion from backscattering cross-section to scattering cross-section and from meters to nautical miles (nmi).

2. **Computation Approach:**
   - Cells Selection: Cells are chosen based on their depth and distance. The distance calculation is based on latitude and longitude coordinates.
   - NASC Calculation: For each channel and cell, the NASC is computed using the following steps:
     - Multiply the Sv (in linear units) with the height of the samples. The sample height is determined as the difference between consecutive depth values.
     - Compute the mean of the obtained values.
     - Multiply the mean value by the number of samples within the selected cell per the number of pings in the same cell.
     - Further multiply the result by $4 \times \pi \times 1852^2$
     - Finally, divide the obtained result by the percentage of non-NaN samples present in the analysis.