### PR TITLE
Fixes issue with Docker build failing

### DIFF
--- a/.ci_helpers/docker/minioci.dockerfile
+++ b/.ci_helpers/docker/minioci.dockerfile
@@ -2,6 +2,7 @@ FROM minio/minio
 ARG TARGETPLATFORM
 
 # Install git
+USER root
 RUN microdnf install git
 
 CMD ["minio", "server", "/data"]


### PR DESCRIPTION
Fixes issue with `minioci.dockerfile` failing. This might be a possible fix to failing build!

CC @leewujung 