### PR TITLE
Fix invalid \d warning by using raw string

### DIFF
--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -133,7 +133,7 @@ def _check_channel_selection_form(
 
         # make sure all keys are of the form Sonar/Beam_group using regular expression
         are_keys_right_form = [
-            True if re.match("Sonar/Beam_group(\d{1})", elem) else False  # noqa
+            True if re.match(r"Sonar/Beam_group(\d{1})", elem) else False  # noqa
             for elem in channel_selection.keys()
         ]
         if not all(are_keys_right_form):


### PR DESCRIPTION
This PR fixes the warning below:

<img width="789" alt="Screenshot 2025-02-09 at 6 08 21 AM" src="https://github.com/user-attachments/assets/fe498383-0191-4952-947f-62bf626c00e2" />
