### PR TITLE
Moved `complex` data type reshaping to parser rather than during rectangularize [all tests ci]

### DIFF
--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -283,24 +283,6 @@ class ParseEK(ParseBase):
 
             # Split complex data into real and imaginary components
             if data_type == "complex":
-                # Get the number of transducer sectors
-                num_transducer_sectors = self.num_transducer_sectors
-
-                if (ch_id in num_transducer_sectors) and (num_transducer_sectors[ch_id] > 0):
-                    # Reshape the padded array
-                    # based on the number of transducer sectors
-                    # if it exists
-                    # This reshaping is the same as what was done for angle data
-                    # in ek_raw_parsers.py.SimradRawParser._unpack_contents
-                    # TODO: consider moving this reshaping there
-                    data_shape = padded_arr.shape
-                    data_shape = (
-                        data_shape[0],
-                        int(data_shape[1] / num_transducer_sectors[ch_id]),
-                        num_transducer_sectors[ch_id],
-                    )
-                    padded_arr = padded_arr.reshape(data_shape)
-
                 # Split the complex data into real and imaginary components
                 padded_arr = {
                     "real": np.real(padded_arr).astype("float64"),

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -708,7 +708,6 @@ class SetGroupsEK80(SetGroupsBase):
         return ds_tmp
 
     def _assemble_ds_complex(self, ch):
-        num_transducer_sectors = self.parser_obj.num_transducer_sectors[ch]
         data_shape = self.parser_obj.ping_data_dict["complex"][ch]["real"].shape
         ds_tmp = xr.Dataset(
             {
@@ -746,7 +745,7 @@ class SetGroupsEK80(SetGroupsBase):
                 ),
                 "beam": (
                     ["beam"],
-                    np.arange(start=1, stop=num_transducer_sectors + 1).astype(str),
+                    np.arange(start=1, stop=data_shape[2] + 1).astype(str),
                     self._varattrs["beam_coord_default"]["beam"],
                 ),
             },

--- a/echopype/convert/utils/ek_raw_parsers.py
+++ b/echopype/convert/utils/ek_raw_parsers.py
@@ -1620,12 +1620,9 @@ class SimradRawParser(_SimradDatagramParser):
                         raw_string[indx : indx + block_size],  # noqa
                         dtype=data["complex_dtype"],
                     )
-                    data_shape = data["complex"].shape
-                    if version == 3:
-                        data["complex"] = data["complex"].reshape(
-                            (int(data_shape[0] / (2 * data["n_complex"])), 2 * data["n_complex"])
-                        )
                     data["complex"].dtype = np.complex64
+                    if version == 3:
+                        data["complex"] = data["complex"].reshape((-1, data["n_complex"]))
                 else:
                     data["complex"] = None
 

--- a/echopype/convert/utils/ek_raw_parsers.py
+++ b/echopype/convert/utils/ek_raw_parsers.py
@@ -1620,6 +1620,11 @@ class SimradRawParser(_SimradDatagramParser):
                         raw_string[indx : indx + block_size],  # noqa
                         dtype=data["complex_dtype"],
                     )
+                    data_shape = data["complex"].shape
+                    if version == 3:
+                        data["complex"] = data["complex"].reshape(
+                            (int(data_shape[0] / (2 * data["n_complex"])), 2 * data["n_complex"])
+                        )
                     data["complex"].dtype = np.complex64
                 else:
                     data["complex"] = None


### PR DESCRIPTION
Addresses #1213 and now `complex` data type reshaping occurs in `ek_raw_parsers.py` instead of in `parse_base.py`.

CC @leewujung @lsetiawan 