### PR TITLE
Fixes build issue with `minioci.dockerfile` [all tests ci]

### DIFF
--- a/.ci_helpers/docker/http.dockerfile
+++ b/.ci_helpers/docker/http.dockerfile
@@ -1,4 +1,7 @@
 FROM httpd:2.4
 ARG TARGETPLATFORM
 
+RUN apt update && apt-get update
+RUN apt install -y git
+
 COPY echopype/test_data /usr/local/apache2/htdocs/data

--- a/.ci_helpers/docker/http.dockerfile
+++ b/.ci_helpers/docker/http.dockerfile
@@ -1,7 +1,4 @@
 FROM httpd:2.4
 ARG TARGETPLATFORM
 
-RUN apt update && apt-get update
-RUN apt install -y git
-
 COPY echopype/test_data /usr/local/apache2/htdocs/data

--- a/.ci_helpers/docker/minioci.dockerfile
+++ b/.ci_helpers/docker/minioci.dockerfile
@@ -1,7 +1,4 @@
-FROM minio/minio:RELEASE.2023-10-25T06-33-25Z.fips
+FROM minio/minio
 ARG TARGETPLATFORM
-
-# Install git
-RUN microdnf install git
 
 CMD ["minio", "server", "/data"]

--- a/.ci_helpers/docker/minioci.dockerfile
+++ b/.ci_helpers/docker/minioci.dockerfile
@@ -1,4 +1,4 @@
-FROM minio/minio
+FROM minio/minio:RELEASE.2023-10-25T06-33-25Z.fips
 ARG TARGETPLATFORM
 
 # Install git


### PR DESCRIPTION
Fixes build issue with `minioci.dockerfile` due to `microdnf` command not found.