### PR TITLE
Fixtures to generate mock data for clean up `use_swap` handling

### DIFF
--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -282,7 +282,7 @@ class ParseEK(ParseBase):
                 self.ping_time[new_datagram["channel"]].append(new_datagram["timestamp"])
 
                 # Append ping by ping data
-                self._append_channel_ping_data(new_datagram)
+                self._append_channel_ping_data(new_datagram, zarr_vars=False)
 
             # EK80 datagram sequence:
             #   - XML0 pingsequence
@@ -302,7 +302,7 @@ class ParseEK(ParseBase):
 
                 # Append ping by ping data
                 new_datagram.update(current_parameters)
-                self._append_channel_ping_data(new_datagram)
+                self._append_channel_ping_data(new_datagram, zarr_vars=False)
 
             # RAW4 datagrams store raw transmit pulse for a channel for EK80
             elif new_datagram["type"].startswith("RAW4"):
@@ -317,7 +317,7 @@ class ParseEK(ParseBase):
 
                 # Append ping by ping data
                 new_datagram.update(current_parameters)
-                self._append_channel_ping_data(new_datagram, rx=False)
+                self._append_channel_ping_data(new_datagram, rx=False, zarr_vars=False)
 
             # NME datagrams store ancillary data as NMEA-0817 style ASCII data.
             elif new_datagram["type"].startswith("NME"):

--- a/echopype/tests/convert/conftest.py
+++ b/echopype/tests/convert/conftest.py
@@ -1,0 +1,112 @@
+import pytest
+
+from collections import defaultdict
+
+import xarray as xr
+import numpy as np
+import pandas as pd
+
+
+DATA_LEN = {
+    "power": 1,
+    "angle": 2,
+    "complex": 4,
+}
+
+
+@pytest.fixture
+def mock_channel(
+    range_sample_len=[100, 500, 10000],
+    range_sample_ping_time_len=[20, 30, 10],
+    data_type="power",
+) -> np.ndarray:
+    """
+    Create data for one channel with variable length
+    along the range_sample dimension.
+
+    To generate channel data with uniform length across ping_time,
+    set range_sample_len and range_sample_ping_time_len both to single-element lists.
+
+    To generate channel data with variable length across ping_time,
+    set range_sample_len and range_sample_ping_time_len as lists similar to the default.
+
+    Parameters
+    ----------
+    range_sample_len
+        length along the range_sample dimension for each block of pings
+    range_sample_ping_time_len
+        number of pings in each block
+    data_type
+        whether the generated channel data is mimicking the
+        power, angle, or complex data generated from EK60 and EK80.
+
+    Returns
+    -------
+    A numpy array containing mock data for one channel.
+    """
+    ch_data = []
+    for rs_len, pt_len in zip(range_sample_len, range_sample_ping_time_len):
+        # Generate data for each ping
+        if pt_len is not None:
+            for pt in np.arange(pt_len):  # looping since this needs to be a list of np arrays
+                ch_data.append(np.random.randint(0, 10000, size=(rs_len, DATA_LEN[data_type])).squeeze())
+    return ch_data
+
+
+@pytest.fixture
+def mock_channel_timestamp(ping_time_len, ping_time_interval="1S", ping_time_jitter_max_ms=0):
+    # TODO: this is the same function as in tests/commongrid/conftest.py::_gen_ping_time
+    #       consider moving this to consolidate
+    ping_time = pd.date_range("2018-07-01", periods=ping_time_len, freq=ping_time_interval)
+    if ping_time_jitter_max_ms != 0:  # if to add jitter
+        jitter = (
+            np.random.randint(ping_time_jitter_max_ms, size=ping_time_len) / 1000
+        )  # convert to seconds
+        ping_time = pd.to_datetime(ping_time.astype(int) / 1e9 + jitter, unit="s")
+    return ping_time
+
+
+@pytest.fixture
+def gen_timestamp_data(ch_num, ch_range_sample_ping_time_len):
+    timestamp_data = defaultdict(list)
+    for ch_seq in np.arange(ch_num):
+        mock_time = mock_channel_timestamp(
+            ping_time_len=sum(ch_range_sample_ping_time_len[ch_seq]),
+            ping_time_interval="1S",
+            ping_time_jitter_max_ms=0
+        )
+        timestamp_data[ch_seq+1] = [np.datetime64(t) for t in mock_time.tolist()]
+    return timestamp_data
+
+
+@pytest.fixture
+def gen_echo_data(ch_num, ch_range_sample_len, ch_range_sample_ping_time_len, data_type):
+    echo_data = defaultdict(list)
+    for ch_seq in np.arange(ch_num):
+        # ch_seq+1 below because EK60/EK80 channel sequence is 1-based
+        echo_data[ch_seq+1] = mock_channel(
+            range_sample_len=ch_range_sample_len[ch_seq],
+            range_sample_ping_time_len=ch_range_sample_ping_time_len[ch_seq],
+            data_type=data_type,
+        )
+    return echo_data
+
+
+@pytest.fixture
+def mock_regular_ping_data_dict(
+    ch_num,
+    ch_range_sample_len=[[100], [100], [100]],
+    ch_range_sample_ping_time_len=[[20], [20], [20]],
+):
+
+    if (ch_num != len(ch_range_sample_len)) or (ch_num != len(ch_range_sample_ping_time_len)):
+        raise ValueError("Channel length mismatches!")
+
+    ping_data_dict = defaultdict(list)
+
+    # Echo data (power, angle, complex) generation
+    ping_data_dict["power"] = gen_echo_data(ch_num, ch_range_sample_len, ch_range_sample_ping_time_len, data_type="power")
+    ping_data_dict["angle"] = gen_echo_data(ch_num, ch_range_sample_len, ch_range_sample_ping_time_len, data_type="angle")
+    
+    # Ping time generation
+    ping_data_dict["timestamp"] = gen_timestamp_data(ch_num, ch_range_sample_ping_time_len)

--- a/echopype/tests/convert/conftest.py
+++ b/echopype/tests/convert/conftest.py
@@ -114,7 +114,7 @@ def mock_ping_data_dict(
         # the length along range_sample changes across ping_time in different ways for each channel
         ch_range_sample_len=[[10, 20, 100], [130], [20, 100, 10]]
 
-        # the number of pings in each block (each block has diffrent length along range_sample)
+        # the number of pings in each block (each block has different length along range_sample)
         # is different for each channel
         ch_range_sample_ping_time_len=[[20, 100, 20], [120, 10, 5], [50, 20, 20]]
 


### PR DESCRIPTION
@lsetiawan : in this PR you'll find functions that generate mock data for testing the `use_swap` functionality for #1179.

I made it such that the output is in identical format with `parser.ping_data_dict`, for `timestamp`, `power`, and `angle`.

See my comment here for more info: https://github.com/OSOceanAcoustics/echopype/issues/1179#issuecomment-1737733489

Because of the possible variations, I think using both the actual data for integration tests and mock data for unittest will be a good idea.

In terms of actual .raw data that we need to handle, see my previous investigation https://github.com/OSOceanAcoustics/echopype/issues/489#issuecomment-968340670 and https://github.com/OSOceanAcoustics/echopype/issues/489#issuecomment-968342133.