### PR TITLE
Chunks as dictionaries in `_get_auto_chunk` [all tests ci]

### DIFF
--- a/echopype/tests/utils/test_coding.py
+++ b/echopype/tests/utils/test_coding.py
@@ -5,13 +5,13 @@ import math
 import dask
 import warnings
 
-from echopype.utils.coding import _get_auto_chunk, set_netcdf_encodings, _encode_time_dataarray, DEFAULT_TIME_ENCODING
+from echopype.utils.coding import _get_dask_auto_chunk, set_netcdf_encodings, _encode_time_dataarray, DEFAULT_TIME_ENCODING
 
 @pytest.mark.parametrize(
     "chunk",
     ["auto", "5MB", "10MB", "30MB", "70MB", "100MB", "default"],
 )
-def test__get_auto_chunk(chunk):
+def test__get_dask_auto_chunk(chunk):
     random_data = 15 + 8 * np.random.randn(10, 1000, 1000)
 
     da = xr.DataArray(
@@ -22,9 +22,9 @@ def test__get_auto_chunk(chunk):
     if chunk == "auto":
         dask_data = da.chunk('auto').data
     elif chunk == "default":
-        dask_data = da.chunk(_get_auto_chunk(da)).data
+        dask_data = da.chunk(_get_dask_auto_chunk(da)).data
     else:
-        dask_data = da.chunk(_get_auto_chunk(da, chunk)).data
+        dask_data = da.chunk(_get_dask_auto_chunk(da, chunk)).data
     
     chunk_byte_size = math.prod(dask_data.chunksize + (dask_data.itemsize,))
     

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -96,11 +96,11 @@ def _encode_time_dataarray(da):
     )
 
 
-def _get_auto_chunk(
+def _get_dask_auto_chunk(
     variable: xr.DataArray, chunk_size: "int | str | float" = "100MB"
 ) -> Tuple[int]:
     """
-    Calculate default chunks for a data array based on desired chunk size
+    Calculate default Dask chunks for a data array based on desired chunk size
 
     Parameters
     ----------
@@ -218,7 +218,10 @@ def set_zarr_encodings(
             if rechunk:
                 # Use dask auto chunk to determine the optimal chunk
                 # spread for optimal chunk size
-                chunks = _get_auto_chunk(val, chunk_size=chunk_size)
+                chunks = _get_dask_auto_chunk(val, chunk_size=chunk_size)
+                # Dask expects chunk dictionary but Zarr expects list-like iterable of
+                # values in encoding
+                chunks = [*chunks.values()]
 
             encoding[name]["chunks"] = chunks
         if PREFERRED_CHUNKS in encoding[name]:

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -115,9 +115,18 @@ def _get_auto_chunk(
     tuple
         The chunks
     """
-    auto_tuple = tuple(["auto" for i in variable.shape])
+    # Create a tuple filled with "auto" for each dimension in the variable's shape.
+    auto_tuple = tuple("auto" for _ in variable.shape)
+
+    # Generate a tuple of chunk sizes using the dask 'auto_chunks' function.
     chunks = auto_chunks(auto_tuple, variable.shape, chunk_size, variable.dtype)
-    return tuple([c[0] if isinstance(c, tuple) else c for c in chunks])
+
+    # Ensure each chunk is a single value by extracting the first element if it's a tuple.
+    list_chunks = list(c[0] if isinstance(c, tuple) else c for c in chunks)
+
+    # Map each key from variable.sizes to its corresponding chunk. We use zip to ensure that
+    # the keys are paired with the chunks in the correct order.
+    return dict(zip(variable.sizes, list_chunks))
 
 
 def set_time_encodings(ds: xr.Dataset) -> xr.Dataset:


### PR DESCRIPTION
Resolves deprecation warning when chunks are passed in as tuples discovered in #1444:

> Warning: Supplying chunks as dimension-order tuples is deprecated. It will raise an error in the future. Instead use a dict with dimension names as keys.