### PR TITLE
Padding Short Pings

### DIFF
--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -639,13 +639,15 @@ class ParseEK(ParseBase):
             # Create output array from mask
             out_array = np.full(mask.shape, np.nan)
 
+            # Concatenate short pings
+            concat_short_pings = np.concatenate(data_list).reshape(-1)  # reshape in case data > 1D
+
             # Take care of problem of np.nan being implicitly "real"
-            arr_dtype = data_list[0].dtype
-            if np.issubdtype(arr_dtype, np.complex_):
-                out_array = out_array.astype(arr_dtype)
+            if concat_short_pings.dtype == np.complex64:
+                out_array = out_array.astype(np.complex64)
 
             # Fill in values
-            out_array[mask] = np.concatenate(data_list).reshape(-1)  # reshape in case data > 1D
+            out_array[mask] = concat_short_pings
         else:
             out_array = np.array(data_list)
         return out_array


### PR DESCRIPTION
When testing SWFSC RAW files, there was a file where range was adaptive and based on bottom. When `open_raw` is called, these pings need to be padded because they are short and non-uniform with the other short pings. In this padding code, there was a snippet that relied on `complex_` to work, but `complex_` is `complex128`, while our data is `complex64`. I changed this to instead use `complex64`.