### PR TITLE
Allow Waveform Mode FM in Calibrate API

### DIFF
--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -32,7 +32,9 @@ def _compute_cal(
     if echodata.sonar_model == "EK80":
         if waveform_mode is None or encode_mode is None:
             raise ValueError("waveform_mode and encode_mode must be specified for EK80 calibration")
-        check_input_args_combination(waveform_mode, encode_mode)
+        check_input_args_combination(
+            waveform_mode="BB" if waveform_mode == "FM" else waveform_mode, encode_mode=encode_mode
+        )
     elif echodata.sonar_model in ("EK60", "AZFP"):
         if waveform_mode is not None and waveform_mode != "CW":
             logger.warning(
@@ -51,7 +53,7 @@ def _compute_cal(
         env_params=env_params,
         cal_params=cal_params,
         ecs_file=ecs_file,
-        waveform_mode=waveform_mode,
+        waveform_mode="BB" if waveform_mode == "FM" else waveform_mode,
         encode_mode=encode_mode,
     )
 
@@ -157,14 +159,14 @@ def compute_Sv(echodata: EchoData, **kwargs) -> xr.Dataset:
         Passing in calibration parameters for other echosounders
         are not currently supported.
 
-    waveform_mode : {"CW", "BB"}, optional
+    waveform_mode : {"CW", "BB", "FM"}, optional
         Type of transmit waveform.
         Required only for data from the EK80 echosounder
         and not used with any other echosounder.
 
         - `"CW"` for narrowband transmission,
           returned echoes recorded either as complex or power/angle samples
-        - `"BB"` for broadband transmission,
+        - `"BB"` or `"FM"` for broadband transmission,
           returned echoes recorded as complex samples
 
     encode_mode : {"complex", "power"}, optional
@@ -185,7 +187,7 @@ def compute_Sv(echodata: EchoData, **kwargs) -> xr.Dataset:
     Notes
     -----
     The EK80 echosounder can be configured to transmit
-    either broadband (``waveform_mode="BB"``)
+    either broadband/frequency modulated (``waveform_mode="BB"`` or ``waveform_mode="FM"``)
     or narrowband (``waveform_mode="CW"``) signals.
     When transmitting in broadband mode, the returned echoes are
     encoded as complex samples (``encode_mode="complex"``).
@@ -246,14 +248,14 @@ def compute_TS(echodata: EchoData, **kwargs):
         Passing in calibration parameters for other echosounders
         are not currently supported.
 
-    waveform_mode : {"CW", "BB"}, optional
+    waveform_mode : {"CW", "BB", "FM"}, optional
         Type of transmit waveform.
         Required only for data from the EK80 echosounder
         and not used with any other echosounder.
 
         - `"CW"` for narrowband transmission,
           returned echoes recorded either as complex or power/angle samples
-        - `"BB"` for broadband transmission,
+        - `"BB"` or `"FM"` for broadband transmission,
           returned echoes recorded as complex samples
 
     encode_mode : {"complex", "power"}, optional
@@ -274,7 +276,7 @@ def compute_TS(echodata: EchoData, **kwargs):
     Notes
     -----
     The EK80 echosounder can be configured to transmit
-    either broadband (``waveform_mode="BB"``)
+    either broadband/frequency modulated (``waveform_mode="BB"`` or ``waveform_mode="FM"``)
     or narrowband (``waveform_mode="CW"``) signals.
     When transmitting in broadband mode, the returned echoes are
     encoded as complex samples (``encode_mode="complex"``).

--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -28,13 +28,14 @@ def _compute_cal(
     waveform_mode=None,
     encode_mode=None,
 ):
+    # Make waveform_mode "FM" equivalent to "BB"
+    waveform_mode = "BB" if waveform_mode == "FM" else waveform_mode
+
     # Check on waveform_mode and encode_mode inputs
     if echodata.sonar_model == "EK80":
         if waveform_mode is None or encode_mode is None:
             raise ValueError("waveform_mode and encode_mode must be specified for EK80 calibration")
-        check_input_args_combination(
-            waveform_mode="BB" if waveform_mode == "FM" else waveform_mode, encode_mode=encode_mode
-        )
+        check_input_args_combination(waveform_mode=waveform_mode, encode_mode=encode_mode)
     elif echodata.sonar_model in ("EK60", "AZFP"):
         if waveform_mode is not None and waveform_mode != "CW":
             logger.warning(
@@ -53,7 +54,7 @@ def _compute_cal(
         env_params=env_params,
         cal_params=cal_params,
         ecs_file=ecs_file,
-        waveform_mode="BB" if waveform_mode == "FM" else waveform_mode,
+        waveform_mode=waveform_mode,
         encode_mode=encode_mode,
     )
 

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -457,3 +457,15 @@ def test_check_echodata_backscatter_size(
     
     # Turn off logger verbosity
     ep.utils.log.verbose(override=True)
+
+
+@pytest.mark.integration
+def test_fm_equals_bb():
+    """Check that waveform_mode='BB' and waveform_mode='FM' result in the same Sv."""
+    # Open Raw and Compute both Sv
+    ed = ep.open_raw("echopype/test_data/ek80/D20170912-T234910.raw", sonar_model = "EK80")
+    ds_Sv_bb = ep.calibrate.compute_Sv(ed, waveform_mode="BB", encode_mode="complex")
+    ds_Sv_fm = ep.calibrate.compute_Sv(ed, waveform_mode="FM", encode_mode="complex")
+
+    # Check that they are equal
+    assert ds_Sv_bb.equals(ds_Sv_fm)

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -461,11 +461,14 @@ def test_check_echodata_backscatter_size(
 
 @pytest.mark.integration
 def test_fm_equals_bb():
-    """Check that waveform_mode='BB' and waveform_mode='FM' result in the same Sv."""
-    # Open Raw and Compute both Sv
+    """Check that waveform_mode='BB' and waveform_mode='FM' result in the same Sv/TS."""
+    # Open Raw and Compute both Sv and both TS
     ed = ep.open_raw("echopype/test_data/ek80/D20170912-T234910.raw", sonar_model = "EK80")
     ds_Sv_bb = ep.calibrate.compute_Sv(ed, waveform_mode="BB", encode_mode="complex")
     ds_Sv_fm = ep.calibrate.compute_Sv(ed, waveform_mode="FM", encode_mode="complex")
+    ds_TS_bb = ep.calibrate.compute_TS(ed, waveform_mode="BB", encode_mode="complex")
+    ds_TS_fm = ep.calibrate.compute_TS(ed, waveform_mode="FM", encode_mode="complex")
 
     # Check that they are equal
     assert ds_Sv_bb.equals(ds_Sv_fm)
+    assert ds_TS_bb.equals(ds_TS_fm)


### PR DESCRIPTION
Addresses #1334

This was the easiest way I could envision allowing FM. Otherwise, I would've reviewed all the calibrate code and added FM there. What are your thoughts @leewujung?