### PR TITLE
Handle `NaN` in `apply_mask` input mask

### DIFF
--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -400,6 +400,9 @@ def apply_mask(
                 "have the channel dimension, that dimension should match between the two."
             )
 
+    # Turn NaN in final_mask to False
+    final_mask = final_mask.fillna(False)
+
     # Apply the mask to var_name
     var_name_masked = xr.where(final_mask, x=source_da, y=fill_value)
 

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -400,7 +400,7 @@ def apply_mask(
                 "have the channel dimension, that dimension should match between the two."
             )
 
-    # Turn NaN in final_mask to False
+    # Turn NaN in final_mask to False, otherwise xr.where treats as True
     final_mask = final_mask.fillna(False)
 
     # Apply the mask to var_name

--- a/echopype/tests/mask/test_mask.py
+++ b/echopype/tests/mask/test_mask.py
@@ -1098,6 +1098,27 @@ def test_apply_mask(
         temp_dir.cleanup()
 
 
+def test_apply_mask_NaN_elements():
+    """
+    Make sure NaNs are interpreted correctly as False.
+    """
+    arr_mask = np.identity(3)
+    arr_mask = np.where(arr_mask==1, 1, np.nan)
+
+    da_mask = xr.DataArray(
+        arr_mask,
+        coords={"ping_time": np.arange(3), "depth": np.arange(3)},
+    )
+    ds_data = xr.DataArray(
+        np.random.rand(2, 3, 3),
+        coords={"channel": ["ch1", "ch2"], "ping_time": np.arange(3), "depth": np.arange(3)},
+    )
+    ds_data.name = "Sv"
+    ds_data = ds_data.to_dataset()
+    ds_data_masked = ep.mask.apply_mask(source_ds=ds_data, mask=da_mask)
+    assert np.array_equal( np.isnan(arr_mask), ds_data_masked["Sv"].isel(channel=0).isnull().values)
+    
+
 @pytest.mark.integration
 @pytest.mark.parametrize(
     ("source_has_ch", "mask", "truth_da"),


### PR DESCRIPTION
This addresses #1375.

I added a simple test, because it doesn't look like this one would fit under any of the existing parameterized tests, but let me know if that's not the case.