### PR TITLE
Resolve critical warnings from #1439

### DIFF
--- a/echopype/commongrid/utils.py
+++ b/echopype/commongrid/utils.py
@@ -598,3 +598,26 @@ def _groupby_x_along_channels(
         **flox_kwargs,
     )
     return sv_mean
+
+
+def assign_actual_range(ds_MVBS: xr.Dataset) -> xr.Dataset:
+    """
+    Post computation function to assign Sv 'actual_range' attribute. 'actual_range' was
+    originally removed from the 'compute_MVBS' operation because it forced compute, which
+    was undesirable if users wanted to lazily evaluate 'compute_MVBS'.
+
+    Parameters
+    ----------
+    ds_MVBS : xr.Dataset
+        MVBS dataset without actual range attribute.
+
+    Returns
+    -------
+    ds_MVBS : xr.Dataset
+        MVBS dataset with actual range attribute.
+    """
+    actual_range = [
+        round(float(ds_MVBS["Sv"].min().values), 2),
+        round(float(ds_MVBS["Sv"].max().values), 2),
+    ]
+    return ds_MVBS.assign_attrs({"actual_range": actual_range})

--- a/echopype/convert/parse_azfp6.py
+++ b/echopype/convert/parse_azfp6.py
@@ -306,6 +306,13 @@ class ParseAZFP6(ParseBase):
 
         # Set flags for presence of valid parameters for temperature and tilt
         def _test_valid_params(params):
+            # If parameters are all empty return True.
+            if all([len(self.parameters[p]) == 0 for p in params]):
+                return True
+            # The above was added because of the deprecation warning that arose due to
+            # the code below:
+            # 'DeprecationWarning: The truth value of an empty array is ambiguous.
+            # Returning False, but in future this will result in an error.
             if all([np.isclose(self.parameters[p], 0) for p in params]):
                 return False
             else:

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -74,28 +74,29 @@ class EchoData:
 
     def cleanup_swap_files(self):
         """
-        Clean up the swap files during raw data conversion
+        Clean up only the swap files created during raw data conversion.
         """
         sonar_group = "Sonar"
         beam_group_var = "beam_group"
         for beam_group in self[sonar_group][beam_group_var].to_numpy():
             # Go through each beam group
             for var in self[f"{sonar_group}/{beam_group}"].data_vars.values():
-                # Go through each variable and only delete if it's a dask array
+                # Go through each variable that is a dask array
                 if isinstance(var.data, dask.array.Array):
                     da = var.data
-                    # Get the dask graph so we have access to the underlying
-                    # zarr stores
+                    # Get the dask graph so we have access to the underlying zarr stores
                     dask_graph = da.__dask_graph__()
-                    # Get the zarr stores
+                    # Get the zarr stores that exist due to the use swap file operation
                     zarr_stores = [
                         v.store for k, v in dask_graph.items() if "original-from-zarr" in k
                     ]
-                    fs = zarr_stores[0].fs
-                    from ..utils.io import delete_zarr_store
+                    if len(zarr_stores) > 0:
+                        # Grab the first associated file since there is only one unique file
+                        fs = zarr_stores[0].fs
+                        from ..utils.io import delete_zarr_store
 
-                    for store in zarr_stores:
-                        delete_zarr_store(store, fs)
+                        for store in zarr_stores:
+                            delete_zarr_store(store, fs)
 
     def __del__(self):
         # TODO: this destructor seems to not work in Jupyter Lab if restart or

