### PR TITLE
Dataset.dims to Dataset.sizes [all tests ci]

### DIFF
--- a/echopype/consolidate/api.py
+++ b/echopype/consolidate/api.py
@@ -469,10 +469,11 @@ def add_splitbeam_angle(
 
     # fail if source_Sv and ds_beam do not have the same lengths
     # for ping_time, range_sample, and channel
-    same_dim_lens = [
-        ds_beam.dims[dim] == source_Sv.dims[dim] for dim in ["channel", "ping_time", "range_sample"]
+    same_size_lens = [
+        ds_beam.sizes[dim] == source_Sv.sizes[dim]
+        for dim in ["channel", "ping_time", "range_sample"]
     ]
-    if not same_dim_lens:
+    if not same_size_lens:
         raise ValueError(
             "The 'source_Sv' dataset does not have the same dimensions as data in 'echodata'!"
         )

--- a/echopype/convert/set_groups_ad2cp.py
+++ b/echopype/convert/set_groups_ad2cp.py
@@ -225,7 +225,7 @@ class SetGroupsAd2cp(SetGroupsBase):
         ds = xr.Dataset(data_vars=data_vars, coords=coords)
         # make arange coords for the remaining dims
         non_coord_dims = {dim.dimension_name() for dim in used_dims} - set(ds.coords.keys())
-        ds = ds.assign_coords({dim: np.arange(ds.dims[dim]) for dim in non_coord_dims})
+        ds = ds.assign_coords({dim: np.arange(ds.sizes[dim]) for dim in non_coord_dims})
         return ds
 
     def set_env(self) -> xr.Dataset:

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -458,7 +458,7 @@ def test_skip_ec150(ek80_path):
     assert "EC150" not in echodata["Sonar/Beam_group1"]["channel"].values
     assert "backscatter_i" in echodata["Sonar/Beam_group1"].data_vars
     assert (
-        echodata["Sonar/Beam_group1"].dims
+        echodata["Sonar/Beam_group1"].sizes
         == {'channel_all': 1, 'beam_group': 1, 'channel': 1, 'ping_time': 2, 'range_sample': 115352, 'beam': 4}
     )
 
@@ -471,7 +471,7 @@ def test_parse_mru0_mru1(ek80_path):
 
     # Check dimensions
     assert (
-        echodata["Platform"].dims
+        echodata["Platform"].sizes
         == {'channel': 1, 'time1': 1, 'time2': 43, 'time3': 43}
     )
 

--- a/echopype/tests/echodata/test_echodata_combine.py
+++ b/echopype/tests/echodata/test_echodata_combine.py
@@ -200,8 +200,8 @@ def test_combine_echodata(raw_datasets):
             grp_drop_dims = []
             concat_dims = []
         else:
-            grp_drop_dims = list(set(combined_group.dims).intersection(set(all_drop_dims)))
-            concat_dims = list(set(combined_group.dims).intersection(append_dims))
+            grp_drop_dims = list(set(combined_group.sizes).intersection(set(all_drop_dims)))
+            concat_dims = list(set(combined_group.sizes).intersection(append_dims))
 
         # concat all Datasets along each concat dimension
         diff_concats = []
@@ -236,7 +236,7 @@ def test_combine_echodata(raw_datasets):
 def _check_prov_ds(prov_ds, eds):
     """Checks the Provenance dataset against source_filenames variable
     and global attributes in the original echodata object"""
-    for i in range(prov_ds.dims["echodata_filename"]):
+    for i in range(prov_ds.sizes["echodata_filename"]):
         ed_ds = eds[i]
         one_ds = prov_ds.isel(echodata_filename=i, filenames=i)
         for key, value in one_ds.data_vars.items():
@@ -286,7 +286,7 @@ def test_combine_echodata_combined_append(ek60_multi_test_data, test_param, sona
         
         def _check_prov_ds_and_dims(sel_comb_ed, n_val_expected):
             prov_ds = sel_comb_ed["Provenance"]
-            for _, n_val in prov_ds.dims.items():
+            for _, n_val in prov_ds.sizes.items():
                 assert n_val == n_val_expected
             _check_prov_ds(prov_ds, eds)
 


### PR DESCRIPTION
This resolves a deprecation warning found in #1444:

> Warning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.