### PR TITLE
test echo range for EK80 reduced sample rate

### DIFF
--- a/echopype/tests/calibrate/test_range_integration.py
+++ b/echopype/tests/calibrate/test_range_integration.py
@@ -19,6 +19,7 @@ import echopype as ep
         # EK80 CW power
         ("EK80", "EK80", "Summer2018--D20180905-T033113.raw", None, None, None, "CW", "power"),
         # TODO: EK80 reduced sampling rate
+        ("EK80", "EK80", "Summer2018--D20180905-T033113.raw", None, None, None, "BB", "complex"),
     ],
     ids=[
         "azfp",
@@ -26,6 +27,7 @@ import echopype as ep
         "ek80_bb_complex",
         "ek80_cw_complex",
         "ek80_cw_power",
+        "ek80_bb_complex"
     ]
 )
 def test_range_dimensions(


### PR DESCRIPTION
Fixes #969 
I don't know if the mean by reduced sampling rate is the reduced file size, if it is, The **fifth** test case do the same thing as me.
Or I should resample the data?