### PR TITLE
Handle missing `receiver_sampling_frequency` in EK80 data [all tests ci]

### DIFF
--- a/echopype/calibrate/cal_params.py
+++ b/echopype/calibrate/cal_params.py
@@ -396,7 +396,10 @@ def get_cal_params_EK(
     # Private function to get fs
     def _get_fs():
         # If receiver_sampling_frequency recorded, use it
-        if "receiver_sampling_frequency" in vend:
+        if (
+            "receiver_sampling_frequency" in vend
+            and not np.isclose(vend["receiver_sampling_frequency"], 0).all()
+        ):
             return vend["receiver_sampling_frequency"]
         else:
             # If receiver_sampling_frequency not recorded, use default value


### PR DESCRIPTION
Addresses #1217 by adding a check for `receiver_sampling_frequency` not being equal to 0 or else setting it to its default value.

CC @leewujung 