### PR TITLE
Add add_location warnings

### DIFF
--- a/add_location_nan_zero_warnings.ipynb
+++ b/add_location_nan_zero_warnings.ipynb
@@ -1,0 +1,117 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Pip install necessary libraries\n",
+        "#%pip install echopype s3fs boto3==1.34.51 numpy==1.24.4 xarray==2022.12.0"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Import necessary libraries\n",
+        "import s3fs\n",
+        "import boto3\n",
+        "import echopype as ep\n",
+        "from botocore import UNSIGNED\n",
+        "from botocore.config import Config"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Grab from S3 and parse EK60 \n",
+        "s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))\n",
+        "s3_file_system = s3fs.S3FileSystem(anon=True)\n",
+        "\n",
+        "bucket_name = 'noaa-wcsd-pds'\n",
+        "ship_name = 'Albatross_Iv'\n",
+        "cruise_name = 'AL0403'\n",
+        "sensor_name = 'EK60'\n",
+        "file_name = \"L0010-D20040416-T094042-EK60.raw\"\n",
+        "\n",
+        "raw_file_s3_path = f\"s3://{bucket_name}/data/raw/{ship_name}/{cruise_name}/{sensor_name}/{file_name}\"\n",
+        "echodata = ep.open_raw(raw_file_s3_path, sonar_model=sensor_name, use_swap=True, storage_options={'anon': True})"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Latitude Values Pre Interp (lowest 5): [ 0.          0.         43.68361    43.68362333 43.68362333]\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "2024-04-04 21:06:21,791:echopype.consolidate.api:WARNING: The echodata[\"Platform\"][\"latitude\"] array contains zeros. Interpolation may be negatively impacted, so the user should handle these values.\n",
+            "2024-04-04 21:06:21,792:echopype.consolidate.api:WARNING: The echodata[\"Platform\"][\"longitude\"] array contains zeros. Interpolation may be negatively impacted, so the user should handle these values.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Latitude Values Post Interp (lowest 5): [19.57221436 23.97964969 43.68361412 43.68363238 43.68365699]\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Turn on Echopype Verbosity\n",
+        "ep.utils.log.verbose(override=False)\n",
+        "\n",
+        "# Print out pre interpolated latitudes\n",
+        "latitude = echodata.platform.latitude.values\n",
+        "latitude_values = latitude.copy()\n",
+        "latitude_values.sort()\n",
+        "print(\"Latitude Values Pre Interp (lowest 5):\", latitude_values[:5])\n",
+        "\n",
+        "ds_sv = ep.calibrate.compute_Sv(echodata)\n",
+        "ds_sv_location = ep.consolidate.add_location(ds_sv, echodata)\n",
+        "\n",
+        "# Print out post interpolated latitudes\n",
+        "latitude_2 = ds_sv_location.latitude.values\n",
+        "latitude_values_2 = latitude_2.copy()\n",
+        "latitude_values_2.sort()\n",
+        "print(\"Latitude Values Post Interp (lowest 5):\", latitude_values_2[:5])"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "echopype",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.9.18"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -273,7 +273,7 @@ def apply_mask(
         Points to a Dataset that contains the variable the mask should be applied to
     mask: xr.DataArray, str, pathlib.Path, or a list of these datatypes
         The mask(s) to be applied.
