### PR TITLE
Unpinning numpy and scipy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,4 +39,4 @@ repos:
       - id: codespell
         # Checks spelling in `docs/source` and `echopype` dirs ONLY
         # Ignores `.ipynb` files and `_build` folders
-        args: ["-L", "soop,anc,indx,nd", "--skip=*.ipynb,docs/source/_build,echopype/test_data", "-w", "docs/source", "echopype"]
+        args: ["-L", "soop,anc,indx", "--skip=*.ipynb,docs/source/_build,echopype/test_data", "-w", "docs/source", "echopype"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,4 +39,4 @@ repos:
       - id: codespell
         # Checks spelling in `docs/source` and `echopype` dirs ONLY
         # Ignores `.ipynb` files and `_build` folders
-        args: ["-L", "soop,anc,indx", "--skip=*.ipynb,docs/source/_build,echopype/test_data", "-w", "docs/source", "echopype"]
+        args: ["-L", "soop,anc,indx,nd", "--skip=*.ipynb,docs/source/_build,echopype/test_data", "-w", "docs/source", "echopype"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,14 +7,14 @@ fsspec
 geopy
 jinja2
 netCDF4>1.6,<1.7.1
-numpy<2
+numpy
 pandas
 psutil>=5.9.1
 pynmea2
 pytz
 requests
 s3fs
-scipy<1.15.2
+scipy
 typing-extensions
 xarray>=2024.11.0
 zarr>=2,<3


### PR DESCRIPTION
This PR removes the version pinning for numpy and scipy to allow compatibility with newer versions and to simplify dependency management.

Actual versions
numpy 2.3.1 (from numpy<2)
scipy 1.16.0 (from scipy<1.15.2)

Resolves #1512
Resolves #1513