### PR TITLE
Fill in NaN for missing EK80 coefficients [all tests ci]

### DIFF
--- a/echopype/calibrate/ek80_complex.py
+++ b/echopype/calibrate/ek80_complex.py
@@ -62,11 +62,11 @@ def filter_decimate_chirp(coeff_ch: Dict, y_ch: np.array, fs: float):
 
     # WBT filter and decimation
     ytx_wbt = signal.convolve(y_ch, coeff_ch["wbt_fil"])
-    ytx_wbt_deci = ytx_wbt[0 :: coeff_ch["wbt_decifac"]]
+    ytx_wbt_deci = ytx_wbt[0 :: int(coeff_ch["wbt_decifac"])]
 
     # PC filter and decimation
     ytx_pc = signal.convolve(ytx_wbt_deci, coeff_ch["pc_fil"])
-    ytx_pc_deci = ytx_pc[0 :: coeff_ch["pc_decifac"]]
+    ytx_pc_deci = ytx_pc[0 :: int(coeff_ch["pc_decifac"])]
     ytx_pc_deci_time = (
         np.arange(ytx_pc_deci.size) * 1 / fs * coeff_ch["wbt_decifac"] * coeff_ch["pc_decifac"]
     )

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -1373,30 +1373,6 @@ class SetGroupsEK80(SetGroupsBase):
                 val_deci = fil_df[type_num] if fil_df else np.nan
                 coeffs_and_decimation[param][DECIMATION].append(val_deci)
 
-            # if fil_coeffs and fil_df:
-            #     # get filter coefficient values
-            #     for type_num, values in fil_coeffs.items():
-            #         param = param_map[type_num]
-            #         coeffs_and_decimation[param][FILTER_IMAG].append(np.imag(values))
-            #         coeffs_and_decimation[param][FILTER_REAL].append(np.real(values))
-
-            #     # get decimation factor values
-            #     for type_num, value in fil_df.items():
-            #         param = param_map[type_num]
-            #         coeffs_and_decimation[param][DECIMATION].append(value)
-
-            # else:
-            #     # get filter coefficient values
-            #     for type_num in param_map.keys():
-            #         param = param_map[type_num]
-            #         coeffs_and_decimation[param][FILTER_IMAG].append([np.nan])
-            #         coeffs_and_decimation[param][FILTER_REAL].append([np.nan])
-
-            #     # get decimation factor values
-            #     for type_num in param_map.keys():
-            #         param = param_map[type_num]
-            #         coeffs_and_decimation[param][DECIMATION].append(np.nan)
-
         # Assemble everything into a Dataset
         ds = xr.merge([ds_table, ds_cal])
 

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -1360,17 +1360,42 @@ class SetGroupsEK80(SetGroupsBase):
             fil_coeffs = self.parser_obj.fil_coeffs.get(ch, None)
             fil_df = self.parser_obj.fil_df.get(ch, None)
 
-            if fil_coeffs and fil_df:
+            for type_num in param_map.keys():
+                param = param_map[type_num]
+
                 # get filter coefficient values
-                for type_num, values in fil_coeffs.items():
-                    param = param_map[type_num]
-                    coeffs_and_decimation[param][FILTER_IMAG].append(np.imag(values))
-                    coeffs_and_decimation[param][FILTER_REAL].append(np.real(values))
+                val_imag =  np.imag(fil_coeffs[type_num]) if fil_coeffs else [np.nan]
+                val_real =  np.real(fil_coeffs[type_num]) if fil_coeffs else [np.nan]
+                coeffs_and_decimation[param][FILTER_IMAG].append(val_imag)
+                coeffs_and_decimation[param][FILTER_REAL].append(val_real)
 
                 # get decimation factor values
