### PR TITLE
Update workflows python version [all tests ci]

### DIFF
--- a/.ci_helpers/user_environment.yml
+++ b/.ci_helpers/user_environment.yml
@@ -2,7 +2,7 @@ name: echopype
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python=3.11
   - ipykernel
   - echopype
   - dask

--- a/.github/workflows/packit.yaml
+++ b/.github/workflows/packit.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5.3.0
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Install dependencies
       run: python -m pip install setuptools wheel
@@ -55,7 +55,7 @@ jobs:
     - uses: actions/setup-python@v5.3.0
       name: Install Python
       with:
-        python-version: 3.9
+        python-version: 3.11
     - uses: actions/download-artifact@v4
       with:
         name: releases

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -50,7 +50,7 @@ jobs:
       # We only want to install this on one run, because otherwise we'll have
       # duplicate annotations.
       - name: Install error reporter
-        if: ${{ matrix.python-version == '3.9' }}
+        if: ${{ matrix.python-version == '3.11' }}
         run: python -m pip install pytest-github-actions-annotate-failures
       - name: Install echopype
         run: python -m pip install -e ".[plot]"

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5.3.0
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Install dependencies
       run: python -m pip install setuptools wheel
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/setup-python@v5.3.0
       name: Install Python
       with:
-        python-version: 3.9
+        python-version: 3.11
     - uses: actions/download-artifact@v4
       with:
         name: releases

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.11"
   jobs:
     pre_build:
       # Generate the Sphinx configuration for this Jupyter Book so it builds.

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.12"
   jobs:
     pre_build:
       # Generate the Sphinx configuration for this Jupyter Book so it builds.


### PR DESCRIPTION
- `.ci_helpers/py${{ matrix.python-version }}.yaml` are only used in windows workflows, which are not currently run.