### PR TITLE
Add error warning for all NaN lat/lon in `get_distance_from_latlon`

### DIFF
--- a/echopype/commongrid/utils.py
+++ b/echopype/commongrid/utils.py
@@ -200,6 +200,10 @@ def get_distance_from_latlon(ds_Sv):
     df_pos["latitude_prev"] = df_pos["latitude"].shift(-1)
     df_pos["longitude_prev"] = df_pos["longitude"].shift(-1)
     df_latlon_nonan = df_pos.dropna().copy()
+
+    if len(df_latlon_nonan) == 0:  # lat/lon entries are all NaN
+        raise ValueError("All lat/lon entries are NaN!")
+    
     df_latlon_nonan["dist"] = df_latlon_nonan.apply(
         lambda x: distance.distance(
             (x["latitude"], x["longitude"]),


### PR DESCRIPTION
When the lat/lon dataframe contains all NaN entries, the `get_distance_from_latlon` spits out errors that are hard to decipher. This PR adds a clear error message for this case.

`get_distance_from_latlon` is currently used in `compute_MVBS`.