### PR TITLE
Set EK60/80 `Platform` and `NMEA` nan timestamp to first `ping_time` value [all tests ci]

### DIFF
--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -158,15 +158,22 @@ class SetGroupsAZFP(SetGroupsBase):
         """Set the Platform group."""
         platform_dict = {"platform_name": "", "platform_type": "", "platform_code_ICES": ""}
         unpacked_data = self.parser_obj.unpacked_data
-        time2 = self.parser_obj.ping_time
-        time1 = [time2[0]]
+
+        # Create nan time coordinate for lat/lon (lat/lon do not exist in AZFP 01A data)
+        time1 = [np.nan]
 
         # If tilt_x and/or tilt_y are all nan, create single-value time2 dimension
         # and single-value (np.nan) tilt_x and tilt_y
         tilt_x = [np.nan] if np.isnan(unpacked_data["tilt_x"]).all() else unpacked_data["tilt_x"]
         tilt_y = [np.nan] if np.isnan(unpacked_data["tilt_y"]).all() else unpacked_data["tilt_y"]
         if (len(tilt_x) == 1 and np.isnan(tilt_x)) and (len(tilt_y) == 1 and np.isnan(tilt_y)):
-            time2 = [time2[0]]
+            time2 = [self.parser_obj.ping_time[0]]
+        else:
+            time2 = self.parser_obj.ping_time
+
+        # Handle potential nan timestamp for time1 and time2
+        time1 = self._nan_timestamp_handler(time1)
+        time2 = self._nan_timestamp_handler(time2)  # should not be nan; but add for completeness
 
         ds = xr.Dataset(
             {

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -112,7 +112,7 @@ class SetGroupsBase(abc.ABC):
         """Set the Platform group."""
         raise NotImplementedError
 
-    def _NaT_timestamp_handler(self, time_val) -> List:
+    def _nan_timestamp_handler(self, time_val) -> List:
         """
         Replace NaT in time coordinate to avoid xarray warning.
         """
@@ -137,7 +137,7 @@ class SetGroupsBase(abc.ABC):
             raw_nmea = [np.nan]
 
         # Handle potential NaT timestamp for time
-        time = self._NaT_timestamp_handler(time)
+        time = self._nan_timestamp_handler(time)
 
         ds = xr.Dataset(
             {

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -114,11 +114,18 @@ class SetGroupsBase(abc.ABC):
 
     def _nan_timestamp_handler(self, time_val) -> List:
         """
-        Replace NaT in time coordinate to avoid xarray warning.
+        Replace nan in time coordinate to avoid xarray warning.
         """
         if len(time_val) == 1 and np.isnan(time_val[0]):
-            # set time 1 to earliest ping_time among all channels
-            return [np.array([v[0] for v in self.parser_obj.ping_time.values()]).min()]
+            # set time_val to earliest ping_time among all channels
+            if self.sonar_model in ["EK60", "ES70", "EK80", "ES80", "EA640"]:
+                return [np.array([v[0] for v in self.parser_obj.ping_time.values()]).min()]
+            elif self.sonar_model == "AZFP":
+                return [self.parser_obj.ping_time[0]]
+            else:
+                return NotImplementedError(
+                    f"Nan timestamp handling has not been implemented for {self.sonar_model}!"
+                )
         else:
             return time_val
 
@@ -136,7 +143,7 @@ class SetGroupsBase(abc.ABC):
             time = [np.nan]
             raw_nmea = [np.nan]
 
-        # Handle potential NaT timestamp for time
+        # Handle potential nan timestamp for time
         time = self._nan_timestamp_handler(time)
 
         ds = xr.Dataset(

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -181,9 +181,8 @@ class SetGroupsEK60(SetGroupsBase):
         # are identical across channels
         ch = list(self.sorted_channel.keys())[0]
 
-        # If time1 is a single-value np.nan array, set it to the first ping_time value
-        if len(time1) == 1 and np.isnan(time1[0]):
-            time1 = [self.parser_obj.ping_time[ch][0]]
+        # Handle potential NaT timestamp for time1 and time2
+        time1 = self._NaT_timestamp_handler(time1)
 
         ds = xr.Dataset(
             {

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -181,7 +181,7 @@ class SetGroupsEK60(SetGroupsBase):
         # are identical across channels
         ch = list(self.sorted_channel.keys())[0]
 
-        # Handle potential NaT timestamp for time1 and time2
+        # Handle potential nan timestamp for time1 and time2
         time1 = self._nan_timestamp_handler(time1)
 
         ds = xr.Dataset(

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -182,7 +182,7 @@ class SetGroupsEK60(SetGroupsBase):
         ch = list(self.sorted_channel.keys())[0]
 
         # Handle potential NaT timestamp for time1 and time2
-        time1 = self._NaT_timestamp_handler(time1)
+        time1 = self._nan_timestamp_handler(time1)
 
         ds = xr.Dataset(
             {

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -179,6 +179,10 @@ class SetGroupsEK60(SetGroupsBase):
         # Values for the variables below having a channel (ch) dependence
         # are identical across channels
         ch = list(self.sorted_channel.keys())[0]
+        # If time1 is a single-value np.nan array, set it to the first ping_time value
+        if len(time1) == 1 and np.isnan(time1[0]):
+            time1 = [self.parser_obj.ping_time[ch][0]]
+
         ds = xr.Dataset(
             {
                 "latitude": (

--- a/echopype/convert/set_groups_ek60.py
+++ b/echopype/convert/set_groups_ek60.py
@@ -176,9 +176,11 @@ class SetGroupsEK60(SetGroupsBase):
 
         # NMEA dataset: variables filled with np.nan if they do not exist
         platform_dict = {"platform_name": "", "platform_type": "", "platform_code_ICES": ""}
-        # Values for the variables below having a channel (ch) dependence
+
+        # Values for the variables in ds below having a channel (ch) dependence
         # are identical across channels
         ch = list(self.sorted_channel.keys())[0]
+
         # If time1 is a single-value np.nan array, set it to the first ping_time value
         if len(time1) == 1 and np.isnan(time1[0]):
             time1 = [self.parser_obj.ping_time[ch][0]]

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -310,7 +310,7 @@ class SetGroupsEK80(SetGroupsBase):
         time2 = self.parser_obj.mru.get("timestamp", None)
         time2 = np.array(time2) if time2 is not None else [np.nan]
 
-        # Handle potential NaT timestamp for time1 and time2
+        # Handle potential nan timestamp for time1 and time2
         time1 = self._nan_timestamp_handler(time1)
         time2 = self._nan_timestamp_handler(time2)
 

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -310,10 +310,9 @@ class SetGroupsEK80(SetGroupsBase):
         time2 = self.parser_obj.mru.get("timestamp", None)
         time2 = np.array(time2) if time2 is not None else [np.nan]
 
-        # If time1 is a single-value np.nan array, set it to the first ping_time value
-        if len(time1) == 1 and np.isnan(time1[0]):
-            # set time 1 to earliest ping_time among all channels
-            time1 = [np.array([v[0] for v in self.parser_obj.ping_time.values()]).min()]
+        # Handle potential NaT timestamp for time1 and time2
+        time1 = self._NaT_timestamp_handler(time1)
+        time2 = self._NaT_timestamp_handler(time2)
 
         # Assemble variables into a dataset: variables filled with nan if do not exist
         platform_dict = {"platform_name": "", "platform_type": "", "platform_code_ICES": ""}

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -310,6 +310,11 @@ class SetGroupsEK80(SetGroupsBase):
         time2 = self.parser_obj.mru.get("timestamp", None)
         time2 = np.array(time2) if time2 is not None else [np.nan]
 
+        # If time1 is a single-value np.nan array, set it to the first ping_time value
+        if len(time1) == 1 and np.isnan(time1[0]):
+            # set time 1 to earliest ping_time among all channels
+            time1 = [np.array([v[0] for v in self.parser_obj.ping_time.values()]).min()]
+
         # Assemble variables into a dataset: variables filled with nan if do not exist
         platform_dict = {"platform_name": "", "platform_type": "", "platform_code_ICES": ""}
         ds = xr.Dataset(

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -311,8 +311,8 @@ class SetGroupsEK80(SetGroupsBase):
         time2 = np.array(time2) if time2 is not None else [np.nan]
 
         # Handle potential NaT timestamp for time1 and time2
-        time1 = self._NaT_timestamp_handler(time1)
-        time2 = self._NaT_timestamp_handler(time2)
+        time1 = self._nan_timestamp_handler(time1)
+        time2 = self._nan_timestamp_handler(time2)
 
         # Assemble variables into a dataset: variables filled with nan if do not exist
         platform_dict = {"platform_name": "", "platform_type": "", "platform_code_ICES": ""}


### PR DESCRIPTION
Addresses the first two xarray warnings identified in #1153. Implements the solution described there, for EK60.

Setting single-valued nan `Platform.time1` cases to the first `ping_time` value is consistent with the approach currently used with AZFP. EK80 may benefit from this change, too, but I'm not aware of a test case raw file, plus we're short on time.

See discussion in #1153.


**[@leewujung edits for future reference]**: Saildrone EK80 data by default does not have the lat/lon data since GPS is not plugged into the echosounder itself.