### PR TITLE
Enhanced `update_platform` to Auto-assign first `ping_time` as `Platform` timestamp for fixed-location update case without timestamp. [all tests ci]

### DIFF
--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -517,9 +517,21 @@ class EchoData:
             if v["ext_time_dim_name"] == "scalar"
         ]
         for platform_var in scalar_vars:
+            # Set time_stamp equal to the first ping time whenever either
+            # latitude or longitude is updated without a time dimension
             ext_var = mappings_expanded[platform_var]["external_var"]
-            # Replace the scalar value and add a history attribute
-            platform[platform_var].data = float(extra_platform_data[ext_var].data)
+            if platform_var == "latitude" or platform_var == "longitude":
+                platform[platform_var].data = np.array([extra_platform_data[ext_var].data])
+                platform[platform_var] = platform[platform_var].assign_coords(
+                    **{
+                        platform[platform_var].dims[0]: [
+                            self["Sonar/Beam_group1"]["ping_time"].data[0]
+                        ]
+                    }
+                )
+            else:
+                # Replace the scalar value and add a history attribute
+                platform[platform_var].data = float(extra_platform_data[ext_var].data)
             platform[platform_var] = platform[platform_var].assign_attrs(
                 **{"history": f"{history_attr}. From external {ext_var} variable."}
             )

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -517,7 +517,7 @@ class EchoData:
             if v["ext_time_dim_name"] == "scalar"
         ]
         for platform_var in scalar_vars:
-            # Set time_stamp equal to the first ping time whenever either
+            # Set timestamp equal to the first ping time whenever either
             # latitude or longitude is updated without a time dimension
             ext_var = mappings_expanded[platform_var]["external_var"]
             if platform_var == "latitude" or platform_var == "longitude":


### PR DESCRIPTION
Addresses #1126. and now `update_platform` will Auto-assign first `ping_time` as `Platform` timestamp for fixed-location update without a timestamp.

CC @leewujung @emiliom 