### PR TITLE
hotfix: Temporarily skip datagrams generated by EC150

### DIFF
--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -500,13 +500,13 @@ class ParseEK(ParseBase):
                     self.environment["timestamp"] = new_datagram["timestamp"]
                 elif new_datagram["subtype"] == "parameter":
                     if "EC150" not in new_datagram["parameter"]["channel_id"]:
-                        print(
-                            f"{new_datagram['parameter']['channel_id']} from XML-parameter "
-                            "-- NOT SKIPPING"
-                        )
+                        #    print(
+                        #        f"{new_datagram['parameter']['channel_id']} from XML-parameter "
+                        #        "-- NOT SKIPPING"
+                        #    )
                         current_parameters = new_datagram["parameter"]
-                    # else:
-                    #     print(f"{new_datagram['parameter']['channel_id']} from XML-parameter")
+                # else:
+                #     print(f"{new_datagram['parameter']['channel_id']} from XML-parameter")
 
             # RAW0 datagrams store raw acoustic data for a channel for EK60
             elif new_datagram["type"].startswith("RAW0"):

--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -498,8 +498,11 @@ class ParseEK(ParseBase):
                     self.environment["xml"] = new_datagram["xml"]
                     self.environment["timestamp"] = new_datagram["timestamp"]
                 elif new_datagram["subtype"] == "parameter":
-                    if not "EC150" in new_datagram["parameter"]["channel_id"]:
-                        # print(f"{new_datagram['parameter']['channel_id']} from XML-parameter -- NOT SKIPPING")
+                    if "EC150" not in new_datagram["parameter"]["channel_id"]:
+                        print(
+                            f"{new_datagram['parameter']['channel_id']} from XML-parameter "
+                            "-- NOT SKIPPING"
+                        )
                         current_parameters = new_datagram["parameter"]
                     # else:
                     #     print(f"{new_datagram['parameter']['channel_id']} from XML-parameter")
@@ -519,7 +522,7 @@ class ParseEK(ParseBase):
             #   - RAW3
             # RAW3 datagrams store raw acoustic data for a channel for EK80
             elif new_datagram["type"].startswith("RAW3"):
-                if not "EC150" in new_datagram["channel_id"]:
+                if "EC150" not in new_datagram["channel_id"]:
                     # print(f"{new_datagram['channel_id']} from RAW3 -- NOT SKIPPING")
                     curr_ch_id = new_datagram["channel_id"]
                     # Check if the proceeding Parameter XML does not
@@ -538,7 +541,7 @@ class ParseEK(ParseBase):
 
             # RAW4 datagrams store raw transmit pulse for a channel for EK80
             elif new_datagram["type"].startswith("RAW4"):
-                if not "EC150" in new_datagram["channel_id"]:
+                if "EC150" not in new_datagram["channel_id"]:
                     # print(f"{new_datagram['channel_id']} from RAW4 -- NOT SKIPPING")
                     curr_ch_id = new_datagram["channel_id"]
                     # Check if the proceeding Parameter XML does not
@@ -570,7 +573,7 @@ class ParseEK(ParseBase):
 
             # FIL datagrams contain filters for processing bascatter data for EK80
             elif new_datagram["type"].startswith("FIL"):
-                if not "EC150" in new_datagram["channel_id"]:
+                if "EC150" not in new_datagram["channel_id"]:
                     # print(f"{new_datagram['channel_id']} from FIL -- NOT SKIPPING")
                     self.fil_coeffs[new_datagram["channel_id"]][new_datagram["stage"]] = new_datagram[
                         "coefficients"

--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -349,13 +349,14 @@ class ParseEK(ParseBase):
                 self.config_datagram["timestamp"].replace(tzinfo=None), "[ns]"
             )
 
-            # Remove EC150 (ADCP) config datagrams
-            channel_id = list(self.config_datagram["configuration"].keys())
-            channel_id_rm = [ch for ch in channel_id if "EC150" in ch]
-            for ch in channel_id_rm:
-                _ = self.config_datagram["configuration"].pop(ch)
-
+            # Only EK80 files have configuration in self.config_datagram
             if "configuration" in self.config_datagram:
