### PR TITLE
Coding: `channel_mode` dtype from `float16` to `float32`

### DIFF
--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -41,7 +41,7 @@ EXPECTED_VAR_DTYPE = {
     "channel": np.str_,
     "cal_channel_id": np.str_,
     "beam": np.str_,
-    "channel_mode": np.float16,
+    "channel_mode": np.float32,
     "beam_stabilisation": np.byte,
     "non_quantitative_processing": np.int16,
 }  # channel name  # beam name


### PR DESCRIPTION
Fixes #1348: NetCDF doesn't accept `np.float16` and only accepts `np.float32` and `np.float64`.