### PR TITLE
ci: Update CI to barebone python [all tests ci]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,6 +72,8 @@ jobs:
           python -m pip install -e .[plot]
       - name: Print installed packages
         run: |
+          which pip
+          pip list
           micromamba list -n ${{ env.CONDA_ENV }}
       - name: Copying test data to services
         shell: bash -l {0}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,6 +70,9 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install -e .[plot]
+      - name: Print installed packages
+        run: |
+          micromamba list -n ${{ env.CONDA_ENV }}
       - name: Copying test data to services
         shell: bash -l {0}
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
       - name: Set up Python
-        uses: actions/setup-python@v4.7.0
+        uses: actions/setup-python@v4.7.1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,13 +14,13 @@ env:
 jobs:
   test:
     name: ${{ matrix.python-version }}-build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]  # TODO: add back 3.11 once parsed2zarr is fixed
+        python-version: ["3.9", "3.10", "3.11"]
         runs-on: [ubuntu-latest]
         experimental: [false]
     services:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,6 @@ on:
   workflow_dispatch:
 
 env:
-  CONDA_ENV: echopype
   NUM_WORKERS: 2
 
 jobs:
@@ -21,13 +20,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]  # TODO: add back 3.11 once parsed2zarr is fixed
+        python-version: ["3.9", "3.10", "3.11"]  # TODO: add back 3.11 once parsed2zarr is fixed
         runs-on: [ubuntu-latest]
         experimental: [false]
-        include:
-        - runs-on: ubuntu-latest
-          python-version: "3.11"
-          experimental: true
     services:
       # TODO: figure out how to update tag when there's a new one
       minio:
@@ -46,35 +41,20 @@ jobs:
       - name: Set environment variables
         run: |
           echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
-      - name: Setup micromamba
-        uses: mamba-org/setup-micromamba@v1
+      - name: Set up Python
+        uses: actions/setup-python@v4.7.0
         with:
-          environment-file: .ci_helpers/py${{ matrix.python-version }}.yaml
-          environment-name: ${{ env.CONDA_ENV }}
-          cache-environment: true
-          post-cleanup: 'all'
-      - name: Print conda environment
-        shell: bash -l {0}
-        run: |
-          micromamba info
-          micromamba list
+          python-version: ${{ matrix.python-version }}
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
       - name: Remove docker-compose python
-        if: ${{ matrix.python-version == '3.10' || matrix.python-version == '3.11' }}
-        shell: bash -l {0}
         run: sed -i "/docker-compose/d" requirements-dev.txt
       - name: Install dev tools
-        shell: bash -l {0}
-        run: |
-          micromamba install -c conda-forge -n ${{ env.CONDA_ENV }} --yes --file requirements-dev.txt
+        run: python -m pip install -r requirements-dev.txt
       - name: Install echopype
-        shell: bash -l {0}
-        run: |
-          python -m pip install -e .[plot]
+        run: python -m pip install -e ".[plot]"
       - name: Print installed packages
-        run: |
-          which pip
-          pip list
-          micromamba list -n ${{ env.CONDA_ENV }}
+        run: python -m pip list
       - name: Copying test data to services
         shell: bash -l {0}
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,13 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]  # TODO: add back 3.11 once parsed2zarr is fixed
+        python-version: ["3.9", "3.10", "3.11"]
         runs-on: [ubuntu-latest]
         experimental: [false]
-        include:
-        - runs-on: ubuntu-latest
-          python-version: "3.11"
-          experimental: true
     services:
       # TODO: figure out how to update tag when there's a new one
       minio:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -73,6 +73,8 @@ jobs:
           python -m pip install -e .[plot]
       - name: Print installed packages
         run: |
+          which pip
+          pip list
           micromamba list -n ${{ env.CONDA_ENV }}
       - name: Copying test data to services
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.
       - name: Set up Python
-        uses: actions/setup-python@v4.7.0
+        uses: actions/setup-python@v4.7.1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,7 +5,6 @@ on:
     paths-ignore: ["**/docker.yaml", "docs"]
 
 env:
-  CONDA_ENV: echopype
   NUM_WORKERS: 2
 
 jobs:
@@ -24,9 +23,6 @@ jobs:
         - runs-on: ubuntu-latest
           python-version: "3.11"
           experimental: true
-    defaults:
-      run:
-        shell: bash -l {0}
     services:
       # TODO: figure out how to update tag when there's a new one
       minio:
@@ -42,26 +38,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.
+      - name: Set up Python
+        uses: actions/setup-python@v4.7.0
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Set environment variables
         run: |
           echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
-      - name: Setup micromamba
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: .ci_helpers/py${{ matrix.python-version }}.yaml
-          environment-name: ${{ env.CONDA_ENV }}
-          cache-environment: true
-          post-cleanup: 'all'
-      - name: Print conda environment
-        run: |
-          micromamba info
-          micromamba list
       - name: Remove docker-compose python
-        if: ${{ matrix.python-version == '3.10' || matrix.python-version == '3.11' }}
         run: sed -i "/docker-compose/d" requirements-dev.txt
       - name: Install dev tools
-        run: |
-          micromamba install -c conda-forge -n ${{ env.CONDA_ENV }} --yes --file requirements-dev.txt
+        run: python -m pip install -r requirements-dev.txt
       # We only want to install this on one run, because otherwise we'll have
       # duplicate annotations.
       - name: Install error reporter
@@ -73,9 +60,7 @@ jobs:
           python -m pip install -e .[plot]
       - name: Print installed packages
         run: |
-          which pip
-          pip list
-          micromamba list -n ${{ env.CONDA_ENV }}
+          python -m pip list
       - name: Copying test data to services
         run: |
           python .ci_helpers/docker/setup-services.py --deploy --data-only --http-server ${{ job.services.httpserver.id }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -71,6 +71,9 @@ jobs:
       - name: Install echopype
         run: |
           python -m pip install -e .[plot]
+      - name: Print installed packages
+        run: |
+          micromamba list -n ${{ env.CONDA_ENV }}
       - name: Copying test data to services
         run: |
           python .ci_helpers/docker/setup-services.py --deploy --data-only --http-server ${{ job.services.httpserver.id }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -42,6 +42,8 @@ jobs:
         uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
       - name: Set environment variables
         run: |
           echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
@@ -53,14 +55,11 @@ jobs:
       # duplicate annotations.
       - name: Install error reporter
         if: ${{ matrix.python-version == '3.9' }}
-        run: |
-          python -m pip install pytest-github-actions-annotate-failures
+        run: python -m pip install pytest-github-actions-annotate-failures
       - name: Install echopype
-        run: |
-          python -m pip install -e .[plot]
+        run: python -m pip install -e ".[plot]"
       - name: Print installed packages
-        run: |
-          python -m pip list
+        run: python -m pip list
       - name: Copying test data to services
         run: |
           python .ci_helpers/docker/setup-services.py --deploy --data-only --http-server ${{ job.services.httpserver.id }}

--- a/echopype/tests/convert/test_parsed_to_zarr.py
+++ b/echopype/tests/convert/test_parsed_to_zarr.py
@@ -15,6 +15,8 @@ from echopype.convert.parsed_to_zarr_ek60 import Parsed2ZarrEK60
 from echopype.echodata.convention import sonarnetcdf_1
 from echopype.convert.api import _check_file, SONAR_MODELS
 
+pytestmark = pytest.mark.skip(reason="Removed Parsed2Zarr")
+
 test_bucket_name = "echopype-test"
 port = 5555
 endpoint_uri = "http://127.0.0.1:%s/" % port


### PR DESCRIPTION
This PR is a follow up to https://github.com/OSOceanAcoustics/echopype/pull/1191 since even new PR's are failing!

Conda is now removed from CI since there isn't any special packages that we need from there anymore and we're basically already installing via pip through conda anyways. Plus this was a recommendation from Filipe to do over the summer.