+                # Remove EC150 (ADCP) from config
+                channel_id = list(self.config_datagram["configuration"].keys())
+                channel_id_rm = [ch for ch in channel_id if "EC150" in ch]
+                for ch in channel_id_rm:
+                    _ = self.config_datagram["configuration"].pop(ch)
+
                 for v in self.config_datagram["configuration"].values():
                     if "pulse_duration" not in v and "pulse_length" in v:
                         # it seems like sometimes this field can appear with the name "pulse_length"

--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -348,6 +348,13 @@ class ParseEK(ParseBase):
             self.config_datagram["timestamp"] = np.datetime64(
                 self.config_datagram["timestamp"].replace(tzinfo=None), "[ns]"
             )
+
+            # Remove EC150 (ADCP) config datagrams
+            channel_id = list(self.config_datagram["configuration"].keys())
+            channel_id_rm = [ch for ch in channel_id if "EC150" in ch]
+            for ch in channel_id_rm:
+                _ = self.config_datagram["configuration"].pop(ch)
+
             if "configuration" in self.config_datagram:
                 for v in self.config_datagram["configuration"].values():
                     if "pulse_duration" not in v and "pulse_length" in v:
@@ -476,6 +483,12 @@ class ParseEK(ParseBase):
                 new_datagram["timestamp"].replace(tzinfo=None), "[ns]"
             )
 
+            # # For debugging EC150 datagrams
+            # if new_datagram["type"].startswith("XML") and "subtype" in new_datagram:
+            #     print(f"{new_datagram['type']} - {new_datagram['subtype']}")
+            # else:
+            #     print(new_datagram["type"])
+
             num_datagrams_parsed += 1
 
             # XML datagrams store environment or instrument parameters for EK80
@@ -485,7 +498,11 @@ class ParseEK(ParseBase):
                     self.environment["xml"] = new_datagram["xml"]
                     self.environment["timestamp"] = new_datagram["timestamp"]
                 elif new_datagram["subtype"] == "parameter":
-                    current_parameters = new_datagram["parameter"]
+                    if not "EC150" in new_datagram["parameter"]["channel_id"]:
+                        # print(f"{new_datagram['parameter']['channel_id']} from XML-parameter -- NOT SKIPPING")
+                        current_parameters = new_datagram["parameter"]
+                    # else:
+                    #     print(f"{new_datagram['parameter']['channel_id']} from XML-parameter")
 
             # RAW0 datagrams store raw acoustic data for a channel for EK60
             elif new_datagram["type"].startswith("RAW0"):
@@ -502,33 +519,41 @@ class ParseEK(ParseBase):
             #   - RAW3
             # RAW3 datagrams store raw acoustic data for a channel for EK80
             elif new_datagram["type"].startswith("RAW3"):
-                curr_ch_id = new_datagram["channel_id"]
-                # Check if the proceeding Parameter XML does not
-                # match with data in this RAW3 datagram
-                if current_parameters["channel_id"] != curr_ch_id:
-                    raise ValueError("Parameter ID does not match RAW")
+                if not "EC150" in new_datagram["channel_id"]:
+                    # print(f"{new_datagram['channel_id']} from RAW3 -- NOT SKIPPING")
+                    curr_ch_id = new_datagram["channel_id"]
+                    # Check if the proceeding Parameter XML does not
+                    # match with data in this RAW3 datagram
+                    if current_parameters["channel_id"] != curr_ch_id:
+                        raise ValueError("Parameter ID does not match RAW")
 
-                # Save channel-specific ping time
-                self.ping_time[curr_ch_id].append(new_datagram["timestamp"])
+                    # Save channel-specific ping time
+                    self.ping_time[curr_ch_id].append(new_datagram["timestamp"])
 
-                # Append ping by ping data
-                new_datagram.update(current_parameters)
-                self._append_channel_ping_data(new_datagram)
+                    # Append ping by ping data
+                    new_datagram.update(current_parameters)
+                    self._append_channel_ping_data(new_datagram)
+                # else:
+                #     print(f"{new_datagram['channel_id']} from RAW3")
 
             # RAW4 datagrams store raw transmit pulse for a channel for EK80
             elif new_datagram["type"].startswith("RAW4"):
