### PR TITLE
Overhaul AZFP `Environment` group

### DIFF
--- a/echopype/tests/convert/test_convert_azfp.py
+++ b/echopype/tests/convert/test_convert_azfp.py
@@ -165,13 +165,9 @@ def test_convert_azfp_01a_no_temperature_pressure_tilt(azfp_path):
         raw_file=azfp_01a_path, sonar_model='AZFP', xml_path=azfp_xml_path
     )
 
-    # Temperature variable is present in the Environment group and its values are all nan
-    assert "temperature" in echodata["Environment"]
-    assert echodata["Environment"]["temperature"].isnull().all()
-
-    # Pressure variable is present in the Environment group and its values are all nan
-    assert "pressure" in echodata["Environment"]
-    assert echodata["Environment"]["pressure"].isnull().all()
+    # Temperature and pressure variables are not present in the Environment group
+    assert "temperature" not in echodata["Environment"]
+    assert "pressure" not in echodata["Environment"]
 
     # Tilt variables are present in the Platform group and their values are all nan
     assert "tilt_x" in echodata["Platform"]
@@ -182,8 +178,8 @@ def test_convert_azfp_01a_no_temperature_pressure_tilt(azfp_path):
 
 def test_convert_azfp_01a_pressure_temperature(azfp_path):
     """Test converting file with valid pressure and temperature data."""
-    azfp_01a_path = azfp_path / 'pressure' / '22042221.01A'
-    azfp_xml_path = azfp_path / 'pressure' / '22042220.XML'
+    azfp_01a_path = azfp_path / 'pressure/22042221.01A'
+    azfp_xml_path = azfp_path / 'pressure/22042220.XML'
 
     echodata = open_raw(
         raw_file=azfp_01a_path, sonar_model='AZFP', xml_path=azfp_xml_path
@@ -199,7 +195,6 @@ def test_convert_azfp_01a_pressure_temperature(azfp_path):
 
 
 def test_load_parse_azfp_xml(azfp_path):
-
     azfp_xml_path = azfp_path / '23081211.XML'
     parseAZFP = ParseAZFP(None, str(azfp_xml_path))
     parseAZFP.load_AZFP_xml()


### PR DESCRIPTION
Fully addresses #1225.

I'm not aware of a source of data to populate the `absorption_indicative` & `sound_speed_indicative` variables, so I'm simply filling them with `np.nan`. @leewujung do you know if there's something in the AZFP raw data & XML that could be used? If there isn't, or it's not straightforward, I suggest leaving the variables in with `np.nan`; after all, the variables were not present before this PR :sweat_smile: 