### PR TITLE
Fixed failing CI tests due to dependency version error [all tests ci]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ xarray-datatree==0.0.6
 psutil>=5.9.1
 geopy
 flox>=0.7.2,<1.0.0
+charset-normalizer==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ xarray-datatree==0.0.6
 psutil>=5.9.1
 geopy
 flox>=0.7.2,<1.0.0
-charset-normalizer==3.1.0
+charset-normalizer<3.2


### PR DESCRIPTION
Fixed failing CI tests which is caused due to `charset-normalizer` dependency version error for which version should be explicitly set to `3.1.0`. 

Discussions regarding the error and its fix - [Stackoverflow](https://stackoverflow.com/questions/75501048/how-to-fix-attributeerror-partially-initialized-module-charset-normalizer-has), [Github](https://github.com/microsoft/TaskMatrix/issues/242).

CC @emiliom 