### PR TITLE
[1486] Support computing MVBS with frequency_nominal and fix some tests [all tests ci]

### DIFF
--- a/echopype/commongrid/api.py
+++ b/echopype/commongrid/api.py
@@ -137,13 +137,16 @@ def compute_MVBS(
         **flox_kwargs,
     )
 
+    # Generalize the first dimension name to support multiple like channel and frequency_nominal
+    dim_0 = list(raw_MVBS.dims.keys())[0]
+
     # create MVBS dataset
     # by transforming the binned dimensions to regular coords
     ds_MVBS = xr.Dataset(
-        data_vars={"Sv": (["channel", "ping_time", range_var], raw_MVBS["Sv"].data)},
+        data_vars={"Sv": ([dim_0, "ping_time", range_var], raw_MVBS["Sv"].data)},
         coords={
             "ping_time": np.array([v.left for v in raw_MVBS.ping_time_bins.values]),
-            "channel": raw_MVBS.channel.values,
+            dim_0: getattr(raw_MVBS, dim_0).values,
             range_var: np.array([v.left for v in raw_MVBS[f"{range_var}_bins"].values]),
         },
     )
@@ -206,6 +209,7 @@ def compute_MVBS(
     prov_dict["processing_function"] = "commongrid.compute_MVBS"
     ds_MVBS = ds_MVBS.assign_attrs(prov_dict)
     ds_MVBS["frequency_nominal"] = ds_Sv["frequency_nominal"]  # re-attach frequency_nominal
+    ds_MVBS["channel"] = ds_Sv["channel"]  # re-attach channel
 
     ds_MVBS = insert_input_processing_level(ds_MVBS, input_ds=ds_Sv)
 

--- a/echopype/commongrid/utils.py
+++ b/echopype/commongrid/utils.py
@@ -35,6 +35,7 @@ def compute_raw_MVBS(
         with coordinates ``channel``, ``ping_time``, and ``range_sample``
         at bare minimum.
         Or this can contain ``Sv`` and ``depth`` data with similar coordinates.
+        ``frequency_nominal`` is supported as an alternative to ``channel``
     range_interval: pd.IntervalIndex or np.ndarray
         1D array or interval index representing
         the bins required for ``range_var``
@@ -530,6 +531,8 @@ def _groupby_x_along_channels(
 
         For NASC computatioon this must contain ``Sv`` and ``depth`` data
         with coordinates ``channel``, ``distance_nmi``, and ``range_sample``.
+
+        ``frequency_nominal`` is supported as an alternative to ``channel``
     range_interval: pd.IntervalIndex or np.ndarray
         1D array or interval index representing
         the bins required for ``range_var``
@@ -604,12 +607,13 @@ def _groupby_x_along_channels(
                 f"The ```{array_name}``` coordinate array contain NaNs. {aggregation_msg}"
             )
 
-    # reduce along ping_time or distance_nmi
-    # and echo_range or depth
-    # by binning and averaging
+    # Use the first dimension as the grouping dimension for generality
+    dim_0 = list(ds_Sv.dims.keys())[0]
+
+    # bin and average along ping_time or distance_nmi and echo_range or depth
     sv_mean = xarray_reduce(
         sv,
-        ds_Sv["channel"],
+        ds_Sv[dim_0], # generic: not always 'channel'
         ds_Sv[x_var],
         ds_Sv[range_var],
         expected_groups=(None, x_interval, range_interval),

--- a/echopype/commongrid/utils.py
+++ b/echopype/commongrid/utils.py
@@ -613,7 +613,7 @@ def _groupby_x_along_channels(
     # bin and average along ping_time or distance_nmi and echo_range or depth
     sv_mean = xarray_reduce(
         sv,
-        ds_Sv[dim_0], # generic: not always 'channel'
+        ds_Sv[dim_0],  # generic: not always 'channel'
         ds_Sv[x_var],
         ds_Sv[range_var],
         expected_groups=(None, x_interval, range_interval),

--- a/echopype/testing.py
+++ b/echopype/testing.py
@@ -24,7 +24,7 @@ def _gen_ping_time(ping_time_len, ping_time_interval, ping_time_jitter_max_ms=0)
         jitter = (
             np.random.randint(ping_time_jitter_max_ms, size=ping_time_len) / 1000
         )  # convert to seconds
-        ping_time = pd.to_datetime(ping_time.astype('int64') / 1e9 + jitter, unit="s")
+        ping_time = pd.to_datetime(ping_time.astype("int64") / 1e9 + jitter, unit="s")
     return ping_time
 
 

--- a/echopype/testing.py
+++ b/echopype/testing.py
@@ -24,7 +24,7 @@ def _gen_ping_time(ping_time_len, ping_time_interval, ping_time_jitter_max_ms=0)
         jitter = (
             np.random.randint(ping_time_jitter_max_ms, size=ping_time_len) / 1000
         )  # convert to seconds
-        ping_time = pd.to_datetime(ping_time.astype(int) / 1e9 + jitter, unit="s")
+        ping_time = pd.to_datetime(ping_time.astype('int64') / 1e9 + jitter, unit="s")
     return ping_time
 
 


### PR DESCRIPTION
Resolves #1486 

- Generalized instances of `"channel"` string to support `frequency_nominal` or others in dim 0.
- Added test that includes swapping dims.
- Fixed broken tests.