-        Can be a individual input or list that corresponds to a DataArray or a path.
+        Can be a individual input or a list that corresponds to a DataArray or a path.
         Each individual input or entry in the list must contain dimensions
         ``('ping_time', 'range_sample')`` or dimensions ``('ping_time', 'depth')``.
         The mask can also contain the dimension ``channel``.

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -144,7 +144,7 @@ def _validate_and_collect_mask_input(
 
 
 def _check_var_name_fill_value(
-    source_ds: xr.Dataset, var_name: str, fill_value: Union[int, float, np.ndarray, xr.DataArray]
+    source_ds: xr.Dataset, var_name: str, fill_value: Union[int, float, xr.DataArray]
 ) -> Union[int, float, np.ndarray, xr.DataArray]:
     """
     Ensures that the inputs ``var_name`` and ``fill_value`` for the function
@@ -156,12 +156,12 @@ def _check_var_name_fill_value(
         A Dataset that contains the variable ``var_name``
     var_name: str
         The variable name in ``source_ds`` that the mask should be applied to
-    fill_value: int or float or np.ndarray or xr.DataArray
+    fill_value: int, float, or xr.DataArray
         Specifies the value(s) at false indices
 
     Returns
     -------
-    fill_value: int or float or np.ndarray or xr.DataArray
+    fill_value: int, float, or xr.DataArray
         fill_value with sanitized dimensions
 
     Raises
@@ -183,17 +183,12 @@ def _check_var_name_fill_value(
         raise ValueError("The Dataset source_ds does not contain the variable var_name!")
 
     # check the type of fill_value
-    if not isinstance(fill_value, (int, float, np.ndarray, xr.DataArray)):
-        raise TypeError(
-            "The input fill_value must be of type int or " "float or np.ndarray or xr.DataArray!"
-        )
+    if not isinstance(fill_value, (int, float, xr.DataArray)):
+        raise TypeError("The input fill_value must be of type int, float, or xr.DataArray!")
 
     # make sure that fill_values is the same shape as var_name
-    if isinstance(fill_value, (np.ndarray, xr.DataArray)):
-        if isinstance(fill_value, xr.DataArray):
-            fill_value = fill_value.data.squeeze()  # squeeze out length=1 channel dimension
-        elif isinstance(fill_value, np.ndarray):
-            fill_value = fill_value.squeeze()  # squeeze out length=1 channel dimension
+    if isinstance(fill_value, xr.DataArray):
+        fill_value = fill_value.data.squeeze()  # squeeze out length=1 channel dimension
 
         source_ds_shape = (
             source_ds[var_name].isel(channel=0).shape
@@ -292,10 +287,10 @@ def apply_mask(
         ``channel``.
         In the case of a multi-channel Sv data variable, the ``mask`` will be broadcast
         to all channels.
-    fill_value: int, float, np.ndarray, or xr.DataArray, default=np.nan
+    fill_value: int, float, or xr.DataArray, default=np.nan
         Value(s) at masked indices.
-        If ``fill_value`` is of type ``np.ndarray`` or ``xr.DataArray``,
-        it must have the same shape as each entry of ``mask``.
+        If ``fill_value`` is of type ``xr.DataArray`` it must have the same shape as each
+        entry of ``mask``.
     storage_options_ds: dict, default={}
         Any additional parameters for the storage backend, corresponding to the
         path provided for ``source_ds``

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -267,6 +267,17 @@ def apply_mask(
     Applies the provided mask(s) to the Sv variable ``var_name``
     in the provided Dataset ``source_ds``.
 
+    The code allows for these 3 cases of `source_ds` and `mask` dimensions:
+
+    1) No channel in both source ds and mask, but they have matching ping time and depth
+    dimensions.
+    2) Source ds and mask both have matching channel, ping time, and depth dimensions.
+    3) Source ds has channel dimension and mask doesn't, but they have matching ping
+    time and depth dimensions.
+
+    If a user only wants to apply masks to a subset of the channels in source ds,
+    they could put 1s/0s for all data in the channels that are not masked.
+
     Parameters
     ----------
     source_ds: xr.Dataset, str, or pathlib.Path

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -117,6 +117,15 @@ def _validate_and_collect_mask_input(
                     "('channel', 'ping_time', 'depth')"
                 )
 
+        # Check for the channel dimension consistency
+        channel_dim_shapes = set()
+        for mask_indiv in mask:
+            if "channel" in mask_indiv.dims:
+                for mask_chan_ind in range(len(mask_indiv["channel"])):
+                    channel_dim_shapes.add(mask_indiv.isel(channel=mask_chan_ind).shape)
+        if len(channel_dim_shapes) > 1:
+            raise ValueError("All masks must have the same shape in the 'channel' dimension.")
+
     else:
         if not isinstance(storage_options_mask, dict):
             raise ValueError(

--- a/echopype/tests/mask/test_mask.py
+++ b/echopype/tests/mask/test_mask.py
@@ -497,6 +497,49 @@ def test_validate_and_collect_mask_input(
 
 
 @pytest.mark.parametrize(
+    ("mask_list"),
+    [
+    pytest.param(
+        [xr.DataArray([np.identity(4)], dims=['channel', 'ping_time', 'depth'],
+                       coords={'channel': ['channel_0']})]
+    ),
+    pytest.param(
+        [xr.DataArray([np.identity(4), np.identity(4)], dims=['channel', 'ping_time', 'depth'],
+                       coords={'channel': ['channel_0', 'channel_1']})]
+    ),
+    pytest.param(
+        [xr.DataArray([np.identity(4), np.identity(4)], dims=['channel', 'ping_time', 'depth'],
+                       coords={'channel': ['channel_0', 'channel_1']}),
+        xr.DataArray([np.identity(4), np.identity(4)], dims=['channel', 'ping_time', 'depth'],
+                       coords={'channel': ['channel_0', 'channel_1']})]
+    ),
+    pytest.param(
+        [xr.DataArray([np.identity(3), np.identity(3)], dims=['channel', 'ping_time', 'depth'],
+                       coords={'channel': ['channel_0', 'channel_1']}),
+        xr.DataArray([np.identity(4), np.identity(4)], dims=['channel', 'ping_time', 'depth'],
+                       coords={'channel': ['channel_0', 'channel_1']})],
+        marks=pytest.mark.xfail(
+            strict=True,
+            reason="This should fail because the channel dims are not uniform."
+        ))
+    ],
+    ids=["single_channel_mask", "double_channel", "double_channel_double_masks",
+         "inconsistent_channels_across_two_masks"]
+)
+def test_multi_mask_validate_and_collect_mask(mask_list: List[xr.DataArray]):
+    """
+    Tests the allowable types and dimensions for multimask input.
+
+    Parameters
+    ----------
+    mask_list: List[xr.DataArray]
+        Multimask input to be tested in validate and collect mask input.
+    """
+
+    _validate_and_collect_mask_input(mask=mask_list, storage_options_mask={})
+
+
+@pytest.mark.parametrize(
     ("n", "n_chan", "var_name", "fill_value"),
     [
         pytest.param(4, 2, 2.0, np.nan,

--- a/echopype/tests/mask/test_mask.py
+++ b/echopype/tests/mask/test_mask.py
@@ -708,11 +708,12 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
         temp_dir.cleanup()
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
-    ("source_has_ch", "keep_unmasked_channel", "mask", "truth_da"),
+    ("source_has_ch", "mask", "truth_da"),
     [   
-        # source_with_ch_mask_list_with_ch_keep_unmasked_channel_true
-        (True, True, [
+        # source_with_ch_mask_list_with_ch
+        (True, [
         xr.DataArray(
             np.array([np.identity(2), np.identity(2)]),
             coords={"channel": ["chan1", "chan2"], "ping_time": np.arange(2), "depth": np.arange(2)},
@@ -732,32 +733,11 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
                     "ping_time": np.arange(2), "depth": np.arange(2)},
         )),
 
-        # source_with_ch_mask_list_with_ch_keep_unmasked_channel_false
-        (True, False, [
+        # source_with_ch_mask_list_with_ch_fail_different_channel_lengths
+        (True, [
         xr.DataArray(
             np.array([np.identity(2)]),
             coords={"channel": ["chan1"], "ping_time": np.arange(2), "depth": np.arange(2)},
-            attrs={"long_name": "mask_with_channel"},
-        ),
-        xr.DataArray(
-            np.array([np.identity(2)]),
-            coords={"channel": ["chan3"], "ping_time": np.arange(2), "depth": np.arange(2)},
-            attrs={"long_name": "mask_with_channel"},
-        ),
-        ],
-        xr.DataArray(
-            np.array([[[1, np.nan], [np.nan, 1]],
-                     [[np.nan, np.nan], [np.nan, np.nan]],
-                        [[1, np.nan], [np.nan, 1]]]),
-            coords={"channel": ["chan1", "chan2", "chan3"],
-                    "ping_time": np.arange(2), "depth": np.arange(2)},
-        )),
-
-        # source_no_ch_mask_list_with_ch_keep_unmasked_channel_true
-        (False, True, [
-        xr.DataArray(
-            np.array([np.identity(2), np.identity(2)]),
-            coords={"channel": ["chan1", "chan2"], "ping_time": np.arange(2), "depth": np.arange(2)},
             attrs={"long_name": "mask_with_channel"},
         ),
         xr.DataArray(
@@ -766,16 +746,13 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
             attrs={"long_name": "mask_with_channel"},
         ),
         ],
-        xr.DataArray(
-            np.array([[1, np.nan], [np.nan, 1]]),
-            coords={"ping_time": np.arange(2), "depth": np.arange(2)},
-        )),
+        None),
 
-        # source_with_ch_mask_with_ch_keep_unmasked_channel_true
-        (True, True,
+        # source_with_ch_mask_with_ch
+        (True,
         xr.DataArray(
-            np.array([np.identity(2), np.identity(2)]),
-            coords={"channel": ["chan1", "chan2"], "ping_time": np.arange(2), "depth": np.arange(2)},
+            np.array([np.identity(2), np.identity(2), np.ones_like(np.identity(2))]),
+            coords={"channel": ["chan1", "chan2", "chan3"], "ping_time": np.arange(2), "depth": np.arange(2)},
             attrs={"long_name": "mask_with_channel"},
         ),
         xr.DataArray(
@@ -786,34 +763,8 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
                     "ping_time": np.arange(2), "depth": np.arange(2)},
         )),
 
-        # source_with_ch_mask_with_ch_keep_unmasked_channel_false
-        (True, False,
-        xr.DataArray(
-            np.array([np.identity(2), np.identity(2)]),
-            coords={"channel": ["chan1", "chan2"], "ping_time": np.arange(2), "depth": np.arange(2)},
-            attrs={"long_name": "mask_with_channel"},
-        ),
-        xr.DataArray(
-            np.array([[[1, np.nan], [np.nan, 1]],
-                     [[1, np.nan], [np.nan, 1]],
-                     [[np.nan, np.nan], [np.nan, np.nan]]]),
-            coords={"channel": ["chan1", "chan2", "chan3"],
-                    "ping_time": np.arange(2), "depth": np.arange(2)},
-        )),
-
-        # source_no_ch_mask_with_ch_keep_unmasked_channel_true
-        (False, True, xr.DataArray(
-            np.array([np.identity(2), np.identity(2)]),
-            coords={"channel": ["chan1", "chan2"], "ping_time": np.arange(2), "depth": np.arange(2)},
-            attrs={"long_name": "mask_with_channel"},
-        ),
-        xr.DataArray(
-            np.array([[1, np.nan], [np.nan, 1]]),
-            coords={"ping_time": np.arange(2), "depth": np.arange(2)},
-        )),
-
-        # source_with_ch_mask_no_ch_keep_unmasked_channel_true
-        (True, True, xr.DataArray(
+        # source_with_ch_mask_no_ch
+        (True, xr.DataArray(
             np.identity(2),
             coords={"ping_time": np.arange(2), "depth": np.arange(2)},
             attrs={"long_name": "mask_no_channel"},
@@ -825,8 +776,16 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
                     "channel": ["chan1", "chan2", "chan3"]}
         )),
 
-        # source_no_ch_mask_no_ch_keep_unmasked_channel_true
-        (False, True, xr.DataArray(
+        # source_no_ch_mask_with_ch_fail
+        (False, xr.DataArray(
+            np.array([np.identity(2)]),
+            coords={"channel": ["chan1"], "ping_time": np.arange(2), "depth": np.arange(2)},
+            attrs={"long_name": "mask_with_channel"},
+        ),
+        None),
+
+        # source_no_ch_mask_no_ch
+        (False, xr.DataArray(
             np.identity(2),
             coords={"ping_time": np.arange(2), "depth": np.arange(2)},
             attrs={"long_name": "mask_no_channel"},
@@ -835,39 +794,60 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
             np.array([[1, np.nan], [np.nan, 1]]),
             coords={"ping_time": np.arange(2), "depth": np.arange(2)}
         )),
+
+        # source_no_ch_mask_no_ch_fail_different_ping_time_depth_shape
+        (False, xr.DataArray(
+            np.zeros((3, 1)),
+            coords={"ping_time": np.arange(3), "depth": np.arange(1)},
+            attrs={"long_name": "mask_no_channel"},
+        ),
+        None),
     ],
     ids=[
-        "source_with_ch_mask_list_with_ch_keep_unmasked_channel_true",
-        "source_with_ch_mask_list_with_ch_keep_unmasked_channel_false",
-        "source_no_ch_mask_list_with_ch_keep_unmasked_channel_true",
-        "source_with_ch_mask_with_ch_keep_unmasked_channel_true",
-        "source_with_ch_mask_with_ch_keep_unmasked_channel_false",
-        "source_no_ch_mask_with_ch_keep_unmasked_channel_true",
-        "source_with_ch_mask_no_ch_keep_unmasked_channel_true",
-        "source_no_ch_mask_no_ch_keep_unmasked_channel_true",
+        "source_with_ch_mask_list_with_ch",
+        "source_with_ch_mask_list_with_ch_fail_different_channel_lengths",
+        "source_with_ch_mask_with_ch",
+        "source_with_ch_mask_no_ch",
+        "source_no_ch_mask_with_ch_fail",
+        "source_no_ch_mask_no_ch",
+        "source_no_ch_mask_no_ch_fail_different_ping_time_depth_shape",
     ]
 )
-def test_apply_mask_channel_variation(source_has_ch, keep_unmasked_channel, mask, truth_da):
+def test_apply_mask_channel_variation(source_has_ch, mask, truth_da):
 
     # Create source dataset
     source_ds = get_mock_source_ds_apply_mask(2, 3, False)
     var_name = "var1"
 
-    # Apply mask
-    if source_has_ch:
-        masked_ds = echopype.mask.apply_mask(source_ds,
-                                             mask,
-                                             var_name,
-                                             keep_unmasked_channel=keep_unmasked_channel
-                                            )
+    if truth_da is None:
+        # Attempt to apply mask w/ 'bad' shapes and check for raised ValueError
+        with pytest.raises(ValueError):
+            if source_has_ch:
+                masked_ds = echopype.mask.apply_mask(source_ds,
+                                                    mask,
+                                                    var_name
+                                                    )
+            else:
+                source_ds[f"{var_name}_ch0"] = source_ds[var_name].isel(channel=0).squeeze()
+                var_name = f"{var_name}_ch0"
+                masked_ds = echopype.mask.apply_mask(source_ds,
+                                                    mask,
+                                                    var_name
+                                                    )
     else:
-        source_ds[f"{var_name}_ch0"] = source_ds[var_name].isel(channel=0).squeeze()
-        var_name = f"{var_name}_ch0"
-        masked_ds = echopype.mask.apply_mask(source_ds,
-                                             mask,
-                                             var_name,
-                                             keep_unmasked_channel=keep_unmasked_channel
-                                            )
-    
-    # Check mask to match truth
-    assert masked_ds[var_name].equals(truth_da)
+        # Apply mask and check matching truth_da
+        if source_has_ch:
+            masked_ds = echopype.mask.apply_mask(source_ds,
+                                                mask,
+                                                var_name
+                                                )
+        else:
+            source_ds[f"{var_name}_ch0"] = source_ds[var_name].isel(channel=0).squeeze()
+            var_name = f"{var_name}_ch0"
+            masked_ds = echopype.mask.apply_mask(source_ds,
+                                                mask,
+                                                var_name
+                                                )
+        
+        # Check mask to match truth
+        assert masked_ds[var_name].equals(truth_da)

--- a/echopype/tests/mask/test_mask.py
+++ b/echopype/tests/mask/test_mask.py
@@ -707,14 +707,37 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
         # remove the temporary directory, if it was created
         temp_dir.cleanup()
 
-
+"""
 @pytest.mark.parametrize(
-    ("source_has_ch", "mask_has_ch"),
+    ("source_has_ch", "mask"),
     [
-        (True, True),
-        (False, True),
-        (True, False),
-        (False, False),
+        (True, [
+        xr.DataArray(
+            np.array([[np.identity(2)], np.identity(2)]),
+            coords={"channel": ["chan1", "chan2"], "ping_time": np.arange(2), "depth": np.arange(2)},
+            attrs={"long_name": "mask_with_channel"},
+        ),
+        xr.DataArray(
+            np.array([np.identity(2)]),
+            coords={"channel": ["chan3"], "ping_time": np.arange(2), "depth": np.arange(2)},
+            attrs={"long_name": "mask_with_channel"},
+        ),
+        ]),
+        (False, xr.DataArray(
+            np.array([np.identity(2), np.identity(2)]),
+            coords={"channel": ["chan1", "chan2"], "ping_time": np.arange(2), "depth": np.arange(2)},
+            attrs={"long_name": "mask_with_channel"},
+        )),
+        (True, xr.DataArray(
+            np.identity(2),
+            coords={"ping_time": np.arange(2), "depth": np.arange(2)},
+            attrs={"long_name": "mask_no_channel"},
+        )),
+        (False, xr.DataArray(
+            np.identity(2),
+            coords={"ping_time": np.arange(2), "depth": np.arange(2)},
+            attrs={"long_name": "mask_no_channel"},
+        )),
     ],
     ids=[
         "source_with_ch_mask_with_ch",
@@ -723,23 +746,10 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
         "source_no_ch_mask_no_ch",
     ]
 )
-def test_apply_mask_channel_variation(source_has_ch, mask_has_ch):
+def test_apply_mask_channel_variation(source_has_ch, mask):
 
     source_ds = get_mock_source_ds_apply_mask(2, 3, False)
     var_name = "var1"
-
-    if mask_has_ch:
-        mask = xr.DataArray(
-            np.array([np.identity(2)]),
-            coords={"channel": ["chA"], "ping_time": np.arange(2), "depth": np.arange(2)},
-            attrs={"long_name": "mask_with_channel"},
-        )
-    else:
-        mask = xr.DataArray(
-            np.identity(2),
-            coords={"ping_time": np.arange(2), "depth": np.arange(2)},
-            attrs={"long_name": "mask_no_channel"},
-        )
 
     if source_has_ch:
         masked_ds = echopype.mask.apply_mask(source_ds, mask, var_name)
@@ -751,7 +761,7 @@ def test_apply_mask_channel_variation(source_has_ch, mask_has_ch):
     # Output dimension will be the same as source
     if source_has_ch:
         truth_da = xr.DataArray(
-            np.array([[[1, np.nan], [np.nan, 1]]] * 3),
+            np.array([[[1, 1], [1, 1]]] * 3),
             coords={"channel": ["chan1", "chan2", "chan3"], "ping_time": np.arange(2), "depth": np.arange(2)},
             attrs=source_ds[var_name].attrs
         )
@@ -763,3 +773,4 @@ def test_apply_mask_channel_variation(source_has_ch, mask_has_ch):
         )
 
     assert masked_ds[var_name].equals(truth_da)
