### PR TITLE
Assemble AD2CP timestamp with nanosecond precision

### DIFF
--- a/echopype/convert/parse_ad2cp.py
+++ b/echopype/convert/parse_ad2cp.py
@@ -328,7 +328,8 @@ class Ad2cpDataPacket:
         microsec100 = self.data["microsec100"]
         try:
             return np.datetime64(
-                f"{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{seconds:02}.{microsec100:04}", "ns"
+                f"{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{seconds:02}.{microsec100:04}",
+                "ns",
             )  # type: ignore
         except ValueError:
             return np.datetime64("NaT")  # type: ignore

--- a/echopype/convert/parse_ad2cp.py
+++ b/echopype/convert/parse_ad2cp.py
@@ -328,7 +328,7 @@ class Ad2cpDataPacket:
         microsec100 = self.data["microsec100"]
         try:
             return np.datetime64(
-                f"{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{seconds:02}.{microsec100:04}"
+                f"{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{seconds:02}.{microsec100:04}", "ns"
             )  # type: ignore
         except ValueError:
             return np.datetime64("NaT")  # type: ignore

--- a/echopype/convert/parse_ad2cp.py
+++ b/echopype/convert/parse_ad2cp.py
@@ -328,7 +328,7 @@ class Ad2cpDataPacket:
         microsec100 = self.data["microsec100"]
         try:
             return np.datetime64(
-                f"{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{seconds:02}.{microsec100:04}",
+                f"{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{seconds:02}.{microsec100:04}",  # noqa
                 "ns",
             )  # type: ignore
         except ValueError:


### PR DESCRIPTION
Previously when assembling timestamp for AD2CP files, the precision was not explicitly set and defaulted to `us`. This causes issues with encoding times in xarray: When the time is encoded with `us`, `coding.times.encode_cf_datetime` returns negative values, which are then converted to NaT in `coding.times.decode_cf_datetime` and causes whole bunch tests failing seen in [here](https://github.com/OSOceanAcoustics/echopype/actions/runs/13094690085/job/36535527616?pr=1429).

This PR addresses this issue by explicitly set precision to `ns` when assembling timestamp in `parse_ad2cp.py::Ad2cpDataPacket.timestamp`.

The encode-decode code block:
https://github.com/OSOceanAcoustics/echopype/blob/f64e8c39713d463331a19c77f9f835b64cb23104/echopype/utils/coding.py#L81-L96