### PR TITLE
Replace `utcnow()` with timezone-aware object

### DIFF
--- a/echopype/consolidate/api.py
+++ b/echopype/consolidate/api.py
@@ -224,7 +224,7 @@ def add_depth(
     used_platform_angles = use_platform_angles and not tilt
     used_beam_angles = use_beam_angles and not tilt
     history_attr = (
-        f"{datetime.datetime.utcnow()} +00:00. depth` calculated using:"
+        f"{datetime.datetime.now(datetime.UTC)} +00:00. depth` calculated using:"
         f" Sv `echo_range`"
         f"{', Echodata `Platform` Vertical Offsets' if (used_platform_vertical_offsets) else ''}"
         f"{', Echodata `Platform` Angles' if (used_platform_angles) else ''}"
@@ -320,7 +320,7 @@ def add_location(
     # Most attributes are attached automatically via interpolation
     # here we add the history
     history_attr = (
-        f"{datetime.datetime.utcnow()} +00:00. "
+        f"{datetime.datetime.now(datetime.UTC)} +00:00. "
         f"Interpolated or propagated from Platform {lat_name}/{lon_name}."  # noqa
     )
     for da_name in POSITION_VARIABLES:
@@ -515,7 +515,7 @@ def add_splitbeam_angle(
 
     # Add history attribute
     history_attr = (
-        f"{datetime.datetime.utcnow()} +00:00. "
+        f"{datetime.datetime.now(datetime.UTC)} +00:00. "
         "Calculated using data stored in the Beam groups of the echodata object."  # noqa
     )
     for da_name in ["angle_alongship", "angle_athwartship"]:

--- a/echopype/consolidate/api.py
+++ b/echopype/consolidate/api.py
@@ -224,7 +224,7 @@ def add_depth(
     used_platform_angles = use_platform_angles and not tilt
     used_beam_angles = use_beam_angles and not tilt
     history_attr = (
-        f"{datetime.datetime.now(datetime.UTC)} +00:00. depth` calculated using:"
+        f"{datetime.datetime.now(datetime.UTC)}. `depth` calculated using:"
         f" Sv `echo_range`"
         f"{', Echodata `Platform` Vertical Offsets' if (used_platform_vertical_offsets) else ''}"
         f"{', Echodata `Platform` Angles' if (used_platform_angles) else ''}"
@@ -320,7 +320,7 @@ def add_location(
     # Most attributes are attached automatically via interpolation
     # here we add the history
     history_attr = (
-        f"{datetime.datetime.now(datetime.UTC)} +00:00. "
+        f"{datetime.datetime.now(datetime.UTC)}. "
         f"Interpolated or propagated from Platform {lat_name}/{lon_name}."  # noqa
     )
     for da_name in POSITION_VARIABLES:
@@ -515,7 +515,7 @@ def add_splitbeam_angle(
 
     # Add history attribute
     history_attr = (
-        f"{datetime.datetime.now(datetime.UTC)} +00:00. "
+        f"{datetime.datetime.now(datetime.UTC)}. "
         "Calculated using data stored in the Beam groups of the echodata object."  # noqa
     )
     for da_name in ["angle_alongship", "angle_athwartship"]:

--- a/echopype/consolidate/api.py
+++ b/echopype/consolidate/api.py
@@ -330,8 +330,7 @@ def add_location(
         else f"{datetime.datetime.now(datetime.UTC)}. `depth` calculated using:"
     )
     history_attr = (
-        history_attr +
-        f"Interpolated or propagated from Platform {lat_name}/{lon_name}."  # noqa
+        history_attr + f"Interpolated or propagated from Platform {lat_name}/{lon_name}."  # noqa
     )
     for da_name in POSITION_VARIABLES:
         interp_ds[da_name] = interp_ds[da_name].assign_attrs({"history": history_attr})
@@ -530,8 +529,8 @@ def add_splitbeam_angle(
         else f"{datetime.datetime.now(datetime.UTC)}. `depth` calculated using:"
     )
     history_attr = (
-        history_attr + 
-        "Calculated using data stored in the Beam groups of the echodata object."  # noqa
+        history_attr
+        + "Calculated using data stored in the Beam groups of the echodata object."  # noqa
     )
     for da_name in ["angle_alongship", "angle_athwartship"]:
         source_Sv[da_name] = source_Sv[da_name].assign_attrs({"history": history_attr})

--- a/echopype/consolidate/api.py
+++ b/echopype/consolidate/api.py
@@ -1,3 +1,4 @@
+import sys
 import datetime
 import pathlib
 from numbers import Number
@@ -224,7 +225,12 @@ def add_depth(
     used_platform_angles = use_platform_angles and not tilt
     used_beam_angles = use_beam_angles and not tilt
     history_attr = (
-        f"{datetime.datetime.now(datetime.UTC)}. `depth` calculated using:"
+        f"{datetime.datetime.utcnow()}+00:00. `depth` calculated using:"
+        if sys.version_info < (3, 11, 0)
+        else f"{datetime.datetime.now(datetime.UTC)}. `depth` calculated using:"
+    )
+    history_attr = (
+        history_attr +
         f" Sv `echo_range`"
         f"{', Echodata `Platform` Vertical Offsets' if (used_platform_vertical_offsets) else ''}"
         f"{', Echodata `Platform` Angles' if (used_platform_angles) else ''}"

--- a/echopype/consolidate/api.py
+++ b/echopype/consolidate/api.py
@@ -326,7 +326,12 @@ def add_location(
     # Most attributes are attached automatically via interpolation
     # here we add the history
     history_attr = (
-        f"{datetime.datetime.now(datetime.UTC)}. "
+        f"{datetime.datetime.utcnow()}+00:00. `depth` calculated using:"
+        if sys.version_info < (3, 11, 0)
+        else f"{datetime.datetime.now(datetime.UTC)}. `depth` calculated using:"
+    )
+    history_attr = (
+        history_attr +
         f"Interpolated or propagated from Platform {lat_name}/{lon_name}."  # noqa
     )
     for da_name in POSITION_VARIABLES:
@@ -521,7 +526,12 @@ def add_splitbeam_angle(
 
     # Add history attribute
     history_attr = (
-        f"{datetime.datetime.now(datetime.UTC)}. "
+        f"{datetime.datetime.utcnow()}+00:00. `depth` calculated using:"
+        if sys.version_info < (3, 11, 0)
+        else f"{datetime.datetime.now(datetime.UTC)}. `depth` calculated using:"
+    )
+    history_attr = (
+        history_attr + 
         "Calculated using data stored in the Beam groups of the echodata object."  # noqa
     )
     for da_name in ["angle_alongship", "angle_athwartship"]:

--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -1,7 +1,7 @@
-import sys
-import os
-from collections import defaultdict
 import datetime
+import os
+import sys
+from collections import defaultdict
 from typing import Any, Dict, Literal, Optional, Tuple
 
 import dask
@@ -74,13 +74,13 @@ class ParseEK(ParseBase):
 
     def _print_status(self):
         if sys.version_info < (3, 11, 0):
-            time = datetime.datetime.utcfromtimestamp(self.config_datagram["timestamp"].tolist() / 1e9).strftime(
-                "%Y-%b-%d %H:%M:%S"
-            )
+            time = datetime.datetime.utcfromtimestamp(
+                self.config_datagram["timestamp"].tolist() / 1e9
+            ).strftime("%Y-%b-%d %H:%M:%S")
         else:
-            time = datetime.datetime.fromtimestamp(self.config_datagram["timestamp"].tolist() / 1e9, datetime.UTC).strftime(
-                "%Y-%b-%d %H:%M:%S"
-            )
+            time = datetime.datetime.fromtimestamp(
+                self.config_datagram["timestamp"].tolist() / 1e9, datetime.UTC
+            ).strftime("%Y-%b-%d %H:%M:%S")
 
         logger.info(
             f"parsing file {os.path.basename(self.source_file)}, " f"time of first ping: {time}"

--- a/echopype/convert/parse_base.py
+++ b/echopype/convert/parse_base.py
@@ -1,6 +1,7 @@
+import sys
 import os
 from collections import defaultdict
-from datetime import datetime as dt
+import datetime
 from typing import Any, Dict, Literal, Optional, Tuple
 
 import dask
@@ -72,9 +73,15 @@ class ParseEK(ParseBase):
         self.CON1_datagram = None  # Holds the ME70 CON1 datagram
 
     def _print_status(self):
-        time = dt.utcfromtimestamp(self.config_datagram["timestamp"].tolist() / 1e9).strftime(
-            "%Y-%b-%d %H:%M:%S"
-        )
+        if sys.version_info < (3, 11, 0):
+            time = datetime.datetime.utcfromtimestamp(self.config_datagram["timestamp"].tolist() / 1e9).strftime(
+                "%Y-%b-%d %H:%M:%S"
+            )
+        else:
+            time = datetime.datetime.fromtimestamp(self.config_datagram["timestamp"].tolist() / 1e9, datetime.UTC).strftime(
+                "%Y-%b-%d %H:%M:%S"
+            )
+
         logger.info(
             f"parsing file {os.path.basename(self.source_file)}, " f"time of first ping: {time}"
         )

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -413,7 +413,7 @@ class EchoData:
 
         # History attribute to be included in each updated variable
         history_attr = (
-            f"{datetime.datetime.now(datetime.UTC)} +00:00. Added from external platform data"
+            f"{datetime.datetime.now(datetime.UTC)}. Added from external platform data"
         )
         if extra_platform_data_file_name:
             history_attr += ", from file " + extra_platform_data_file_name

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -1,3 +1,4 @@
+import sys
 import datetime
 import re
 import warnings
@@ -412,7 +413,12 @@ class EchoData:
             extra_platform_data = extra_platform_data.swap_dims({obs_dim: time_dim})
 
         # History attribute to be included in each updated variable
-        history_attr = f"{datetime.datetime.now(datetime.UTC)}. Added from external platform data"
+        history_attr = (
+            f"{datetime.datetime.utcnow()}+00:00. `depth` calculated using:"
+            if sys.version_info < (3, 11, 0)
+            else f"{datetime.datetime.now(datetime.UTC)}. `depth` calculated using:"
+        )
+        history_attr = f"{history_attr}. Added from external platform data"
         if extra_platform_data_file_name:
             history_attr += ", from file " + extra_platform_data_file_name
 

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -1,6 +1,6 @@
-import sys
 import datetime
 import re
+import sys
 import warnings
 from html import escape
 from pathlib import Path

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -412,7 +412,7 @@ class EchoData:
             extra_platform_data = extra_platform_data.swap_dims({obs_dim: time_dim})
 
         # History attribute to be included in each updated variable
-        history_attr = f"{datetime.datetime.utcnow()} +00:00. Added from external platform data"
+        history_attr = f"{datetime.datetime.now(datetime.UTC)} +00:00. Added from external platform data"
         if extra_platform_data_file_name:
             history_attr += ", from file " + extra_platform_data_file_name
 

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -412,7 +412,9 @@ class EchoData:
             extra_platform_data = extra_platform_data.swap_dims({obs_dim: time_dim})
 
         # History attribute to be included in each updated variable
-        history_attr = f"{datetime.datetime.now(datetime.UTC)} +00:00. Added from external platform data"
+        history_attr = (
+            f"{datetime.datetime.now(datetime.UTC)} +00:00. Added from external platform data"
+        )
         if extra_platform_data_file_name:
             history_attr += ", from file " + extra_platform_data_file_name
 

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -252,7 +252,9 @@ def _variable_prov_attrs(
         ],
     }
     # Add history attribute
-    history_attr = f"{datetime.datetime.now(datetime.UTC)} +00:00. " "Created masked Sv dataarray."  # noqa
+    history_attr = (
+        f"{datetime.datetime.now(datetime.UTC)} +00:00. " "Created masked Sv dataarray."
+    )  # noqa
     attrs = {**attrs, **{"history": history_attr}}
 
     # Add attributes from the mask DataArray, if present

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -253,7 +253,7 @@ def _variable_prov_attrs(
     }
     # Add history attribute
     history_attr = (
-        f"{datetime.datetime.now(datetime.UTC)} +00:00. " "Created masked Sv dataarray."
+        f"{datetime.datetime.now(datetime.UTC)}. " "Created masked Sv dataarray."
     )  # noqa
     attrs = {**attrs, **{"history": history_attr}}
 
@@ -624,7 +624,7 @@ def frequency_differencing(
 
     xr_dataarray_attrs = {
         "mask_type": "frequency differencing",
-        "history": f"{datetime.datetime.now(datetime.UTC)} +00:00. "
+        "history": f"{datetime.datetime.now(datetime.UTC)}. "
         "Mask created by mask.frequency_differencing. "
         f"Operation: Sv['{chanA}'] - Sv['{chanB}'] {operator} {diff}",
     }

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -1,3 +1,4 @@
+import sys
 import datetime
 import operator as op
 import pathlib
@@ -252,7 +253,12 @@ def _variable_prov_attrs(
         ],
     }
     # Add history attribute
-    history_attr = f"{datetime.datetime.now(datetime.UTC)}. " "Created masked Sv dataarray."  # noqa
+    history_attr = (
+        f"{datetime.datetime.utcnow()}+00:00. `depth` calculated using:"
+        if sys.version_info < (3, 11, 0)
+        else f"{datetime.datetime.now(datetime.UTC)}. `depth` calculated using:"
+    )
+    history_attr = f"{history_attr}. " "Created masked Sv dataarray."  # noqa
     attrs = {**attrs, **{"history": history_attr}}
 
     # Add attributes from the mask DataArray, if present
@@ -620,9 +626,15 @@ def frequency_differencing(
             coords=template.coords,
         )
 
+    history_attr = (
+        f"{datetime.datetime.utcnow()}+00:00. `depth` calculated using:"
+        if sys.version_info < (3, 11, 0)
+        else f"{datetime.datetime.now(datetime.UTC)}. `depth` calculated using:"
+    )
+
     xr_dataarray_attrs = {
         "mask_type": "frequency differencing",
-        "history": f"{datetime.datetime.now(datetime.UTC)}. "
+        "history": f"{history_attr}. "
         "Mask created by mask.frequency_differencing. "
         f"Operation: Sv['{chanA}'] - Sv['{chanB}'] {operator} {diff}",
     }

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -252,7 +252,7 @@ def _variable_prov_attrs(
         ],
     }
     # Add history attribute
-    history_attr = f"{datetime.datetime.utcnow()} +00:00. " "Created masked Sv dataarray."  # noqa
+    history_attr = f"{datetime.datetime.now(datetime.UTC)} +00:00. " "Created masked Sv dataarray."  # noqa
     attrs = {**attrs, **{"history": history_attr}}
 
     # Add attributes from the mask DataArray, if present
@@ -622,7 +622,7 @@ def frequency_differencing(
 
     xr_dataarray_attrs = {
         "mask_type": "frequency differencing",
-        "history": f"{datetime.datetime.utcnow()} +00:00. "
+        "history": f"{datetime.datetime.now(datetime.UTC)} +00:00. "
         "Mask created by mask.frequency_differencing. "
         f"Operation: Sv['{chanA}'] - Sv['{chanB}'] {operator} {diff}",
     }

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -1,7 +1,7 @@
-import sys
 import datetime
 import operator as op
 import pathlib
+import sys
 from typing import List, Optional, Union
 
 import dask

--- a/echopype/tests/commongrid/conftest.py
+++ b/echopype/tests/commongrid/conftest.py
@@ -334,7 +334,7 @@ def ds_Sv_echo_range_regular(regular_data_params, random_number_generator):
 @pytest.fixture
 def latlon_history_attr():
     return (
-        "2023-08-31 12:00:00.000000 +00:00. "
+        "2023-08-31 12:00:00.000000+00:00. "
         "Interpolated or propagated from Platform latitude/longitude."  # noqa
     )
 

--- a/echopype/tests/consolidate/test_add_depth.py
+++ b/echopype/tests/consolidate/test_add_depth.py
@@ -308,8 +308,8 @@ def test_add_depth_without_echodata():
 
     # Check history attribute
     history_attribute = ds_Sv_depth["depth"].attrs["history"]
-    history_attribute_without_time = history_attribute[33:]
-    assert history_attribute_without_time == ". depth` calculated using: Sv `echo_range`."
+    history_attribute_without_time = history_attribute[32:]
+    assert history_attribute_without_time == ". `depth` calculated using: Sv `echo_range`."
 
 
 @pytest.mark.integration
@@ -439,7 +439,7 @@ def test_add_depth_EK_with_platform_angles(file, sonar_model, compute_Sv_kwargs)
 
     # Check history attribute
     history_attribute = ds_Sv_with_depth["depth"].attrs["history"]
-    history_attribute_without_time = history_attribute[33:]
+    history_attribute_without_time = history_attribute[32:]
     assert history_attribute_without_time == (
         ". `depth` calculated using: Sv `echo_range`, Echodata `Platform` Angles."
     )
@@ -494,9 +494,9 @@ def test_add_depth_EK_with_beam_angles(file, sonar_model, compute_Sv_kwargs):
 
     # Check history attribute
     history_attribute = ds_Sv_with_depth["depth"].attrs["history"]
-    history_attribute_without_time = history_attribute[33:]
+    history_attribute_without_time = history_attribute[32:]
     assert history_attribute_without_time == (
-        ". depth` calculated using: Sv `echo_range`, Echodata `Beam_group1` Angles."
+        ". `depth` calculated using: Sv `echo_range`, Echodata `Beam_group1` Angles."
     )
 
     # Compute echo range scaling values
@@ -543,9 +543,9 @@ def test_add_depth_EK_with_beam_angles_with_different_beam_groups(
 
     # Check history attribute
     history_attribute = ds_Sv["depth"].attrs["history"]
-    history_attribute_without_time = history_attribute[33:]
+    history_attribute_without_time = history_attribute[32:]
     assert history_attribute_without_time == (
-        f". depth` calculated using: Sv `echo_range`, Echodata `{expected_beam_group_name}` Angles."
+        f". `depth` calculated using: Sv `echo_range`, Echodata `{expected_beam_group_name}` Angles."
     )
 
 

--- a/echopype/tests/consolidate/test_add_depth.py
+++ b/echopype/tests/consolidate/test_add_depth.py
@@ -441,7 +441,7 @@ def test_add_depth_EK_with_platform_angles(file, sonar_model, compute_Sv_kwargs)
     history_attribute = ds_Sv_with_depth["depth"].attrs["history"]
     history_attribute_without_time = history_attribute[33:]
     assert history_attribute_without_time == (
-        ". depth` calculated using: Sv `echo_range`, Echodata `Platform` Angles."
+        ". `depth` calculated using: Sv `echo_range`, Echodata `Platform` Angles."
     )
 
     # Compute transducer depth

--- a/echopype/tests/consolidate/test_add_depth.py
+++ b/echopype/tests/consolidate/test_add_depth.py
@@ -384,9 +384,9 @@ def test_add_depth_EK_with_platform_vertical_offsets(file, sonar_model, compute_
 
     # Check history attribute
     history_attribute = ds_Sv_with_depth["depth"].attrs["history"]
-    history_attribute_without_time = history_attribute[33:]
+    history_attribute_without_time = history_attribute[32:]
     assert history_attribute_without_time == (
-        ". depth` calculated using: Sv `echo_range`, Echodata `Platform` Vertical Offsets."
+        ". `depth` calculated using: Sv `echo_range`, Echodata `Platform` Vertical Offsets."
     )
 
     # Compute transducer depth

--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -1,7 +1,7 @@
-import sys
+import datetime
 import functools
 import re
-import datetime
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 

--- a/echopype/utils/prov.py
+++ b/echopype/utils/prov.py
@@ -1,6 +1,7 @@
+import sys
 import functools
 import re
-from datetime import datetime as dt
+import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 
@@ -29,11 +30,14 @@ def echopype_prov_attrs(process_type: ProcessType) -> Dict[str, str]:
     process_type : ProcessType
         Echopype process function type
     """
-
+    if sys.version_info < (3, 11, 0):
+        utc_now = datetime.datetime.utcnow().isoformat(timespec="seconds") + "+00:00"
+    else:
+        utc_now = datetime.datetime.now(datetime.UTC).isoformat(timespec="seconds")
     prov_dict = {
         f"{process_type}_software_name": "echopype",
         f"{process_type}_software_version": ECHOPYPE_VERSION,
-        f"{process_type}_time": dt.utcnow().isoformat(timespec="seconds") + "Z",  # use UTC time
+        f"{process_type}_time": utc_now,
     }
 
     return prov_dict


### PR DESCRIPTION
This PR addresses the warning
`datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).`
 that occurs in various places in our codebase.