### PR TITLE
Fix 'Division by Zero' error when converting EK80 files without Sound Velocity Profile Depth value(s)

### DIFF
--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -173,7 +173,7 @@ class SetGroupsEK80(SetGroupsBase):
                     (
                         self.parser_obj.environment["sound_velocity_profile"][::2]
                         if "sound_velocity_profile" in self.parser_obj.environment
-                        else []
+                        else [np.nan]
                     ),
                     {
                         "standard_name": "depth",

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -485,7 +485,7 @@ def test_parse_mru0_mru1(ek80_path):
     for mru_var_name in mru_var_names:
         assert not np.any(np.isnan(echodata["Platform"][mru_var_name]))
 
-@pytest.mark.test
+
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "raw_path",

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -487,21 +487,16 @@ def test_parse_mru0_mru1(ek80_path):
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize(
-    "raw_path",
-    [
-        ("echopype/test_data/ek80_missing_sound_velocity_profile/Hake-D20230624-T144316.raw"),
-        ("echopype/test_data/ek80_missing_sound_velocity_profile/Hake-D20230701-T073658.raw"),
-        ("echopype/test_data/ek80_missing_sound_velocity_profile/Hake-D20230719-T050043.raw"),
-    ]
-)
-def test_parse_missing_sound_velocity_profile(raw_path):
+def test_parse_missing_sound_velocity_profile():
     """
     Tests that RAW files that are missing sound velocity profile values can be
     converted, saved to Zarr, and opened again.
     """
     # Open RAW
-    ed = open_raw(raw_path,sonar_model="EK80")
+    ed = open_raw(
+        "echopype/test_data/ek80_missing_sound_velocity_profile/Hake-D20230701-T073658.raw",
+        sonar_model="EK80"
+    )
 
     # Save RAW to Zarr
     save_path = "echopype/test_data/ek80_missing_sound_velocity_profile/test_save.zarr"


### PR DESCRIPTION
When trying to save an Echodata object to Zarr that was missing the Sound Velocity Profile Depth coordinate in the Environment group, I got the following error:

```
{
	"name": "ZeroDivisionError",
	"message": "division by zero",
	"stack": "---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
Cell In[6], line 1
----> 1 ed.to_zarr(\"test.zarr\")

File ~/echopype/echopype/echodata/echodata.py:602, in EchoData.to_zarr(self, save_path, compress, overwrite, parallel, output_storage_options, consolidated, **kwargs)
    577 \"\"\"Save content of EchoData to zarr.
    578 
    579 Parameters
   (...)
    598     xarray's documentation for a list of all possible arguments.
    599 \"\"\"
    600 from ..convert.api import to_file
--> 602 return to_file(
    603     echodata=self,
    604     engine=\"zarr\",
    605     save_path=save_path,
    606     compress=compress,
    607     overwrite=overwrite,
    608     parallel=parallel,
    609     output_storage_options=output_storage_options,
    610     consolidated=consolidated,
    611     **kwargs,
    612 )

File ~/echopype/echopype/convert/api.py:88, in to_file(echodata, engine, save_path, compress, overwrite, parallel, output_storage_options, **kwargs)
     86     else:
     87         logger.info(f\"saving {output_file}\")
---> 88     _save_groups_to_file(
     89         echodata,
     90         output_path=io.sanitize_file_path(
     91             file_path=output_file, storage_options=output_storage_options
     92         ),
     93         engine=engine,
     94         compress=compress,
     95         **kwargs,
     96     )
     98 # Link path to saved file with attribute as if from open_converted
     99 echodata.converted_raw_path = output_file

File ~/echopype/echopype/convert/api.py:118, in _save_groups_to_file(echodata, output_path, engine, compress, **kwargs)
    108 io.save_file(
    109     echodata[\"Top-level\"],
    110     path=output_path,
   (...)
    114     **kwargs,
    115 )
    117 # Environment group
--> 118 io.save_file(
    119     echodata[\"Environment\"],  # TODO: chunking necessary?
    120     path=output_path,
    121     mode=\"a\",
    122     engine=engine,
    123     group=\"Environment\",
    124     compression_settings=COMPRESSION_SETTINGS[engine] if compress else None,
    125     **kwargs,
    126 )
    128 # Platform group
    129 io.save_file(
    130     echodata[\"Platform\"],  # TODO: chunking necessary? time1 and time2 (EK80) only
    131     path=output_path,
   (...)
    136     **kwargs,
    137 )

File ~/echopype/echopype/utils/io.py:78, in save_file(ds, path, mode, engine, group, compression_settings, **kwargs)
     76         if isinstance(ds[var].data, DaskArray):
     77             ds[var] = ds[var].chunk(enc.get(\"chunks\", {}))
---> 78     ds.to_zarr(store=path, mode=mode, group=group, encoding=encoding, **kwargs)
     79 else:
     80     raise ValueError(f\"{engine} is not a supported save format\")

File ~/miniforge3/envs/echopype/lib/python3.9/site-packages/xarray/core/dataset.py:2549, in Dataset.to_zarr(self, store, chunk_store, mode, synchronizer, group, encoding, compute, consolidated, append_dim, region, safe_chunks, storage_options, zarr_version, write_empty_chunks, chunkmanager_store_kwargs)
   2404 \"\"\"Write dataset contents to a zarr group.
   2405 
   2406 Zarr chunks are determined in the following way:
   (...)
   2545     The I/O user guide, with more details and examples.
   2546 \"\"\"
   2547 from xarray.backends.api import to_zarr
-> 2549 return to_zarr(  # type: ignore[call-overload,misc]
   2550     self,
   2551     store=store,
   2552     chunk_store=chunk_store,
   2553     storage_options=storage_options,
   2554     mode=mode,
   2555     synchronizer=synchronizer,
   2556     group=group,
   2557     encoding=encoding,
   2558     compute=compute,
   2559     consolidated=consolidated,
   2560     append_dim=append_dim,
   2561     region=region,
   2562     safe_chunks=safe_chunks,
   2563     zarr_version=zarr_version,
   2564     write_empty_chunks=write_empty_chunks,
   2565     chunkmanager_store_kwargs=chunkmanager_store_kwargs,
   2566 )

...

File ~/miniforge3/envs/echopype/lib/python3.9/site-packages/zarr/indexing.py:181, in SliceDimIndexer.__init__(self, dim_sel, dim_len, dim_chunk_len)
    179 self.dim_chunk_len = dim_chunk_len
    180 self.nitems = max(0, ceildiv((self.stop - self.start), self.step))
--> 181 self.nchunks = ceildiv(self.dim_len, self.dim_chunk_len)

File ~/miniforge3/envs/echopype/lib/python3.9/site-packages/zarr/indexing.py:167, in ceildiv(a, b)
    166 def ceildiv(a, b):
--> 167     return math.ceil(a / b)

ZeroDivisionError: division by zero"
}
```

Zarr doesn't seem to like it when a coordinate has no associated value(s):

![image](https://github.com/user-attachments/assets/bb3fb5ee-fd92-464f-a79a-27f4a6c8fd27)

So instead of setting `sound_velocity_profile_depth` to `[]` in set groups when the parser contains no associated values, I set it to `[np.nan]`.