-                curr_ch_id = new_datagram["channel_id"]
-                # Check if the proceeding Parameter XML does not
-                # match with data in this RAW4 datagram
-                if current_parameters["channel_id"] != curr_ch_id:
-                    raise ValueError("Parameter ID does not match RAW")
+                if not "EC150" in new_datagram["channel_id"]:
+                    # print(f"{new_datagram['channel_id']} from RAW4 -- NOT SKIPPING")
+                    curr_ch_id = new_datagram["channel_id"]
+                    # Check if the proceeding Parameter XML does not
+                    # match with data in this RAW4 datagram
+                    if current_parameters["channel_id"] != curr_ch_id:
+                        raise ValueError("Parameter ID does not match RAW")
 
-                # Ping time is identical to the immediately following RAW3 datagram
-                # so does not need to be stored separately
+                    # Ping time is identical to the immediately following RAW3 datagram
+                    # so does not need to be stored separately
 
-                # Append ping by ping data
-                new_datagram.update(current_parameters)
-                self._append_channel_ping_data(new_datagram, raw_type="transmit")
+                    # Append ping by ping data
+                    new_datagram.update(current_parameters)
+                    self._append_channel_ping_data(new_datagram, raw_type="transmit")
+                # else:
+                #     print(f"{new_datagram['channel_id']} from RAW4")
 
             # NME datagrams store ancillary data as NMEA-0817 style ASCII data.
             elif new_datagram["type"].startswith("NME"):
@@ -545,12 +570,17 @@ class ParseEK(ParseBase):
 
             # FIL datagrams contain filters for processing bascatter data for EK80
             elif new_datagram["type"].startswith("FIL"):
-                self.fil_coeffs[new_datagram["channel_id"]][new_datagram["stage"]] = new_datagram[
-                    "coefficients"
-                ]
-                self.fil_df[new_datagram["channel_id"]][new_datagram["stage"]] = new_datagram[
-                    "decimation_factor"
-                ]
+                if not "EC150" in new_datagram["channel_id"]:
+                    # print(f"{new_datagram['channel_id']} from FIL -- NOT SKIPPING")
+                    self.fil_coeffs[new_datagram["channel_id"]][new_datagram["stage"]] = new_datagram[
+                        "coefficients"
+                    ]
+                    self.fil_df[new_datagram["channel_id"]][new_datagram["stage"]] = new_datagram[
+                        "decimation_factor"
+                    ]
+                # else:
+                #     print(f"{new_datagram['channel_id']} from FIL")
+
 
             # TAG datagrams contain time-stamped annotations inserted via the recording software
             elif new_datagram["type"].startswith("TAG"):

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -442,3 +442,16 @@ def test_convert_ek80_mru1(ek80_path):
     np.all(echodata["Platform"]["roll"].data == np.array(parser.mru["roll"]))
     np.all(echodata["Platform"]["vertical_offset"].data == np.array(parser.mru["heave"]))
     np.all(echodata["Platform"]["heading"].data == np.array(parser.mru["heading"]))
+
+
+def test_skip_ec150(ek80_path):
+    """Make sure we skip EC150 datagrams correctly."""
+    ek80_mru1_path = str(ek80_path.joinpath("RL2407_ADCP-D20240709-T150437.raw"))
+    echodata = open_raw(raw_file=ek80_mru1_path, sonar_model='EK80')
+
+    assert "EC150" not in echodata["Sonar/Beam_group1"]["channel"].values
+    assert "backscatter_i" in echodata["Sonar/Beam_group1"].data_vars
+    assert (
+        echodata["Sonar/Beam_group1"].dims
+        == {'channel': 1, 'ping_time': 2, 'range_sample': 115352, 'beam': 4}
+    )


### PR DESCRIPTION
This PR includes changes to `ParseEK` to skip reading and saving datagrams generated by EC150 ADCP.

We can actually parse the echosounder-equivalent data fine, but we still need 2 other pieces to carry it to the next stage, so this is a "hotfix" to just skip these datagrams for now. The pieces we need are:
- determine where to save the complex or power data: as a separate `Beam_group3` or with the previous `Beam_group1/2`?
- make sure calibration code can run through fine: not sure at the moment if all the necessary broadband calibration parameters are in place, but looks like all the necessary narrowband calibration parameters are there.

This PR still needs:
- [x] tests with small test file
- [x] an issue that document needed changes for follow-up work (#1358)