-                for type_num, value in fil_df.items():
-                    param = param_map[type_num]
-                    coeffs_and_decimation[param][DECIMATION].append(value)
+                val_deci = fil_df[type_num] if fil_df else np.nan
+                coeffs_and_decimation[param][DECIMATION].append(val_deci)
+
+            # if fil_coeffs and fil_df:
+            #     # get filter coefficient values
+            #     for type_num, values in fil_coeffs.items():
+            #         param = param_map[type_num]
+            #         coeffs_and_decimation[param][FILTER_IMAG].append(np.imag(values))
+            #         coeffs_and_decimation[param][FILTER_REAL].append(np.real(values))
+
+            #     # get decimation factor values
+            #     for type_num, value in fil_df.items():
+            #         param = param_map[type_num]
+            #         coeffs_and_decimation[param][DECIMATION].append(value)
+
+            # else:
+            #     # get filter coefficient values
+            #     for type_num in param_map.keys():
+            #         param = param_map[type_num]
+            #         coeffs_and_decimation[param][FILTER_IMAG].append([np.nan])
+            #         coeffs_and_decimation[param][FILTER_REAL].append([np.nan])
+
+            #     # get decimation factor values
+            #     for type_num in param_map.keys():
+            #         param = param_map[type_num]
+            #         coeffs_and_decimation[param][DECIMATION].append(np.nan)
 
         # Assemble everything into a Dataset
         ds = xr.merge([ds_table, ds_cal])

--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -1364,8 +1364,8 @@ class SetGroupsEK80(SetGroupsBase):
                 param = param_map[type_num]
 
                 # get filter coefficient values
-                val_imag =  np.imag(fil_coeffs[type_num]) if fil_coeffs else [np.nan]
-                val_real =  np.real(fil_coeffs[type_num]) if fil_coeffs else [np.nan]
+                val_imag = np.imag(fil_coeffs[type_num]) if fil_coeffs else [np.nan]
+                val_real = np.real(fil_coeffs[type_num]) if fil_coeffs else [np.nan]
                 coeffs_and_decimation[param][FILTER_IMAG].append(val_imag)
                 coeffs_and_decimation[param][FILTER_REAL].append(val_real)
 

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -616,7 +616,6 @@ def test_ek80_sonar_all_channel():
 
 
 @pytest.mark.unit
-@pytest.mark.test
 def test_ek80_sequence_filter_coeff():
     """
     Checks that filter coefficients are stored properly for EK80 raw files

--- a/echopype/tests/convert/test_convert_ek80.py
+++ b/echopype/tests/convert/test_convert_ek80.py
@@ -431,9 +431,10 @@ def test_convert_ek80_no_fil_coeff(ek80_path):
 
     vendor_spec_ds = echodata["Vendor_specific"]
 
+    # All filter elements should be NaN
     for t in [WIDE_BAND_TRANS, PULSE_COMPRESS]:
         for p in [FILTER_REAL, FILTER_IMAG, DECIMATION]:
-            assert f"{t}_{p}" not in vendor_spec_ds
+            assert np.all(np.isnan(vendor_spec_ds[f"{t}_{p}"]))
 
 
 @pytest.mark.xfail(reason="Setting MRU1 platform motion data to EchoData Platform group is not yet implemented.")
@@ -611,3 +612,31 @@ def test_ek80_sonar_all_channel():
 
     # Check that channel sets are equal
     assert channel_set == target_channel_set
+
+
+@pytest.mark.unit
+def test_ek80_sequence_filter_coeff():
+    """
+    Checks that filter coefficients are stored properly for EK80 raw files
+    generated with ping sequence.
+    """
+    # Convert EK80 Raw File
+    ed = open_raw(
+        raw_file="echopype/test_data/ek80_sequence/three_ensemble-Phase0-D20240506-T053349-0.raw",
+        sonar_model="EK80"
+    )
+
+    # Check that one channel is filter coeff are all NaN
+    assert (
+        ed["Vendor_specific"]["WBT_filter_i"].dropna(dim="channel").sizes
+        == {'channel': 1, 'WBT_filter_n': 191}
+    )
+    assert (
+        ed["Vendor_specific"]["PC_filter_i"].dropna(dim="channel").sizes
+        == {'channel': 1, 'PC_filter_n': 63}
+    )
+    assert np.isnan(ed["Vendor_specific"]["PC_decimation"].values[0])
+    assert ed["Vendor_specific"]["PC_decimation"].values[1] == 2
+
+    assert np.isnan(ed["Vendor_specific"]["WBT_decimation"].values[0])
+    assert ed["Vendor_specific"]["WBT_decimation"].values[1] == 6


### PR DESCRIPTION
This PR change EK80 `set_vendor` to fill in `np.nan` for missing filter coeffs across all channels.

Currently we have below in our test file:
- `D20210330-T123857.raw` that does not contain any filter coeffs
- `three_ensemble-Phase0-D20240506-T053349-0.raw` that only contains filter coeffs from 1 of the 2 channels, which seems to be due to ping sequencing. This file is from #1317. 
  - #1413 seems to be due to a similar reason.

This addresses #1317 and #1413.