### PR TITLE
Set decode timedelta to False since it will default to this in later xarray version [all tests ci]

### DIFF
--- a/echopype/tests/convert/test_convert_ad2cp.py
+++ b/echopype/tests/convert/test_convert_ad2cp.py
@@ -189,6 +189,7 @@ def _check_raw_output(
             base = xr.open_dataset(
                 str(ocean_contour_converted_transmit_data_path),
                 group="Data/RawEcho1_1000kHzTx",
+                decode_timedelta=False,
             )
             if "090" in filepath_raw.parts:
                 for i in range(1, len(echodata["Sonar"]["beam_group"]) + 1):
@@ -231,6 +232,7 @@ def _check_raw_output(
         base = xr.open_dataset(
             str(ocean_contour_converted_data_path),
             group="Data/RawEcho1_1000kHz",
+            decode_timedelta=False,
         )
         if "090" in filepath_raw.parts:
             for i in range(1, len(echodata["Sonar"]["beam_group"]) + 1):


### PR DESCRIPTION
Resolves https://github.com/OSOceanAcoustics/echopype/actions/runs/13098048680/job/36542811253?pr=1429#step:15:944 found in #1439:

> Warning: In a future version of xarray decode_timedelta will default to False rather than None. To silence this warning, set decode_timedelta to True, False, or a 'CFTimedeltaCoder' instance.