### PR TITLE
Enhance `compute_MVBS` feasability 

### DIFF
--- a/echopype/commongrid/api.py
+++ b/echopype/commongrid/api.py
@@ -3,7 +3,7 @@ Functions for enhancing the spatial and temporal coherence of data.
 """
 
 import logging
-from typing import Literal, Union
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -36,7 +36,7 @@ def compute_MVBS(
     reindex: bool = False,
     skipna: bool = True,
     closed: Literal["left", "right"] = "left",
-    range_var_max: Union[int, float] = None,
+    range_var_max: str = None,
     **flox_kwargs,
 ):
     """
@@ -76,7 +76,7 @@ def compute_MVBS(
         Else, the mean operation includes NaN values.
     closed: {'left', 'right'}, default 'left'
         Which side of bin interval is closed.
-    range_var_max: Union[int, float], default None
+    range_var_max: str, default None
         Range variable maximum. Can be true range variable maximum or the maximum depth the
         user wishes to regrid to. If known, users can pass in range variable maximum to
         ensure that `compute_MVBS` can lazily run without any computation.
@@ -104,6 +104,10 @@ def compute_MVBS(
     if range_var_max is None:
         # This computes the range variable max since there might NaNs in the data
         range_var_max = ds_Sv[range_var].max(skipna=True)
+    else:
+        # Parse string and small increase to ensure that we get the bin
+        # corresponding to range_var_max
+        range_var_max = _parse_x_bin(range_var_max) + 1e-8
     range_interval = np.arange(0, range_var_max + range_bin, range_bin)
 
     # create bin information needed for ping_time

--- a/echopype/commongrid/api.py
+++ b/echopype/commongrid/api.py
@@ -105,7 +105,7 @@ def compute_MVBS(
 
     # Create bin information for the range variable
     if range_var_max is None:
-        # This computes the range variable max since there might NaNs in the data
+        # This computes the range variable max since there might be NaNs in the data
         range_var_max = ds_Sv[range_var].max(skipna=True)
     else:
         # Parse string and small increase to ensure that we get the bin

--- a/echopype/commongrid/api.py
+++ b/echopype/commongrid/api.py
@@ -295,6 +295,7 @@ def compute_NASC(
 ) -> xr.Dataset:
     """
     Compute Nautical Areal Scattering Coefficient (NASC) from an Sv dataset.
+    TODO: Add range_var_max and reindex parameters to match `compute_MVBS`.
 
     Parameters
     ----------

--- a/echopype/commongrid/api.py
+++ b/echopype/commongrid/api.py
@@ -35,6 +35,7 @@ def compute_MVBS(
     method: str = "map-reduce",
     reindex: bool = False,
     skipna: bool = True,
+    fill_value: float = np.nan,
     closed: Literal["left", "right"] = "left",
     range_var_max: str = None,
     **flox_kwargs,
@@ -74,6 +75,8 @@ def compute_MVBS(
     skipna: bool, default True
         If true, the mean operation skips NaN values.
         Else, the mean operation includes NaN values.
+    fill_value: float, default np.nan
+        Fill value when no group data exists to aggregate.
     closed: {'left', 'right'}, default 'left'
         Which side of bin interval is closed.
     range_var_max: str, default None
@@ -130,6 +133,7 @@ def compute_MVBS(
         method=method,
         reindex=reindex,
         skipna=skipna,
+        fill_value=fill_value,
         **flox_kwargs,
     )
 

--- a/echopype/commongrid/utils.py
+++ b/echopype/commongrid/utils.py
@@ -22,6 +22,7 @@ def compute_raw_MVBS(
     method="map-reduce",
     reindex=False,
     skipna=True,
+    fill_value=np.nan,
     **flox_kwargs,
 ):
     """
@@ -56,6 +57,8 @@ def compute_raw_MVBS(
     skipna: bool, default True
         If true, the mean operation skips NaN values.
         Else, the mean operation includes NaN values.
+    fill_value: float, default np.nan
+        Fill value when no group data exists to aggregate.
     **flox_kwargs
         Additional keyword arguments to be passed
         to flox reduction function.
@@ -79,6 +82,7 @@ def compute_raw_MVBS(
         reindex=reindex,
         func="nanmean" if skipna else "mean",
         skipna=skipna,
+        fill_value=fill_value,
         **flox_kwargs,
     )
 
@@ -506,6 +510,7 @@ def _groupby_x_along_channels(
     reindex: bool = False,
     func: str = "nanmean",
     skipna: bool = True,
+    fill_value: float = np.nan,
     **flox_kwargs,
 ) -> xr.Dataset:
     """
@@ -558,6 +563,8 @@ def _groupby_x_along_channels(
         Else, aggregation function includes NaN values.
         Note that if ``func`` is set to 'mean' and ``skipna`` is set to True, then aggregation
         will have the same behavior as if func is set to 'nanmean'.
+    fill_value: float, default np.nan
+        Fill value when no group data exists to aggregate.
     **flox_kwargs
         Additional keyword arguments to be passed
         to flox reduction function.
@@ -611,6 +618,7 @@ def _groupby_x_along_channels(
         reindex=reindex,
         func=func,
         skipna=skipna,
+        fill_value=fill_value,
         **flox_kwargs,
     )
     return sv_mean

--- a/echopype/commongrid/utils.py
+++ b/echopype/commongrid/utils.py
@@ -20,6 +20,7 @@ def compute_raw_MVBS(
     ping_interval: Union[pd.IntervalIndex, np.ndarray],
     range_var: Literal["echo_range", "depth"] = "echo_range",
     method="map-reduce",
+    reindex=False,
     skipna=True,
     **flox_kwargs,
 ):
@@ -46,6 +47,12 @@ def compute_raw_MVBS(
         The flox strategy for reduction of dask arrays only.
         See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
         for more details.
+    reindex: bool, default False
+        If False, reindex after the blockwise stage. If True, reindex at the blockwise stage.
+        Generally, `reindex=False` results in less memory at the cost of computation speed.
+        Can only be used when method='map-reduce'.
+        See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
+        for more details.
     skipna: bool, default True
         If true, the mean operation skips NaN values.
         Else, the mean operation includes NaN values.
@@ -69,6 +76,7 @@ def compute_raw_MVBS(
         x_var=x_var,
         range_var=range_var,
         method=method,
+        reindex=reindex,
         func="nanmean" if skipna else "mean",
         skipna=skipna,
         **flox_kwargs,
@@ -495,6 +503,7 @@ def _groupby_x_along_channels(
     x_var: Literal["ping_time", "distance_nmi"] = "ping_time",
     range_var: Literal["echo_range", "depth"] = "echo_range",
     method: str = "map-reduce",
+    reindex: bool = False,
     func: str = "nanmean",
     skipna: bool = True,
     **flox_kwargs,
@@ -532,6 +541,12 @@ def _groupby_x_along_channels(
         **For NASC, this must be ``depth``.**
     method: str
         The flox strategy for reduction of dask arrays only.
+        See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
+        for more details.
+    reindex: bool, default False
+        If False, reindex after the blockwise stage. If True, reindex at the blockwise stage.
+        Generally, `reindex=False` results in less memory at the cost of computation speed.
+        Can only be used when method='map-reduce'.
         See flox `documentation <https://flox.readthedocs.io/en/latest/implementation.html>`_
         for more details.
     func: str, default 'nanmean'
@@ -593,6 +608,7 @@ def _groupby_x_along_channels(
         expected_groups=(None, x_interval, range_interval),
         isbin=[False, True, True],
         method=method,
+        reindex=reindex,
         func=func,
         skipna=skipna,
         **flox_kwargs,

--- a/echopype/tests/commongrid/test_commongrid_api.py
+++ b/echopype/tests/commongrid/test_commongrid_api.py
@@ -555,3 +555,33 @@ def test_assign_actual_range(request):
             round(float(ds_MVBS["Sv"].max().values), 2),
         ]
     )
+
+
+@pytest.mark.integration
+def test_compute_MVBS_range_var_max(request):
+    """
+    Tests compute_MVBS when user specified range_var_max is passed in.
+    """
+    # Grab mock Sv dataset
+    ds_Sv = request.getfixturevalue("mock_Sv_dataset_regular")
+
+    # Compute MVBS
+    ds_MVBS = ep.commongrid.compute_MVBS(ds_Sv, range_bin="1m", range_var_max="8m")
+
+    # Ensure that last echo range value matches range variable maximum
+    assert ds_MVBS["echo_range"].max().compute() == 8
+
+
+@pytest.mark.integration
+def test_compute_reindex_non_NaN_not_map_reduce(request):
+    """
+    Tests compute_MVBS when user passes in reindex non-NaN without method as map-reduce.
+    """
+    # Grab mock Sv dataset
+    ds_Sv = request.getfixturevalue("mock_Sv_dataset_regular")
+
+    # Compute MVBS with invalid parameters
+    for method in ["blockwise", "cohorts"]:
+        for reindex in [True, False]:
+            with pytest.raises(ValueError, match=f"Passing in reindex={reindex} is only allowed when method='map_reduce'."):
+                ep.commongrid.compute_MVBS(ds_Sv, method=method, reindex=reindex)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp
 bottleneck
 dask[array,distributed]
 dask-image
-flox>=0.7.2,<1.0.0
+flox>=0.7.2
 fsspec
 geopy
 jinja2


### PR DESCRIPTION
Allow `reindex` to be visible flox parameter in `compute_MVBS` and default to `reindex=False`, allowing computations to be more memory feasible.

Added `range_var_max` optional parameter which allows a user to specify range variable maximum, which in turn allows `compute_MVBS` to be lazily computed.

Tested the new `compute_MVBS` code on a large 40 GiB Sv dataset on a Dask Local Cluster with 2 workers each with 2 threads and 2 GiB RAM (4 GiB RAM total), shown on the following Gist: https://gist.github.com/ctuguinay/4cafda0c604fe6873b8f18c79cccdd1c

