### PR TITLE
expose func arg and skip_na to compute_MVBS users

### DIFF
--- a/echopype/commongrid/api.py
+++ b/echopype/commongrid/api.py
@@ -64,8 +64,8 @@ def compute_MVBS(
         See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
         for more details.
     skipna: bool, default True
-        If true, mean function skips NaN values.
-        Else, mean function includes NaN values.
+        If true, the mean operation skips NaN values.
+        Else, the mean operation includes NaN values.
     closed: {'left', 'right'}, default 'left'
         Which side of bin interval is closed.
     **flox_kwargs

--- a/echopype/commongrid/api.py
+++ b/echopype/commongrid/api.py
@@ -34,6 +34,7 @@ def compute_MVBS(
     ping_time_bin: str = "20S",
     method="map-reduce",
     func="nanmean",
+    skipna=True,
     closed: Literal["left", "right"] = "left",
     **flox_kwargs,
 ):
@@ -67,6 +68,11 @@ def compute_MVBS(
         The flox aggregation function used for reducing the data array.
         By default, 'nanmean' is used. Other options can be found in the flox `documentation
         <https://flox.readthedocs.io/en/latest/generated/flox.xarray.xarray_reduce.html>`_.
+    skipna: bool, default True
+        If true, aggregation function skips NaN values.
+        Else, aggregation function includes NaN values.
+        Note that if ``func`` is set to 'mean' and ``skipna`` is set to True, then aggregation
+        will have the same behavior as if func is set to 'nanmean'.
     closed: {'left', 'right'}, default 'left'
         Which side of bin interval is closed.
     **flox_kwargs
@@ -111,6 +117,7 @@ def compute_MVBS(
         range_var=range_var,
         method=method,
         func=func,
+        skipna=skipna,
         **flox_kwargs,
     )
 

--- a/echopype/commongrid/api.py
+++ b/echopype/commongrid/api.py
@@ -33,6 +33,7 @@ def compute_MVBS(
     range_bin: str = "20m",
     ping_time_bin: str = "20S",
     method="map-reduce",
+    func="nanmean",
     closed: Literal["left", "right"] = "left",
     **flox_kwargs,
 ):
@@ -62,6 +63,10 @@ def compute_MVBS(
         The flox strategy for reduction of dask arrays only.
         See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
         for more details.
+    func: str, default 'nanmean'
+        The flox aggregation function used for reducing the data array.
+        By default, 'nanmean' is used. Other options can be found in the flox `documentation
+        <https://flox.readthedocs.io/en/latest/generated/flox.xarray.xarray_reduce.html>`_.
     closed: {'left', 'right'}, default 'left'
         Which side of bin interval is closed.
     **flox_kwargs
@@ -105,6 +110,7 @@ def compute_MVBS(
         ping_interval,
         range_var=range_var,
         method=method,
+        func=func,
         **flox_kwargs,
     )
 

--- a/echopype/commongrid/api.py
+++ b/echopype/commongrid/api.py
@@ -31,7 +31,7 @@ def compute_MVBS(
     ds_Sv: xr.Dataset,
     range_var: Literal["echo_range", "depth"] = "echo_range",
     range_bin: str = "20m",
-    ping_time_bin: str = "20S",
+    ping_time_bin: str = "20s",
     method="map-reduce",
     skipna=True,
     closed: Literal["left", "right"] = "left",
@@ -57,7 +57,7 @@ def compute_MVBS(
         ``depth`` as a data variable.
     range_bin : str, default '20m'
         bin size along ``echo_range`` or ``depth`` in meters.
-    ping_time_bin : str, default '20S'
+    ping_time_bin : str, default '20s'
         bin size along ``ping_time``
     method: str, default 'map-reduce'
         The flox strategy for reduction of dask arrays only.
@@ -273,6 +273,7 @@ def compute_NASC(
     range_bin: str = "10m",
     dist_bin: str = "0.5nmi",
     method: str = "map-reduce",
+    skipna=True,
     closed: Literal["left", "right"] = "left",
     **flox_kwargs,
 ) -> xr.Dataset:
@@ -292,6 +293,9 @@ def compute_NASC(
         The flox strategy for reduction of dask arrays only.
         See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
         for more details.
+    skipna: bool, default True
+        If true, mean function skips NaN values.
+        Else, mean function includes NaN values.
     closed: {'left', 'right'}, default 'left'
         Which side of bin interval is closed.
     **flox_kwargs
@@ -362,6 +366,7 @@ def compute_NASC(
         range_interval,
         dist_interval,
         method=method,
+        skipna=skipna,
         **flox_kwargs,
     )
 

--- a/echopype/commongrid/api.py
+++ b/echopype/commongrid/api.py
@@ -33,7 +33,6 @@ def compute_MVBS(
     range_bin: str = "20m",
     ping_time_bin: str = "20S",
     method="map-reduce",
-    func="nanmean",
     skipna=True,
     closed: Literal["left", "right"] = "left",
     **flox_kwargs,
@@ -64,15 +63,9 @@ def compute_MVBS(
         The flox strategy for reduction of dask arrays only.
         See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
         for more details.
-    func: str, default 'nanmean'
-        The flox aggregation function used for reducing the data array.
-        By default, 'nanmean' is used. Other options can be found in the flox `documentation
-        <https://flox.readthedocs.io/en/latest/generated/flox.xarray.xarray_reduce.html>`_.
     skipna: bool, default True
-        If true, aggregation function skips NaN values.
-        Else, aggregation function includes NaN values.
-        Note that if ``func`` is set to 'mean' and ``skipna`` is set to True, then aggregation
-        will have the same behavior as if func is set to 'nanmean'.
+        If true, mean function skips NaN values.
+        Else, mean function includes NaN values.
     closed: {'left', 'right'}, default 'left'
         Which side of bin interval is closed.
     **flox_kwargs
@@ -116,7 +109,6 @@ def compute_MVBS(
         ping_interval,
         range_var=range_var,
         method=method,
-        func=func,
         skipna=skipna,
         **flox_kwargs,
     )

--- a/echopype/commongrid/api.py
+++ b/echopype/commongrid/api.py
@@ -294,8 +294,8 @@ def compute_NASC(
         See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
         for more details.
     skipna: bool, default True
-        If true, mean function skips NaN values.
-        Else, mean function includes NaN values.
+        If true, the mean operation skips NaN values.
+        Else, the mean operation includes NaN values.
     closed: {'left', 'right'}, default 'left'
         Which side of bin interval is closed.
     **flox_kwargs

--- a/echopype/commongrid/utils.py
+++ b/echopype/commongrid/utils.py
@@ -20,6 +20,7 @@ def compute_raw_MVBS(
     ping_interval: Union[pd.IntervalIndex, np.ndarray],
     range_var: Literal["echo_range", "depth"] = "echo_range",
     method="map-reduce",
+    func="nanmean",
     **flox_kwargs,
 ):
     """
@@ -45,6 +46,10 @@ def compute_raw_MVBS(
         The flox strategy for reduction of dask arrays only.
         See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
         for more details.
+    func: str, default 'nanmean'
+        The flox aggregation function used for reducing the data array.
+        By default, 'nanmean' is used. Other options can be found in the flox `documentation
+        <https://flox.readthedocs.io/en/latest/generated/flox.xarray.xarray_reduce.html>`_.
     **flox_kwargs
         Additional keyword arguments to be passed
         to flox reduction function.
@@ -65,6 +70,7 @@ def compute_raw_MVBS(
         x_var=x_var,
         range_var=range_var,
         method=method,
+        func=func,
         **flox_kwargs,
     )
 
@@ -480,6 +486,7 @@ def _groupby_x_along_channels(
     x_var: Literal["ping_time", "distance_nmi"] = "ping_time",
     range_var: Literal["echo_range", "depth"] = "echo_range",
     method: str = "map-reduce",
+    func: str = "nanmean",
     **flox_kwargs,
 ) -> xr.Dataset:
     """
@@ -517,6 +524,10 @@ def _groupby_x_along_channels(
         The flox strategy for reduction of dask arrays only.
         See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
         for more details.
+    func: str, default 'nanmean'
+        The aggregation function used for reducing the data array.
+        By default, 'nanmean' is used. Other options can be found in the flox `documentation
+        <https://flox.readthedocs.io/en/latest/generated/flox.xarray.xarray_reduce.html>`_.
     **flox_kwargs
         Additional keyword arguments to be passed
         to flox reduction function.
@@ -552,6 +563,7 @@ def _groupby_x_along_channels(
         expected_groups=(None, x_interval, range_interval),
         isbin=[False, True, True],
         method=method,
+        func=func,
         **flox_kwargs,
     )
     return sv_mean

--- a/echopype/commongrid/utils.py
+++ b/echopype/commongrid/utils.py
@@ -47,8 +47,8 @@ def compute_raw_MVBS(
         See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
         for more details.
     skipna: bool, default True
-        If true, mean function skips NaN values.
-        Else, mean function includes NaN values.
+        If true, the mean operation skips NaN values.
+        Else, the mean operation includes NaN values.
     **flox_kwargs
         Additional keyword arguments to be passed
         to flox reduction function.

--- a/echopype/commongrid/utils.py
+++ b/echopype/commongrid/utils.py
@@ -559,7 +559,6 @@ def _groupby_x_along_channels(
         ds_Sv["channel"],
         ds_Sv[x_var],
         ds_Sv[range_var],
-        func="nanmean",
         expected_groups=(None, x_interval, range_interval),
         isbin=[False, True, True],
         method=method,

--- a/echopype/commongrid/utils.py
+++ b/echopype/commongrid/utils.py
@@ -61,6 +61,7 @@ def compute_raw_MVBS(
     # Set initial variables
     ds = xr.Dataset()
     x_var = "ping_time"
+
     sv_mean = _groupby_x_along_channels(
         ds_Sv,
         range_interval,

--- a/echopype/commongrid/utils.py
+++ b/echopype/commongrid/utils.py
@@ -108,8 +108,8 @@ def compute_raw_NASC(
         See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
         for more details.
     skipna: bool, default True
-        If true, mean function skips NaN values.
-        Else, mean function includes NaN values.
+        If true, the mean operation skips NaN values.
+        Else, the mean operation includes NaN values.
     **flox_kwargs
         Additional keyword arguments to be passed
         to flox reduction function.

--- a/echopype/commongrid/utils.py
+++ b/echopype/commongrid/utils.py
@@ -86,6 +86,7 @@ def compute_raw_NASC(
     range_interval: Union[pd.IntervalIndex, np.ndarray],
     dist_interval: Union[pd.IntervalIndex, np.ndarray],
     method="map-reduce",
+    skipna=True,
     **flox_kwargs,
 ):
     """
@@ -106,6 +107,9 @@ def compute_raw_NASC(
         The flox strategy for reduction of dask arrays only.
         See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
         for more details.
+    skipna: bool, default True
+        If true, mean function skips NaN values.
+        Else, mean function includes NaN values.
     **flox_kwargs
         Additional keyword arguments to be passed
         to flox reduction function.
@@ -132,6 +136,8 @@ def compute_raw_NASC(
         x_var=x_var,
         range_var=range_var,
         method=method,
+        func="nanmean" if skipna else "mean",
+        skipna=skipna,
         **flox_kwargs,
     )
 
@@ -142,6 +148,7 @@ def compute_raw_NASC(
         ds_Sv["ping_time"],
         ds_Sv[x_var],
         func="nanmean",
+        skipna=True,
         expected_groups=(dist_interval),
         isbin=True,
         method=method,
@@ -160,7 +167,8 @@ def compute_raw_NASC(
     h_mean_denom = xarray_reduce(
         da_denom,
         ds_Sv[x_var],
-        func="sum",
+        func="nansum",
+        skipna=True,
         expected_groups=(dist_interval),
         isbin=[True],
         method=method,
@@ -171,7 +179,8 @@ def compute_raw_NASC(
         ds_Sv["channel"],
         ds_Sv[x_var],
         ds_Sv[range_var].isel(**{range_dim: slice(0, -1)}),
-        func="sum",
+        func="nansum",
+        skipna=True,
         expected_groups=(None, dist_interval, range_interval),
         isbin=[False, True, True],
         method=method,

--- a/echopype/commongrid/utils.py
+++ b/echopype/commongrid/utils.py
@@ -20,7 +20,6 @@ def compute_raw_MVBS(
     ping_interval: Union[pd.IntervalIndex, np.ndarray],
     range_var: Literal["echo_range", "depth"] = "echo_range",
     method="map-reduce",
-    func="nanmean",
     skipna=True,
     **flox_kwargs,
 ):
@@ -47,15 +46,9 @@ def compute_raw_MVBS(
         The flox strategy for reduction of dask arrays only.
         See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
         for more details.
-    func: str, default 'nanmean'
-        The flox aggregation function used for reducing the data array.
-        By default, 'nanmean' is used. Other options can be found in the flox `documentation
-        <https://flox.readthedocs.io/en/latest/generated/flox.xarray.xarray_reduce.html>`_.
     skipna: bool, default True
-        If true, aggregation function skips NaN values.
-        Else, aggregation function includes NaN values.
-        Note that if ``func`` is set to 'mean' and ``skipna`` is set to True, then aggregation
-        will have the same behavior as if func is set to 'nanmean'.
+        If true, mean function skips NaN values.
+        Else, mean function includes NaN values.
     **flox_kwargs
         Additional keyword arguments to be passed
         to flox reduction function.
@@ -76,7 +69,7 @@ def compute_raw_MVBS(
         x_var=x_var,
         range_var=range_var,
         method=method,
-        func=func,
+        func="nanmean" if skipna else "mean",
         skipna=skipna,
         **flox_kwargs,
     )

--- a/echopype/commongrid/utils.py
+++ b/echopype/commongrid/utils.py
@@ -21,6 +21,7 @@ def compute_raw_MVBS(
     range_var: Literal["echo_range", "depth"] = "echo_range",
     method="map-reduce",
     func="nanmean",
+    skipna=True,
     **flox_kwargs,
 ):
     """
@@ -50,6 +51,11 @@ def compute_raw_MVBS(
         The flox aggregation function used for reducing the data array.
         By default, 'nanmean' is used. Other options can be found in the flox `documentation
         <https://flox.readthedocs.io/en/latest/generated/flox.xarray.xarray_reduce.html>`_.
+    skipna: bool, default True
+        If true, aggregation function skips NaN values.
+        Else, aggregation function includes NaN values.
+        Note that if ``func`` is set to 'mean' and ``skipna`` is set to True, then aggregation
+        will have the same behavior as if func is set to 'nanmean'.
     **flox_kwargs
         Additional keyword arguments to be passed
         to flox reduction function.
@@ -71,6 +77,7 @@ def compute_raw_MVBS(
         range_var=range_var,
         method=method,
         func=func,
+        skipna=skipna,
         **flox_kwargs,
     )
 
@@ -487,6 +494,7 @@ def _groupby_x_along_channels(
     range_var: Literal["echo_range", "depth"] = "echo_range",
     method: str = "map-reduce",
     func: str = "nanmean",
+    skipna: bool = True,
     **flox_kwargs,
 ) -> xr.Dataset:
     """
@@ -528,6 +536,11 @@ def _groupby_x_along_channels(
         The aggregation function used for reducing the data array.
         By default, 'nanmean' is used. Other options can be found in the flox `documentation
         <https://flox.readthedocs.io/en/latest/generated/flox.xarray.xarray_reduce.html>`_.
+    skipna: bool, default True
+        If true, aggregation function skips NaN values.
+        Else, aggregation function includes NaN values.
+        Note that if ``func`` is set to 'mean' and ``skipna`` is set to True, then aggregation
+        will have the same behavior as if func is set to 'nanmean'.
     **flox_kwargs
         Additional keyword arguments to be passed
         to flox reduction function.
@@ -563,6 +576,7 @@ def _groupby_x_along_channels(
         isbin=[False, True, True],
         method=method,
         func=func,
+        skipna=skipna,
         **flox_kwargs,
     )
     return sv_mean

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -378,7 +378,7 @@ class EchoData:
             }
         )
         time_dims_max = max([int(dim[-1]) for dim in platform.dims if dim.startswith("time")])
-        new_time_dims = [f"time{time_dims_max+i+1}" for i in range(len(ext_time_dims))]
+        new_time_dims = [f"time{time_dims_max + i + 1}" for i in range(len(ext_time_dims))]
         # Map each new time dim name to the external time dim name:
         new_time_dims_mappings = {new: ext for new, ext in zip(new_time_dims, ext_time_dims)}
 

--- a/echopype/tests/commongrid/conftest.py
+++ b/echopype/tests/commongrid/conftest.py
@@ -162,6 +162,7 @@ def mock_Sv_dataset_irregular(
     # Sprinkle nans around echo_range
     for pos in mock_nan_ilocs:
         ds_Sv["echo_range"][pos] = np.nan
+        ds_Sv["Sv"][pos] = np.nan
     return ds_Sv
 
 
@@ -201,7 +202,7 @@ def mock_nasc_array_regular(mock_Sv_dataset_regular, mock_parameters):
     dist_bin = 0.5
     range_bin = 2
     channel_len = mock_parameters["channel_len"]
-    expected_nasc_val = _get_expected_nasc_val(ds_Sv, dist_bin, range_bin, channel_len)
+    expected_nasc_val = _get_expected_nasc_val_nanmean(ds_Sv, dist_bin, range_bin, channel_len)
 
     return expected_nasc_val
 
@@ -237,7 +238,7 @@ def mock_nasc_array_irregular(mock_Sv_dataset_irregular, mock_parameters):
     dist_bin = 0.5
     range_bin = 2
     channel_len = mock_parameters["channel_len"]
-    expected_nasc_val = _get_expected_nasc_val(ds_Sv, dist_bin, range_bin, channel_len)
+    expected_nasc_val = _get_expected_nasc_val_nanmean(ds_Sv, dist_bin, range_bin, channel_len)
 
     return expected_nasc_val
 
@@ -463,12 +464,12 @@ def mock_Sv_dataset_NASC(mock_parameters, random_number_generator):
 
 
 # Helper functions to generate mock Sv and MVBS dataset
-def _get_expected_nasc_val(
+def _get_expected_nasc_val_nanmean(
     ds_Sv: xr.Dataset, dist_bin: str, range_bin: float, channel_len: int = 2
 ) -> np.ndarray:
     """
     Helper functions to generate expected NASC outputs from mock Sv dataset
-    by brute-force looping and compute the mean
+    by brute-force looping and compute the nanmean
 
     Parameters
     ----------
@@ -500,7 +501,7 @@ def _get_expected_nasc_val(
     sv = ds_Sv["Sv"].pipe(ep.utils.compute._log2lin)
 
     # Compute sv mean
-    sv_mean = _brute_mean_reduce_3d(
+    sv_mean = _brute_nanmean_reduce_3d(
         sv, ds_Sv, "depth", "distance_nmi", channel_len, dist_interval, range_interval
     )
 
@@ -544,7 +545,7 @@ def _get_expected_nasc_val(
     return sv_mean * h_mean * 4 * np.pi * 1852**2
 
 
-def _brute_mean_reduce_3d(
+def _brute_nanmean_reduce_3d(
     sv: xr.DataArray,
     ds_Sv: xr.Dataset,
     range_var: Literal["echo_range", "depth"],
@@ -610,7 +611,7 @@ def _brute_mean_reduce_3d(
                 if 0 in sv_tmp.shape:
                     mean_vals[ch_idx, x_idx, r_idx] = np.nan
                 else:
-                    mean_vals[ch_idx, x_idx, r_idx] = np.mean(sv_tmp)
+                    mean_vals[ch_idx, x_idx, r_idx] = np.nanmean(sv_tmp)
     return mean_vals
 
 

--- a/echopype/tests/commongrid/test_commongrid_api.py
+++ b/echopype/tests/commongrid/test_commongrid_api.py
@@ -438,7 +438,7 @@ def test_compute_NASC_values(request, er_type):
         ds_Sv = request.getfixturevalue("mock_Sv_dataset_irregular")
         expected_nasc = request.getfixturevalue("mock_nasc_array_irregular")
 
-    ds_NASC = ep.commongrid.compute_NASC(ds_Sv, range_bin=range_bin, dist_bin=dist_bin)
+    ds_NASC = ep.commongrid.compute_NASC(ds_Sv, range_bin=range_bin, dist_bin=dist_bin, skipna=True)
 
     assert ds_NASC.NASC.shape == expected_nasc.shape
     # Floating digits need to check with all close not equal
@@ -463,10 +463,6 @@ def test_compute_MVBS_NASC_skipna_nan_and_non_nan_values(request, operation, ski
     ds_Sv = request.getfixturevalue("mock_Sv_dataset_irregular")
     # Already has 2 channels, so subset for only ping time and range sample
     subset_ds_Sv = ds_Sv.isel(ping_time=slice(0,2), range_sample=slice(0,2))
-    # Set the 1 NaN echo range value to non-NaN value
-    subset_ds_Sv["echo_range"][0, 1, 1] = subset_ds_Sv["echo_range"][0, 0, 1].data
-    # Set one of the first channel values to NaN
-    subset_ds_Sv["Sv"][0, 1, 1] = np.nan
 
     # Compute MVBS / Compute NASC
     if operation == "MVBS":

--- a/echopype/tests/commongrid/test_commongrid_api.py
+++ b/echopype/tests/commongrid/test_commongrid_api.py
@@ -449,6 +449,7 @@ def test_compute_MVBS_values(request, er_type, func, add_nan):
             # Ensure that the 5 NaN Sv values, now projected onto the regridded dataset, turn into 2 NaN values in the case
             # where func is mean.
             assert np.array_equal(ds_MVBS["Sv"][0, 0, 0:2].data, np.array([np.nan, np.nan]), equal_nan=True)
+            assert np.sum(np.isnan(ds_MVBS["Sv"][0, 0, :].data)) == 2
         elif func == "nanmean":
             # Ensure that all values in regridded are non-NaN when func is nanmean 
             assert not np.isnan(ds_MVBS["Sv"][0, 0, :].data).any()


### PR DESCRIPTION
PR for #1268

In addition, modified `test_compute_MVBS_values` to include a test for adding NaNs to the `ds_Sv` to illustrate how that would affect the computation of `compute_MVBS` using both `func="nanmean"` and `func="mean"`.