### PR TITLE
Fixes `UnicodeDecodeError` for ES60 files [all tests ci]

### DIFF
--- a/echopype/convert/utils/ek_raw_parsers.py
+++ b/echopype/convert/utils/ek_raw_parsers.py
@@ -1541,7 +1541,7 @@ class SimradRawParser(_SimradDatagramParser):
         for indx, field in enumerate(self.header_fields(version)):
             data[field] = header_values[indx]
             if isinstance(data[field], bytes):
-                data[field] = data[field].decode()
+                data[field] = data[field].decode(encoding="unicode_escape")
 
         data["timestamp"] = nt_to_unix((data["low_date"], data["high_date"]))
         data["bytes_read"] = bytes_read


### PR DESCRIPTION
Addresses #1195 by changing encoding to `unicode_escape` instead of using default encoding `utf-8`.

CC @leewujung 