--- a/echopype/testing.py
+++ b/echopype/testing.py
@@ -282,7 +282,7 @@ def _gen_timestamp_data(ch_name, ch_range_sample_ping_time_len, ping_time_jitter
     for ch_seq, ch in enumerate(ch_name):
         mock_time = _gen_ping_time(
             ping_time_len=sum(ch_range_sample_ping_time_len[ch_seq]),
-            ping_time_interval="1S",
+            ping_time_interval="1s",
             ping_time_jitter_max_ms=ping_time_jitter_max_ms,
         )
         timestamp_data[ch] = [np.datetime64(t) for t in mock_time.tolist()]

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -316,7 +316,7 @@ def test_compute_Sv_combined_ed_ping_time_extend_past_time1():
         # Check that no NaNs exist
         assert not np.any(np.isnan(env_var.data))
 
-@pytest.mark.test1
+
 @pytest.mark.parametrize(
     "raw_path, sonar_model, xml_path, waveform_mode, encode_mode",
     [

--- a/echopype/tests/calibrate/test_calibrate.py
+++ b/echopype/tests/calibrate/test_calibrate.py
@@ -316,7 +316,7 @@ def test_compute_Sv_combined_ed_ping_time_extend_past_time1():
         # Check that no NaNs exist
         assert not np.any(np.isnan(env_var.data))
 
-                
+@pytest.mark.test1
 @pytest.mark.parametrize(
     "raw_path, sonar_model, xml_path, waveform_mode, encode_mode",
     [
@@ -413,6 +413,9 @@ def test_check_echodata_backscatter_size(
         "with the results stored directly in a Zarr store on disk, rather then in memory."
     )
     assert warning_message == caplog.records[0].message
+
+    # Check that no list index warning is raised
+    assert not any("list index out of range" in record.message for record in caplog.records)
     
     # Turn off logger verbosity
     ep.utils.log.verbose(override=True)

--- a/echopype/tests/calibrate/test_env_params.py
+++ b/echopype/tests/calibrate/test_env_params.py
@@ -29,7 +29,7 @@ def ek60_path(test_path):
 def ek80_cal_path(test_path):
     return test_path["EK80_CAL"]
 
-
+@pytest.mark.test1
 @pytest.mark.unit
 def test_harmonize_env_param_time():
     # Scalar
@@ -104,7 +104,7 @@ def test_harmonize_env_param_time():
     assert (p_new["ping_time"] == ping_time_target).all()
     assert isinstance(p_new.data, dask.array.Array)
     # np.array_equal() computes dask array under the hood
-    assert np.array_equal(p_new.data, p.data)
+    assert np.array_equal(p_new.data.compute(), p.data.compute())
 
     # ping_time target requires actual interpolation
     ping_time_target = xr.DataArray(

--- a/echopype/tests/calibrate/test_env_params.py
+++ b/echopype/tests/calibrate/test_env_params.py
@@ -29,7 +29,7 @@ def ek60_path(test_path):
 def ek80_cal_path(test_path):
     return test_path["EK80_CAL"]
 
-@pytest.mark.test1
+
 @pytest.mark.unit
 def test_harmonize_env_param_time():
     # Scalar

--- a/echopype/tests/commongrid/test_commongrid_api.py
+++ b/echopype/tests/commongrid/test_commongrid_api.py
@@ -534,3 +534,24 @@ def test_compute_MVBS_NASC_skipna_nan_and_non_nan_values(
                 [[True, False, False, True, True, True]]
             ]
             assert np.array_equal(da_nan_mask, np.array(expected_values))
+
+
+@pytest.mark.integration
+def test_assign_actual_range(request):
+    """
+    Tests assign_actual_range function to see if the attribute is properly assigned to the MVBS dataset.
+    """
+    # Grab mock Sv dataset
+    ds_Sv = request.getfixturevalue("mock_Sv_dataset_regular")
+
+    # Compute MVBS
+    ds_MVBS = ep.commongrid.compute_MVBS(ds_Sv).compute()
+
+    # Check if attribute matches manually computed attribute.
+    np.array_equal(
+        ep.commongrid.utils.assign_actual_range(ds_MVBS).attrs["actual_range"],
+        [
+            round(float(ds_MVBS["Sv"].min().values), 2),
+            round(float(ds_MVBS["Sv"].max().values), 2),
+        ]
+    )

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -449,6 +449,7 @@ def test_convert_ek80_mru1(ek80_path):
     np.all(echodata["Platform"]["vertical_offset"].data == np.array(parser.mru1["heave"]))
     np.all(echodata["Platform"]["heading"].data == np.array(parser.mru1["heading"]))
 
+
 @pytest.mark.unit
 def test_skip_ec150(ek80_path):
     """Make sure we skip EC150 datagrams correctly."""
@@ -458,7 +459,7 @@ def test_skip_ec150(ek80_path):
     assert "EC150" not in echodata["Sonar/Beam_group1"]["channel"].values
     assert "backscatter_i" in echodata["Sonar/Beam_group1"].data_vars
     assert (
-        echodata["Sonar/Beam_group1"].dims
+        echodata["Sonar/Beam_group1"].sizes
         == {'channel_all': 1, 'beam_group': 1, 'channel': 1, 'ping_time': 2, 'range_sample': 115352, 'beam': 4}
     )
 
@@ -471,7 +472,7 @@ def test_parse_mru0_mru1(ek80_path):
 
     # Check dimensions
     assert (
-        echodata["Platform"].dims
+        echodata["Platform"].sizes
         == {'channel': 1, 'time1': 1, 'time2': 43, 'time3': 43}
     )
 

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -115,9 +115,18 @@ def _get_auto_chunk(
     tuple
         The chunks
     """
-    auto_tuple = tuple(["auto" for i in variable.shape])
+    # Create a tuple filled with "auto" for each dimension in the variable's shape.
+    auto_tuple = tuple("auto" for _ in variable.shape)
+
+    # Generate a tuple of chunk sizes using the dask 'auto_chunks' function.
     chunks = auto_chunks(auto_tuple, variable.shape, chunk_size, variable.dtype)
-    return tuple([c[0] if isinstance(c, tuple) else c for c in chunks])
+
+    # Ensure each chunk is a single value by extracting the first element if it's a tuple.
+    list_chunks = list(c[0] if isinstance(c, tuple) else c for c in chunks)
+
+    # Map each key from variable.sizes to its corresponding chunk. We use zip to ensure that
+    # the keys are paired with the chunks in the correct order.
+    return dict(zip(variable.sizes, list_chunks))
 
 
 def set_time_encodings(ds: xr.Dataset) -> xr.Dataset:


### PR DESCRIPTION
Resolves #1439

**TODO:** 

These tasks seem to be lagged in the CI test:

```
echopype/tests/calibrate/test_calibrate.py::test_compute_Sv_azfp 
echopype/tests/calibrate/test_calibrate.py::test_compute_Sv_returns_water_level 
Warning: divide by zero encountered in log10
Warning: divide by zero encountered in log10
```