### PR TITLE
Add weill to codespell ignore list

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,4 +39,4 @@ repos:
       - id: codespell
         # Checks spelling in `docs/source` and `echopype` dirs ONLY
         # Ignores `.ipynb` files and `_build` folders
-        args: ["-L", "soop,anc,indx", "--skip=*.ipynb,docs/source/_build,echopype/test_data", "-w", "docs/source", "echopype"]
+        args: ["-L", "soop,anc,indx,weill", "--skip=*.ipynb,docs/source/_build,echopype/test_data", "-w", "docs/source", "echopype"]


### PR DESCRIPTION
Extend .pre-commit-config.yaml to ignore the word "weill", which is used as a method in the shoal detection module. If not, codespell incorrectly flags and auto-corrects it to "will".