### PR TITLE
Support lazy-loaded EK80 broadband-complex data

### DIFF
--- a/echopype/calibrate/calibrate_ek.py
+++ b/echopype/calibrate/calibrate_ek.py
@@ -322,7 +322,7 @@ class CalibrateEK80(CalibrateEK):
             # assume transmit_type identical for all pings in a channel
             first_ping_transmit_type = (
                 beam["transmit_type"].isel(ping_time=0).drop_vars("ping_time")
-            )  # noqa
+            ).compute()  # noqa
             return {
                 # For BB: Keep only non-CW channels (LFM or FMD) based on transmit_type
                 "BB": first_ping_transmit_type.where(
@@ -544,9 +544,9 @@ class CalibrateEK80(CalibrateEK):
                 ping_time=beam["ping_time"],
             )
             # Use pulse_duration in place of tau_effective for GPT channels
-            # below assumesthat all transmit parameters are identical
+            # TODO: below assumes that all transmit parameters are identical
             # and needs to be changed when allowing transmit parameters to vary by ping
-            ch_GPT = vend["transceiver_type"] == "GPT"
+            ch_GPT = (vend["transceiver_type"] == "GPT").compute()
             tau_effective[ch_GPT] = beam["transmit_duration_nominal"][ch_GPT].isel(ping_time=0)
 
             # equivalent_beam_angle

--- a/echopype/calibrate/ek80_complex.py
+++ b/echopype/calibrate/ek80_complex.py
@@ -294,20 +294,27 @@ def compress_pulse(backscatter: xr.DataArray, chirp: Dict) -> xr.DataArray:
         replica = np.flipud(np.conj(tx))
 
         # Apply convolve on backscatter (along range sample dimension) and replica
+        # Rechunking backscatter_chan is needed to avoid the following ValueError:
+        #    ValueError: dimension range_sample on 0th function argument to apply_ufunc 
+        #    with dask='parallelized' consists of multiple chunks, but is also a core dimension.
+        #    To fix, either rechunk into a single array chunk along this dimension,
+        #    i.e., ``.chunk(dict(range_sample=-1))``,
+        #    or pass ``allow_rechunk=True`` in ``dask_gufunc_kwargs`` 
+        #    but beware that this may significantly increase memory usage.
         pc = xr.apply_ufunc(
             lambda m: (signal.convolve(m, replica, mode="full")[replica.size - 1 :]),
-            backscatter_chan,
+            backscatter_chan.chunk({"range_sample": -1}),
             input_core_dims=[["range_sample"]],
             output_core_dims=[["range_sample"]],
             dask="parallelized",
             vectorize=True,
             output_dtypes=[np.complex64],
-        ).compute()
+        )#.compute()
 
         # Restore NaN values in the resulting array.
         # Computing of `nan_mask` here is necessary in the case when `nan_mask` is lazy loaded
         # or else the resulting `pc` will also be lazy loaded.
-        pc = xr.where(nan_mask.compute(), np.nan, pc)
+        pc = xr.where(nan_mask, np.nan, pc)
 
         pc_all.append(pc)
 

--- a/echopype/tests/calibrate/test_calibrate_ek80.py
+++ b/echopype/tests/calibrate/test_calibrate_ek80.py
@@ -306,7 +306,10 @@ def test_ek80_BB_power_compute_Sv(
         encode_mode=encode_mode,
     )
     pyel_vals = pyel_BB_p_data["sv_data"]
-    ep_vals = ds_Sv["Sv"].sel(channel=ch_sel).squeeze().data.compute()
+    if dask_array:
+        ep_vals = ds_Sv["Sv"].sel(channel=ch_sel).squeeze().data.compute()	
+    else:	
+        ep_vals = ds_Sv["Sv"].sel(channel=ch_sel).squeeze().data
 
     assert pyel_vals.shape == ep_vals.shape
     idx_to_cmp = ~(

--- a/echopype/tests/calibrate/test_calibrate_ek80.py
+++ b/echopype/tests/calibrate/test_calibrate_ek80.py
@@ -419,7 +419,8 @@ def test_ek80_CW_complex_Sv_receiver_sampling_freq(ek80_path):
 @pytest.mark.integration
 def test_ek80_BB_complex_multiplex_NaNs_and_non_NaNs(raw_data_path, target_channel_ping_pattern):
     # Extract bb complex multiplex EK80 data
-    ed = ep.open_raw(f"echopype/test_data/ek80_bb_complex_multiplex/{raw_data_path}", sonar_model="EK80")
+    # ed = ep.open_raw(f"echopype/test_data/ek80_bb_complex_multiplex/{raw_data_path}", sonar_model="EK80")
+    ed = ep.open_converted(f"echopype/test_data/ek80_bb_complex_multiplex/NYOS2105-D20210525-T213648.zarr", chunks={})
 
     # Compute Sv
     ds_Sv = ep.calibrate.compute_Sv(ed,waveform_mode='BB',encode_mode='complex')

--- a/echopype/tests/calibrate/test_calibrate_ek80.py
+++ b/echopype/tests/calibrate/test_calibrate_ek80.py
@@ -419,8 +419,7 @@ def test_ek80_CW_complex_Sv_receiver_sampling_freq(ek80_path):
 @pytest.mark.integration
 def test_ek80_BB_complex_multiplex_NaNs_and_non_NaNs(raw_data_path, target_channel_ping_pattern):
     # Extract bb complex multiplex EK80 data
-    # ed = ep.open_raw(f"echopype/test_data/ek80_bb_complex_multiplex/{raw_data_path}", sonar_model="EK80")
-    ed = ep.open_converted(f"echopype/test_data/ek80_bb_complex_multiplex/NYOS2105-D20210525-T213648.zarr", chunks={})
+    ed = ep.open_raw(f"echopype/test_data/ek80_bb_complex_multiplex/{raw_data_path}", sonar_model="EK80")
 
     # Compute Sv
     ds_Sv = ep.calibrate.compute_Sv(ed,waveform_mode='BB',encode_mode='complex')


### PR DESCRIPTION
This PR addresses the issues with for "Indexing with a boolean dask array is not allowed" encountered when calibrating EK80 complex data that is lazy-loaded.

This issue essentially calls for forcing to compute in the places where such indexing occurs. The cases I've seen (and "fixed") so far are using boolean indexing to select channels (based on data from the first ping), so the impact on performance is likely small. Right now this is fine since we restrict the use case to when the transmit signals are identical across all `ping_time` (but can vary across `channel`). Performance issue may arise when we want to accommodate transmit signal change across `ping _time` (#925).

I also adjusted one place in the convolution code to allow dask to function in parallel, by rechunking the `range_sample` dimension into 1 chunk.

**Note: this is not yet ready for review.**