### PR TITLE
Temporarily pin flox <0.9.14 [all tests ci]

### DIFF
--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -50,7 +50,7 @@ To create an environment for developing Echopype, we recommend the following ste
     ```shell
     # Create a conda environment using the supplied requirements files
     # Note the last one docs/requirements.txt is only required for building docs
-    conda create -c conda-forge -n echopype --yes python=3.9 --file requirements.txt --file requirements-dev.txt --file docs/requirements.txt
+    conda create -c conda-forge -n echopype --yes python=3.11 --file requirements.txt --file requirements-dev.txt --file docs/requirements.txt
 
     # Switch to the newly built environment
     conda activate echopype

--- a/echopype/test_data/README.md
+++ b/echopype/test_data/README.md
@@ -11,8 +11,6 @@ Most of these files are stored on Git LFS but the ones that aren't (due to file 
 - 2019118 group2survey-D20191214-T081342.raw: Contains 6 channels but only 2 of those channels collect ping data
 - D20200528-T125932.raw: Data collected from WBT mini (instead of WBT), from @emlynjdavies
 - Green2.Survey2.FM.short.slow.-D20191004-T211557.raw: Contains 2-in-1 transducer, from @FletcherFT (reduced from 104.9 MB to 765 KB in test data updates)
-- raw4-D20220514-T172704.raw: Contains RAW4 datagram, 1 channel only, from @cornejotux
-- D20210330-T123857.raw: do not contain filter coefficients
 
 
 ### EA640
@@ -24,7 +22,6 @@ Most of these files are stored on Git LFS but the ones that aren't (due to file 
 - Winter2017-D20170115-T150122.raw: Contains a change of recording length in the middle of the file
 - 2015843-D20151023-T190636.raw: Not used in tests but contains ranges are not constant across ping times
 - SH1701_consecutive_files_w_range_change: Not used in tests. [Folder](https://drive.google.com/drive/u/1/folders/1PaDtL-xnG5EK3N3P1kGlXa5ub16Yic0f) on shared drive that contains sequential files with ranges that are not constant across ping times.
-- NBP_B050N-D20180118-T090228.raw: split-beam setup without angle data
 
 
 ### AZFP

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ aiohttp
 xarray-datatree==0.0.6
 psutil>=5.9.1
 geopy
-flox>=0.7.2,<1.0.0
+flox>=0.7.2,<0.9.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ aiohttp
 xarray-datatree==0.0.6
 psutil>=5.9.1
 geopy
-flox>=0.7.2,<0.9.14
+flox>=0.7.2,<1.0.0


### PR DESCRIPTION
Seems like the function that caused the most recent test failure was `_datetime_nanmin` introduced just 4 days ago at flox=0.9.14 ([here](https://github.com/xarray-contrib/flox/blob/4f6164f74a657d95f795c374e31e91a7e7643e9f/flox/xrutils.py#L348)). Probably why the CI runs with #1403 didn't catch this when it was run a few weeks back. Let's see if this is the issue in the new CI runs.