### PR TITLE
AZFP `platform` group will now include `vertical_offset` data by calculating `depth`

### DIFF
--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -213,7 +213,7 @@ class ParseAZFP(ParseBase):
 
         counts = self.unpacked_data["ancillary"][ping_num][3]
         v_in = 2.5 * (counts / 65535)
-        P = v_in * self.parameters["a1"] + self.parameters["a0"] - 10.125
+        P = v_in * self.parameters["a1"] + self.parameters["a0"] - 10.1325
         return P
 
     def parse_raw(self):

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -7,6 +7,7 @@ import numpy as np
 import xarray as xr
 
 from ..utils.coding import set_time_encodings
+from ..utils.misc import depth_from_pressure
 from .set_groups_base import SetGroupsBase
 
 
@@ -167,6 +168,7 @@ class SetGroupsAZFP(SetGroupsBase):
         """Set the Platform group."""
         platform_dict = {"platform_name": "", "platform_type": "", "platform_code_ICES": ""}
         unpacked_data = self.parser_obj.unpacked_data
+        depth = depth_from_pressure(unpacked_data["pressure"], latitude=30, atm_pres_surf=0)
 
         # Create nan time coordinate for lat/lon (lat/lon do not exist in AZFP 01A data)
         time1 = [np.nan]
@@ -177,7 +179,9 @@ class SetGroupsAZFP(SetGroupsBase):
         tilt_y = [np.nan] if np.isnan(unpacked_data["tilt_y"]).all() else unpacked_data["tilt_y"]
         if (len(tilt_x) == 1 and np.isnan(tilt_x)) and (len(tilt_y) == 1 and np.isnan(tilt_y)):
             time2 = [self.parser_obj.ping_time[0]]
+            depth = [depth[0]]
         else:
+            depth = -1 * depth
             time2 = self.parser_obj.ping_time
 
         # Handle potential nan timestamp for time1 and time2
@@ -208,7 +212,7 @@ class SetGroupsAZFP(SetGroupsBase):
                 ),
                 "vertical_offset": (
                     ["time2"],
-                    [np.nan] * len(time2),
+                    depth,
                     self._varattrs["platform_var_default"]["vertical_offset"],
                 ),
                 "water_level": (

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -170,13 +170,13 @@ class SetGroupsAZFP(SetGroupsBase):
         unpacked_data = self.parser_obj.unpacked_data
         time2 = self.parser_obj.ping_time
         if np.isnan(unpacked_data["pressure"]).all():
-            depth = [np.nan] * len(time2)
-            water_level = [np.nan]
+            vertical_offset = [np.nan] * len(time2)
+            water_level = np.nan
         else:
-            depth = -1 * depth_from_pressure(
+            vertical_offset = -1 * depth_from_pressure(
                 unpacked_data["pressure"], latitude=30, atm_pres_surf=0
             )
-            water_level = [0.0]
+            water_level = 0.0
 
         # Create nan time coordinate for lat/lon (lat/lon do not exist in AZFP 01A data)
         time1 = [np.nan]
@@ -212,11 +212,11 @@ class SetGroupsAZFP(SetGroupsBase):
                 ),
                 "vertical_offset": (
                     ["time2"],
-                    depth,
+                    vertical_offset,
                     self._varattrs["platform_var_default"]["vertical_offset"],
                 ),
                 "water_level": (
-                    ["time1"],
+                    [],
                     water_level,
                     self._varattrs["platform_var_default"]["water_level"],
                 ),

--- a/echopype/convert/set_groups_azfp.py
+++ b/echopype/convert/set_groups_azfp.py
@@ -183,6 +183,11 @@ class SetGroupsAZFP(SetGroupsBase):
 
         tilt_x = unpacked_data["tilt_x"]
         tilt_y = unpacked_data["tilt_y"]
+        if np.isnan(tilt_x).all() and np.isnan(tilt_y).all() and np.isnan(vertical_offset).all():
+            tilt_x = [np.nan]
+            tilt_y = [np.nan]
+            vertical_offset = [np.nan]
+            time2 = [self.parser_obj.ping_time[0]]
 
         # Handle potential nan timestamp for time1 and time2
         time1 = self._nan_timestamp_handler(time1)

--- a/echopype/tests/convert/test_convert_azfp.py
+++ b/echopype/tests/convert/test_convert_azfp.py
@@ -156,8 +156,8 @@ def test_convert_azfp_01a_different_ranges(azfp_path):
     check_platform_required_scalar_vars(echodata)
 
 
-def test_convert_azfp_01a_no_temperature_pressure_tilt(azfp_path):
-    """Test converting file with no valid temperature, pressure and tilt data."""
+def test_convert_azfp_01a_no_temperature_pressure_tilt_verticaloffset(azfp_path):
+    """Test converting file with no valid temperature, pressure, tilt and vertical_offset data."""
     azfp_01a_path = azfp_path / 'rutgers_glider_notemperature/22052500.01A'
     azfp_xml_path = azfp_path / 'rutgers_glider_notemperature/22052501.XML'
 
@@ -173,6 +173,10 @@ def test_convert_azfp_01a_no_temperature_pressure_tilt(azfp_path):
     assert "pressure" in echodata["Environment"]
     assert echodata["Environment"]["pressure"].isnull().all()
 
+    # Vertical offset variable is present in the Platform group and its values are all nan
+    assert "vertical_offset" in echodata["Platform"]
+    assert echodata["Platform"]["vertical_offset"].isnull().all()
+
     # Tilt variables are present in the Platform group and their values are all nan
     assert "tilt_x" in echodata["Platform"]
     assert "tilt_y" in echodata["Platform"]
@@ -180,8 +184,8 @@ def test_convert_azfp_01a_no_temperature_pressure_tilt(azfp_path):
     assert echodata["Platform"]["tilt_y"].isnull().all()
 
 
-def test_convert_azfp_01a_pressure_temperature(azfp_path):
-    """Test converting file with valid pressure and temperature data."""
+def test_convert_azfp_01a_pressure_temperature_verticaloffset(azfp_path):
+    """Test converting file with valid pressure, temperature and vertical_offset data."""
     azfp_01a_path = azfp_path / 'pressure' / '22042221.01A'
     azfp_xml_path = azfp_path / 'pressure' / '22042220.XML'
 
@@ -196,6 +200,10 @@ def test_convert_azfp_01a_pressure_temperature(azfp_path):
     # Temperature variable is present in the Environment group and its values are not all nan
     assert "temperature" in echodata["Environment"]
     assert not echodata["Environment"]["temperature"].isnull().all()
+
+    # Vertical offset variable is present in the Platform group and its values are not all nan
+    assert "vertical_offset" in echodata["Platform"]
+    assert not echodata["Platform"]["vertical_offset"].isnull().all()
 
 
 def test_load_parse_azfp_xml(azfp_path):


### PR DESCRIPTION
Addresses 2nd step of https://github.com/OSOceanAcoustics/echopype/issues/1181#issuecomment-1763217291, by including calculations for `depth` value mentioned in https://github.com/OSOceanAcoustics/echopype/issues/1181#issuecomment-1781696782 which is used to set the `vertical_offset` variable. 

CC @emiliom 