+"""

--- a/echopype/tests/mask/test_mask.py
+++ b/echopype/tests/mask/test_mask.py
@@ -554,13 +554,12 @@ def test_multi_mask_validate_and_collect_mask(mask_list: List[xr.DataArray]):
                                              reason="This should fail because fill_value is an incorrect type.")),
         (4, 2, "var1", 1),
         (4, 2, "var1", 1.0),
-        (2, 1, "var1", np.identity(2)[None, :]),
+        pytest.param(2, 1, "var1", np.identity(2)[None, :],
+                     marks=pytest.mark.xfail(strict=True,
+                     reason="This should fail because fill_value is an incorrect type.")),
         (2, 1, "var1", xr.DataArray(data=np.array([[[1.0, 0], [0, 1]]]),
                                     coords={"channel": ["chan1"], "ping_time": [0, 1], "depth": [0, 1]})
-         ),
-        pytest.param(4, 2, "var2", np.identity(2),
-                     marks=pytest.mark.xfail(strict=True,
-                                             reason="This should fail because fill_value is not the right shape.")),
+         ),          
         pytest.param(4, 2, "var2",
                      xr.DataArray(data=np.array([[1.0, 0], [0, 1]]),
                                   coords={"ping_time": [0, 1], "range_sample": [0, 1]}),
@@ -569,7 +568,7 @@ def test_multi_mask_validate_and_collect_mask(mask_list: List[xr.DataArray]):
     ],
     ids=["wrong_var_name_type", "no_var_name_ds", "wrong_fill_value_type", "fill_value_int",
          "fill_value_float", "fill_value_np_array", "fill_value_DataArray",
-         "fill_value_np_array_wrong_shape", "fill_value_DataArray_wrong_shape"]
+         "fill_value_DataArray_wrong_shape"]
 )
 def test_check_var_name_fill_value(n: int, n_chan: int, var_name: str,
                                    fill_value: Union[int, float, np.ndarray, xr.DataArray]):
@@ -605,8 +604,11 @@ def test_check_var_name_fill_value(n: int, n_chan: int, var_name: str,
         # single_mask_float_fill
         (2, 1, "var1", np.identity(2), None, 2.0, False, np.array([[1, 2.0], [2.0, 1]]), False),
         # single_mask_np_array_fill
-        (2, 1, "var1", np.identity(2), None, np.array([[[np.nan, np.nan], [np.nan, np.nan]]]),
-         False, np.array([[1, np.nan], [np.nan, 1]]), False),
+        pytest.param(
+            2, 1, "var1", np.identity(2), None, np.array([[[np.nan, np.nan], [np.nan, np.nan]]]),
+            False, np.array([[1, np.nan], [np.nan, 1]]), False,
+            marks=pytest.mark.xfail(strict=True,
+            reason="This should fail because fill_value is an incorrect type.")),
         # single_mask_DataArray_fill
         (2, 1, "var1", np.identity(2), None, xr.DataArray(data=np.array([[[np.nan, np.nan], [np.nan, np.nan]]]),
                                                           coords={"channel": ["chan1"],

--- a/echopype/tests/mask/test_mask.py
+++ b/echopype/tests/mask/test_mask.py
@@ -709,10 +709,10 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
 
 
 @pytest.mark.parametrize(
-    ("source_has_ch", "mask", "truth_da"),
+    ("source_has_ch", "keep_unmasked_channel", "mask", "truth_da"),
     [   
-        # source_with_ch_mask_list_with_ch
-        (True, [
+        # source_with_ch_mask_list_with_ch_keep_unmasked_channel_true
+        (True, True, [
         xr.DataArray(
             np.array([np.identity(2), np.identity(2)]),
             coords={"channel": ["chan1", "chan2"], "ping_time": np.arange(2), "depth": np.arange(2)},
@@ -732,8 +732,47 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
                     "ping_time": np.arange(2), "depth": np.arange(2)},
         )),
 
-        # source_with_ch_mask_with_ch
-        (True,
+        # source_with_ch_mask_list_with_ch_keep_unmasked_channel_false
+        (True, False, [
+        xr.DataArray(
+            np.array([np.identity(2)]),
+            coords={"channel": ["chan1"], "ping_time": np.arange(2), "depth": np.arange(2)},
+            attrs={"long_name": "mask_with_channel"},
+        ),
+        xr.DataArray(
+            np.array([np.identity(2)]),
+            coords={"channel": ["chan3"], "ping_time": np.arange(2), "depth": np.arange(2)},
+            attrs={"long_name": "mask_with_channel"},
+        ),
+        ],
+        xr.DataArray(
+            np.array([[[1, np.nan], [np.nan, 1]],
+                     [[np.nan, np.nan], [np.nan, np.nan]],
+                        [[1, np.nan], [np.nan, 1]]]),
+            coords={"channel": ["chan1", "chan2", "chan3"],
+                    "ping_time": np.arange(2), "depth": np.arange(2)},
+        )),
+
+        # source_no_ch_mask_list_with_ch_keep_unmasked_channel_true
+        (False, True, [
+        xr.DataArray(
+            np.array([np.identity(2), np.identity(2)]),
+            coords={"channel": ["chan1", "chan2"], "ping_time": np.arange(2), "depth": np.arange(2)},
+            attrs={"long_name": "mask_with_channel"},
+        ),
+        xr.DataArray(
+            np.array([np.zeros_like(np.identity(2))]),
+            coords={"channel": ["chan3"], "ping_time": np.arange(2), "depth": np.arange(2)},
+            attrs={"long_name": "mask_with_channel"},
+        ),
+        ],
+        xr.DataArray(
+            np.array([[1, np.nan], [np.nan, 1]]),
+            coords={"ping_time": np.arange(2), "depth": np.arange(2)},
+        )),
+
+        # source_with_ch_mask_with_ch_keep_unmasked_channel_true
+        (True, True,
         xr.DataArray(
             np.array([np.identity(2), np.identity(2)]),
             coords={"channel": ["chan1", "chan2"], "ping_time": np.arange(2), "depth": np.arange(2)},
@@ -747,8 +786,23 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
                     "ping_time": np.arange(2), "depth": np.arange(2)},
         )),
 
-        # source_no_ch_mask_with_ch
-        (False, xr.DataArray(
+        # source_with_ch_mask_with_ch_keep_unmasked_channel_false
+        (True, False,
+        xr.DataArray(
+            np.array([np.identity(2), np.identity(2)]),
+            coords={"channel": ["chan1", "chan2"], "ping_time": np.arange(2), "depth": np.arange(2)},
+            attrs={"long_name": "mask_with_channel"},
+        ),
+        xr.DataArray(
+            np.array([[[1, np.nan], [np.nan, 1]],
+                     [[1, np.nan], [np.nan, 1]],
+                     [[np.nan, np.nan], [np.nan, np.nan]]]),
+            coords={"channel": ["chan1", "chan2", "chan3"],
+                    "ping_time": np.arange(2), "depth": np.arange(2)},
+        )),
+
+        # source_no_ch_mask_with_ch_keep_unmasked_channel_true
+        (False, True, xr.DataArray(
             np.array([np.identity(2), np.identity(2)]),
             coords={"channel": ["chan1", "chan2"], "ping_time": np.arange(2), "depth": np.arange(2)},
             attrs={"long_name": "mask_with_channel"},
@@ -758,8 +812,8 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
             coords={"ping_time": np.arange(2), "depth": np.arange(2)},
         )),
 
-        # source_with_ch_mask_no_ch
-        (True, xr.DataArray(
+        # source_with_ch_mask_no_ch_keep_unmasked_channel_true
+        (True, True, xr.DataArray(
             np.identity(2),
             coords={"ping_time": np.arange(2), "depth": np.arange(2)},
             attrs={"long_name": "mask_no_channel"},
@@ -771,8 +825,8 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
                     "channel": ["chan1", "chan2", "chan3"]}
         )),
 
-        # source_no_ch_mask_no_ch
-        (False, xr.DataArray(
+        # source_no_ch_mask_no_ch_keep_unmasked_channel_true
+        (False, True, xr.DataArray(
             np.identity(2),
             coords={"ping_time": np.arange(2), "depth": np.arange(2)},
             attrs={"long_name": "mask_no_channel"},
@@ -783,22 +837,37 @@ def test_apply_mask(n: int, n_chan: int, var_name: str,
         )),
     ],
     ids=[
-        "source_with_ch_mask_list_with_ch",
-        "source_with_ch_mask_with_ch",
-        "source_no_ch_mask_with_ch",
-        "source_with_ch_mask_no_ch",
-        "source_no_ch_mask_no_ch",
+        "source_with_ch_mask_list_with_ch_keep_unmasked_channel_true",
+        "source_with_ch_mask_list_with_ch_keep_unmasked_channel_false",
+        "source_no_ch_mask_list_with_ch_keep_unmasked_channel_true",
+        "source_with_ch_mask_with_ch_keep_unmasked_channel_true",
+        "source_with_ch_mask_with_ch_keep_unmasked_channel_false",
+        "source_no_ch_mask_with_ch_keep_unmasked_channel_true",
+        "source_with_ch_mask_no_ch_keep_unmasked_channel_true",
+        "source_no_ch_mask_no_ch_keep_unmasked_channel_true",
     ]
 )
-def test_apply_mask_channel_variation(source_has_ch, mask, truth_da):
+def test_apply_mask_channel_variation(source_has_ch, keep_unmasked_channel, mask, truth_da):
 
+    # Create source dataset
     source_ds = get_mock_source_ds_apply_mask(2, 3, False)
     var_name = "var1"
 
+    # Apply mask
     if source_has_ch:
-        masked_ds = echopype.mask.apply_mask(source_ds, mask, var_name)
+        masked_ds = echopype.mask.apply_mask(source_ds,
+                                             mask,
+                                             var_name,
+                                             keep_unmasked_channel=keep_unmasked_channel
+                                            )
     else:
         source_ds[f"{var_name}_ch0"] = source_ds[var_name].isel(channel=0).squeeze()
         var_name = f"{var_name}_ch0"
-        masked_ds = echopype.mask.apply_mask(source_ds, mask, var_name)
+        masked_ds = echopype.mask.apply_mask(source_ds,
+                                             mask,
+                                             var_name,
+                                             keep_unmasked_channel=keep_unmasked_channel
+                                            )
+    
+    # Check mask to match truth
     assert masked_ds[var_name].equals(truth_da)


### PR DESCRIPTION
Add warnings for `add_location` for NaN/0 lat/lon and duplicated timestamps to address the following issues:
[Strange GPS coordinates appearing with add_location() method #1286](https://github.com/OSOceanAcoustics/echopype/issues/1286)
[add_location fails with duplicated timestamps in GPS data #1294](https://github.com/OSOceanAcoustics/echopype/issues/1294)