### PR TITLE
Update `_calc_Sv_offset` for AZFP parsing

### DIFF
--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -13,6 +13,42 @@ from .parse_base import ParseBase
 
 FILENAME_DATETIME_AZFP = "\\w+.01A"
 
+# Common Sv_offset values for frequency > 38 kHz
+SV_OFFSET_HF = {
+    300: 1.1,
+    500: 0.8,
+    700: 0.5,
+    900: 0.3,
+    1000: 0.3,
+}
+SV_OFFSET_LF = {
+    500: 1.1,
+    1000: 0.7,
+}
+SV_OFFSET = {
+    38000.0: {**SV_OFFSET_LF},
+    67000.0: {
+        500: 1.1,
+        **SV_OFFSET_HF,
+    },
+    125000.0: {
+        150: 1.4,
+        250: 1.3,
+        **SV_OFFSET_HF,
+    },
+    200000.0: {
+        150: 1.4,
+        250: 1.3,
+        **SV_OFFSET_HF,
+    },
+    455000.0: {
+        250: 1.3, **SV_OFFSET_HF,
+    },
+    769000.0: {
+        150: 1.4, **SV_OFFSET_HF,
+    },
+}
+
 HEADER_FIELDS = (
     ("profile_flag", "u2"),
     ("profile_number", "u2"),
@@ -480,22 +516,31 @@ class ParseAZFP(ParseBase):
         self.ping_time = ping_time
 
     @staticmethod
-    def _calc_Sv_offset(f, pulse_len):
-        """Calculate the compensation factor for Sv calculation."""
-        # TODO: this method seems should be in echopype.process
-        if f > 38000:
-            if pulse_len == 300:
-                return 1.1
-            elif pulse_len == 500:
-                return 0.8
-            elif pulse_len == 700:
-                return 0.5
-            elif pulse_len == 900:
-                return 0.3
-            elif pulse_len == 1000:
-                return 0.3
-        else:
-            if pulse_len == 500:
-                return 1.1
-            elif pulse_len == 1000:
-                return 0.7
+    def _calc_Sv_offset(freq, pulse_len):
+        """
+        Calculate the compensation factor for Sv calculation.
+
+        Parameters
+        ----------
+        freq : number
+            transmit frequency
+        pulse_len : number
+            pulse length
+        """
+        # Check if the specified freq is in the allowable Sv_offset dict
+        if freq not in SV_OFFSET.keys():
+            raise ValueError(
+                f"Frequency {freq} Hz is not in the Sv offset dictionary! "
+                "Please contact AZFP Environmental Sciences "
+                "and raise an issue in the echopype repository."
+            )
+        
+        # Check if the specified freq-pulse length combination is in the allowable Sv_offset dict
+        if pulse_len not in SV_OFFSET[freq]:
+            raise ValueError(
+                f"Pulse length {pulse_len} us is not in the Sv offset dictionary! "
+                "Please contact AZFP Environmental Sciences "
+                "and raise an issue in the echopype repository."
+            )
+
+        return SV_OFFSET[freq][pulse_len]

--- a/echopype/convert/parse_azfp.py
+++ b/echopype/convert/parse_azfp.py
@@ -42,10 +42,12 @@ SV_OFFSET = {
         **SV_OFFSET_HF,
     },
     455000.0: {
-        250: 1.3, **SV_OFFSET_HF,
+        250: 1.3,
+        **SV_OFFSET_HF,
     },
     769000.0: {
-        150: 1.4, **SV_OFFSET_HF,
+        150: 1.4,
+        **SV_OFFSET_HF,
     },
 }
 
@@ -534,7 +536,7 @@ class ParseAZFP(ParseBase):
                 "Please contact AZFP Environmental Sciences "
                 "and raise an issue in the echopype repository."
             )
-        
+
         # Check if the specified freq-pulse length combination is in the allowable Sv_offset dict
         if pulse_len not in SV_OFFSET[freq]:
             raise ValueError(

--- a/echopype/tests/convert/test_convert_azfp.py
+++ b/echopype/tests/convert/test_convert_azfp.py
@@ -95,6 +95,7 @@ def test_convert_azfp_01a_matlab_raw(azfp_path):
     check_platform_required_scalar_vars(echodata)
 
 
+@pytest.mark.skip(reason="tests for comparing AZFP converted data with Matlab outputs have not been implemented")
 def test_convert_azfp_01a_matlab_derived():
     """Compare variables derived from raw parsed data with Matlab outputs."""
     # TODO: test derived data
@@ -104,9 +105,6 @@ def test_convert_azfp_01a_matlab_derived():
 
     # # check convention-required variables in the Platform group
     # check_platform_required_scalar_vars(echodata)
-
-    pytest.xfail("Tests for converting AZFP and comparing it"
-                 + " against Matlab derived data have not been implemented yet.")
 
 
 def test_convert_azfp_01a_raw_echoview(azfp_path):
@@ -156,8 +154,10 @@ def test_convert_azfp_01a_different_ranges(azfp_path):
     check_platform_required_scalar_vars(echodata)
 
 
+@pytest.mark.skip(reason="required pulse length not in Sv offset dictionary")
 def test_convert_azfp_01a_no_temperature_pressure_tilt(azfp_path):
     """Test converting file with no valid temperature, pressure and tilt data."""
+
     azfp_01a_path = azfp_path / 'rutgers_glider_notemperature/22052500.01A'
     azfp_xml_path = azfp_path / 'rutgers_glider_notemperature/22052501.XML'
 


### PR DESCRIPTION
This PR includes the following:
- adds additional values in the Sv_offset dictionary based on communication with ASL Evn Sci
- updates `_calc_Sv_offset` to use a param dictionary instead of nested if-else

One existing test needs to be skipped because the pulse length is not in the Sv_offset dictionary.
We need to request a new file from ASL or Rutgers folks to make sure we still have tests covering files without temperature/pressure/tilt data (those on glider).

This is to address #1300.