### PR TITLE
[1485] Moved the check for duplicate times to after NMEA selection

### DIFF
--- a/echopype/consolidate/api.py
+++ b/echopype/consolidate/api.py
@@ -303,9 +303,6 @@ def add_location(
     # Grab time dimension name
     time_dim_name = list(echodata["Platform"][lon_name].dims)[0]
 
-    # Check if there are duplicates in time_dim_name
-    check_loc_time_dim_duplicates(echodata, time_dim_name)
-
     # Copy dataset
     interp_ds = ds.copy()
 
@@ -318,6 +315,10 @@ def add_location(
             nmea_sentence=nmea_sentence,
             datagram_type=datagram_type,
         )
+
+        # Check if there are duplicates in time_dim_name for this NMEA subset
+        check_loc_time_dim_duplicates(loc_var, time_dim_name)
+
         interp_ds[interp_loc_name] = align_to_ping_time(
             loc_var, time_dim_name, ds["ping_time"], "linear"
         )

--- a/echopype/consolidate/loc_utils.py
+++ b/echopype/consolidate/loc_utils.py
@@ -107,13 +107,13 @@ def check_loc_vars_validity(
             logger.warning(output_message)
 
 
-def check_loc_time_dim_duplicates(echodata: EchoData, time_dim_name: str) -> None:
+def check_loc_time_dim_duplicates(da: xr.DataArray, time_dim_name: str) -> None:
     """Check if there are duplicates in time_dim_name"""
-    if len(np.unique(echodata["Platform"][time_dim_name].data)) != len(
-        echodata["Platform"][time_dim_name].data
+    if len(np.unique(da[time_dim_name].data)) != len(
+        da[time_dim_name].data
     ):
         raise ValueError(
-            f'The ``echodata["Platform"]["{time_dim_name}"]`` array contains duplicate values. '
+            f'The ``da["{time_dim_name}"]`` array contains duplicate values. '
             "Downstream interpolation on the position variables requires unique time values."
         )
 

--- a/echopype/tests/consolidate/test_add_location.py
+++ b/echopype/tests/consolidate/test_add_location.py
@@ -1,5 +1,5 @@
 import math
-
+import os
 import pytest
 import numpy as np
 import xarray as xr
@@ -7,6 +7,7 @@ import xarray as xr
 import echopype as ep
 from echopype.consolidate.loc_utils import sel_nmea
 
+TEST_DATA_DIR = "../../test_data/"
 
 @pytest.mark.unit
 def test_sel_nmea_value_error():
@@ -36,9 +37,9 @@ def test_add_location_datagram_type_specified_not_ek_error():
     """
     # Compute raw and compute Sv
     ed = ep.open_raw(
-        "echopype/test_data/azfp/17082117.01A",
+        os.path.abspath(TEST_DATA_DIR + "azfp/17082117.01A"),
         sonar_model="AZFP",
-        xml_path="echopype/test_data/azfp/23081211.XML"
+        xml_path=os.path.abspath(TEST_DATA_DIR + "azfp/23081211.XML")
     )
     avg_temperature = ed["Environment"]['temperature'].values.mean()
     env_params = {
@@ -56,7 +57,6 @@ def test_add_location_datagram_type_specified_not_ek_error():
             datagram_type="MRU1",
         )
     assert ("Sonar Model must be EK in order to specify datagram_type.") == str(exc_info.value)
-
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
@@ -190,7 +190,7 @@ def test_add_location(
     ("raw_path, sonar_model, datagram_type, parse_idx, time_dim_name, compute_Sv_kwargs"),
     [
         (
-            "echopype/test_data/ek80/D20170912-T234910.raw",
+            os.path.abspath(TEST_DATA_DIR + "ek80/D20170912-T234910.raw"),
             "EK80",
             None,
             False,
@@ -201,7 +201,7 @@ def test_add_location(
             }
         ),
         (
-            "echopype/test_data/ek80/RL2407_ADCP-D20240709-T150437.raw",
+            os.path.abspath(TEST_DATA_DIR + "ek80/RL2407_ADCP-D20240709-T150437.raw"),
             "EK80",
             "MRU1",
             False,
@@ -212,7 +212,7 @@ def test_add_location(
             }
         ),
         (
-            "echopype/test_data/ek80/idx_bot/Hake-D20230711-T181910.raw",
+            os.path.abspath(TEST_DATA_DIR + "ek80/idx_bot/Hake-D20230711-T181910.raw"),
             "EK80",
             "IDX",
             True,
@@ -248,7 +248,7 @@ def test_add_location_time_duplicates_value_error(
 
     # Check if the specific error message is in the logs
     assert (
-        f'The ``echodata["Platform"]["{time_dim_name}"]`` array contains duplicate values. '
+        f'The ``da["{time_dim_name}"]`` array contains duplicate values. '
         "Downstream interpolation on the position variables requires unique time values."
     ) == str(exc_info.value)
 
@@ -258,7 +258,7 @@ def test_add_location_time_duplicates_value_error(
     ("raw_path, sonar_model, datagram_type, parse_idx, compute_Sv_kwargs, error_type, expected_error_message"),
     [
         (
-            "echopype/test_data/ek80/D20170912-T234910.raw",
+            os.path.abspath(TEST_DATA_DIR + "ek80/D20170912-T234910.raw"),
             "EK80",
             None,
             False,
@@ -270,7 +270,7 @@ def test_add_location_time_duplicates_value_error(
             "Coordinate variables not present.",
         ),
         (
-            "echopype/test_data/ek80/RL2407_ADCP-D20240709-T150437.raw",
+            os.path.abspath(TEST_DATA_DIR + "ek80/RL2407_ADCP-D20240709-T150437.raw"),
             "EK80",
             "MRU1",
             False,
@@ -282,7 +282,7 @@ def test_add_location_time_duplicates_value_error(
             "Coordinate variables are all NaN.",
         ),
         (
-            "echopype/test_data/ek80/idx_bot/Hake-D20230711-T181910.raw",
+            os.path.abspath(TEST_DATA_DIR + "ek80/idx_bot/Hake-D20230711-T181910.raw"),
             "EK80",
             "IDX",
             True,
@@ -339,7 +339,7 @@ def test_add_location_lat_lon_missing_all_NaN_errors(
     ("raw_path, sonar_model, datagram_type, parse_idx, compute_Sv_kwargs, expected_warnings"),
     [
         (
-            "echopype/test_data/ek80/D20170912-T234910.raw",
+            os.path.abspath(TEST_DATA_DIR + "ek80/D20170912-T234910.raw"),
             "EK80",
             "NMEA",
             False,
@@ -361,7 +361,7 @@ def test_add_location_lat_lon_missing_all_NaN_errors(
             ]
         ),
         (
-            "echopype/test_data/ek80/RL2407_ADCP-D20240709-T150437.raw",
+            os.path.abspath(TEST_DATA_DIR + "ek80/RL2407_ADCP-D20240709-T150437.raw"),
             "EK80",
             "MRU1",
             False,
@@ -383,7 +383,7 @@ def test_add_location_lat_lon_missing_all_NaN_errors(
             ]
         ),
         (
-            "echopype/test_data/ek80/idx_bot/Hake-D20230711-T181910.raw",
+            os.path.abspath(TEST_DATA_DIR + "ek80/idx_bot/Hake-D20230711-T181910.raw"),
             "EK80",
             "IDX",
             True,


### PR DESCRIPTION
Resolves #1485 

Moved the check for duplicate times to after selecting the NMEA subset when adding location to sv dataset.
Also updated the tests for add_location()