### PR TITLE
Update pr.yaml to run full test suite for all PR [all tests ci]

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -70,13 +70,8 @@ jobs:
       - name: Print Changed files
         run: echo "${{ steps.files.outputs.added_modified_renamed }}"
       - name: Running all Tests
-        if: contains(github.event.pull_request.title, '[all tests ci]')
         run: |
           pytest -vvv -rx --numprocesses=${{ env.NUM_WORKERS }} --max-worker-restart=3 --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings
-      - name: Running Tests
-        if: ${{ !contains(github.event.pull_request.title, '[all tests ci]') }}
-        run: |
-          python .ci_helpers/run-test.py --pytest-args="--log-cli-level=WARNING,-vvv,-rx,--numprocesses=${{ env.NUM_WORKERS }},--max-worker-restart=3,--disable-warnings" --include-cov ${{ steps.files.outputs.added_modified_renamed }}
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
This PR updates the pr.yaml GitHub Actions workflow to always run the full test suite for all pull requests, regardless of the PR title, by removing the conditional logic that previously limited full test runs to PRs titled with [all tests ci].