### PR TITLE
Added support for split-beam angle computation with mixed channel beam types in complex mode

### DIFF
--- a/echopype/consolidate/split_beam_angle.py
+++ b/echopype/consolidate/split_beam_angle.py
@@ -8,7 +8,26 @@ from typing import List, Tuple
 import numpy as np
 import xarray as xr
 
+from ..utils.log import _init_logger
 from ..calibrate.ek80_complex import compress_pulse, get_norm_fac, get_transmit_signal
+
+
+logger = _init_logger(__name__)
+
+# Beam type identifiers
+BEAM_TYPE_SPLIT_4_SECTOR = 1      # 4-sector split-beam (common Simrad type)
+BEAM_TYPE_SPLIT_3_SECTOR = 17     # 3-sector
+BEAM_TYPE_SPLIT_3_PLUS_CENTER = 49  # 3-sector + center element
+BEAM_TYPE_SPLIT_VARIANT_65 = 65   # Another 3+1 variant (vendor-specific)
+BEAM_TYPE_SPLIT_VARIANT_81 = 81   # Another 3+1 variant (vendor-specific)
+
+SUPPORTED_BEAM_TYPES = [
+    BEAM_TYPE_SPLIT_4_SECTOR,
+    BEAM_TYPE_SPLIT_3_SECTOR,
+    BEAM_TYPE_SPLIT_3_PLUS_CENTER,
+    BEAM_TYPE_SPLIT_VARIANT_65,
+    BEAM_TYPE_SPLIT_VARIANT_81,
+]
 
 
 def _compute_angle_from_complex(
@@ -48,7 +67,7 @@ def _compute_angle_from_complex(
     """
 
     # 4-sector transducer
-    if beam_type == 1:
+    if beam_type == BEAM_TYPE_SPLIT_4_SECTOR:
         bs_fore = (bs.isel(beam=2) + bs.isel(beam=3)) / 2  # forward
         bs_aft = (bs.isel(beam=0) + bs.isel(beam=1)) / 2  # aft
         bs_star = (bs.isel(beam=0) + bs.isel(beam=3)) / 2  # starboard
@@ -60,9 +79,14 @@ def _compute_angle_from_complex(
         phi = np.arctan2(np.imag(bs_phi), np.real(bs_phi)) / np.pi * 180
 
     # 3-sector transducer with or without center element
-    elif beam_type in [17, 49, 65, 81]:
+    elif beam_type in [
+        BEAM_TYPE_SPLIT_3_SECTOR,
+        BEAM_TYPE_SPLIT_3_PLUS_CENTER,
+        BEAM_TYPE_SPLIT_VARIANT_65,
+        BEAM_TYPE_SPLIT_VARIANT_81,
+    ]:
         # 3-sector
-        if beam_type == 17:
+        if beam_type == BEAM_TYPE_SPLIT_3_SECTOR:
             bs_star = bs.isel(beam=0)
             bs_port = bs.isel(beam=1)
             bs_fore = bs.isel(beam=2)
@@ -209,8 +233,14 @@ def get_angle_complex_samples(
         )
     else:
         # beam_type different for some channels, process each channel separately
-        theta, phi = [], []
+        theta_list, phi_list, valid_channels = [], [], []
         for ch_id in bs["channel"].data:
+            beam_type_ch = ds_beam["beam_type"].sel(channel=ch_id).item()
+
+            if beam_type_ch not in SUPPORTED_BEAM_TYPES:
+                logger.warning(f"Skipping channel {ch_id}: unsupported beam_type {beam_type_ch}")
+                continue
+
             theta_ch, phi_ch = _compute_angle_from_complex(
                 bs=bs.sel(channel=ch_id),
                 # beam_type is not time-varying
@@ -224,25 +254,18 @@ def get_angle_complex_samples(
                     angle_params["angle_offset_athwartship"].sel(channel=ch_id),
                 ],
             )
-            theta.append(theta_ch)
-            phi.append(phi_ch)
+            theta_list.append(theta_ch)
+            phi_list.append(phi_ch)
+            valid_channels.append(ch_id)
+
+        if not theta_list:
+            raise ValueError("No valid channels found for angle computation.")
 
         # Combine angles from all channels
-        theta = xr.DataArray(
-            data=theta,
-            coords={
-                "channel": bs["channel"],
-                "ping_time": bs["ping_time"],
-                "range_sample": bs["range_sample"],
-            },
-        )
-        phi = xr.DataArray(
-            data=phi,
-            coords={
-                "channel": bs["channel"],
-                "ping_time": bs["ping_time"],
-                "range_sample": bs["range_sample"],
-            },
-        )
+        theta = xr.concat(theta_list, dim="channel")
+        theta = theta.assign_coords(channel=("channel", valid_channels))
+
+        phi = xr.concat(phi_list, dim="channel")
+        phi = phi.assign_coords(channel=("channel", valid_channels))
 
     return theta, phi


### PR DESCRIPTION
This PR adds support for computing split-beam angles in datasets where only a subset of channels have valid `beam_type` values (e.g., `beam_type = 1, 17, 49, 65, 81`). It applies specifically to CW complex data.

Previously, the presence of an unsupported `beam_type` would raise a `ValueError`.

**Changes:**
- updated `get_angle_complex_samples()` to process each channel individually if `beam_type` is not uniform;
- skips channels with unsupported `beam_type` values and logs a warning instead of failing.