### PR TITLE
Modifications to match xarray update to v2025.9.1

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,8 @@ jobs:
   test:
     name: ${{ matrix.python-version }}--${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
-    if: ${{ !contains(github.event.pull_request.title, '[skip ci]') }}
+    # safe on workflow_dispatch (no PR object)
+    if: ${{ !contains(github.event.pull_request.title || '', '[skip ci]') }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
@@ -18,8 +19,8 @@ jobs:
         python-version: ["3.11", "3.12"]
         runs-on: [ubuntu-latest]
         experimental: [false]
+
     services:
-      # TODO: figure out how to update tag when there's a new one
       minio:
         image: cormorack/minioci:latest
         ports:
@@ -28,49 +29,62 @@ jobs:
         image: cormorack/http:latest
         ports:
           - 8080:80
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.
+
       - name: Set up Python
         uses: actions/setup-python@v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
+
       - name: Set environment variables
-        run: |
-          echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
+        run: echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
+
       - name: Remove docker-compose python
         run: sed -i "/docker-compose/d" requirements-dev.txt
+
       - name: Install dev tools
         run: python -m pip install -r requirements-dev.txt
-      # We only want to install this on one run, because otherwise we'll have
-      # duplicate annotations.
+
       - name: Install error reporter
         if: ${{ matrix.python-version == '3.12' }}
         run: python -m pip install pytest-github-actions-annotate-failures
+
       - name: Install echopype
         run: python -m pip install -e ".[plot]"
+
       - name: Print installed packages
         run: python -m pip list
+
       - name: Copying test data to services
         run: |
           python .ci_helpers/docker/setup-services.py --deploy --data-only --http-server ${{ job.services.httpserver.id }}
-
           # Check data endpoint
           curl http://localhost:8080/data/
+
+      # ⬇️ Skip on workflow_dispatch (the action doesn't support it)
       - name: Finding changed files
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         id: files
         uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'csv'
+
       - name: Print Changed files
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: echo "${{ steps.files.outputs.added_modified_renamed }}"
+
       - name: Running all Tests
         run: |
           pytest -vvv -rx --numprocesses=${{ env.NUM_WORKERS }} --max-worker-restart=3 --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings
+
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,7 +1,8 @@
 name: Test PR
 
 on:
-  workflow_dispatch:
+  pull_request:
+    paths-ignore: ["**/docker.yaml", "docs"]
 
 env:
   NUM_WORKERS: 2
@@ -10,8 +11,7 @@ jobs:
   test:
     name: ${{ matrix.python-version }}--${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
-    # safe on workflow_dispatch (no PR object)
-    if: ${{ !contains(github.event.pull_request.title || '', '[skip ci]') }}
+    if: ${{ !contains(github.event.pull_request.title, '[skip ci]') }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
@@ -19,8 +19,8 @@ jobs:
         python-version: ["3.11", "3.12"]
         runs-on: [ubuntu-latest]
         experimental: [false]
-
     services:
+      # TODO: figure out how to update tag when there's a new one
       minio:
         image: cormorack/minioci:latest
         ports:
@@ -29,62 +29,49 @@ jobs:
         image: cormorack/http:latest
         ports:
           - 8080:80
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.
-
       - name: Set up Python
         uses: actions/setup-python@v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
-
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
-
       - name: Set environment variables
-        run: echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
-
+        run: |
+          echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
       - name: Remove docker-compose python
         run: sed -i "/docker-compose/d" requirements-dev.txt
-
       - name: Install dev tools
         run: python -m pip install -r requirements-dev.txt
-
+      # We only want to install this on one run, because otherwise we'll have
+      # duplicate annotations.
       - name: Install error reporter
         if: ${{ matrix.python-version == '3.12' }}
         run: python -m pip install pytest-github-actions-annotate-failures
-
       - name: Install echopype
         run: python -m pip install -e ".[plot]"
-
       - name: Print installed packages
         run: python -m pip list
-
       - name: Copying test data to services
         run: |
           python .ci_helpers/docker/setup-services.py --deploy --data-only --http-server ${{ job.services.httpserver.id }}
+
           # Check data endpoint
           curl http://localhost:8080/data/
-
-      # ⬇️ Skip on workflow_dispatch (the action doesn't support it)
       - name: Finding changed files
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         id: files
         uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'csv'
-
       - name: Print Changed files
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: echo "${{ steps.files.outputs.added_modified_renamed }}"
-
       - name: Running all Tests
         run: |
           pytest -vvv -rx --numprocesses=${{ env.NUM_WORKERS }} --max-worker-restart=3 --cov=echopype --cov-report=xml --log-cli-level=WARNING --disable-warnings
-
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,8 +1,7 @@
 name: Test PR
 
 on:
-  pull_request:
-    paths-ignore: ["**/docker.yaml", "docs"]
+  workflow_dispatch:
 
 env:
   NUM_WORKERS: 2

--- a/echopype/echodata/echodata.py
+++ b/echopype/echodata/echodata.py
@@ -472,9 +472,7 @@ class EchoData:
                 ext_var = mappings_expanded[platform_var]["external_var"]
                 platform_var_attrs = platform[platform_var].attrs.copy()
 
-                # Create new (replaced) variable using dataset "update"
-                # With update, dropping the variable first is not needed
-                platform = platform.update({platform_var: (time_dim, ext_ds[ext_var].data)})
+                platform[platform_var] = (time_dim, ext_ds[ext_var].data)
 
                 # Assign attributes to newly created (replaced) variables
                 var_attrs = platform_var_attrs

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -69,7 +69,9 @@ def save_file(ds, path, mode, engine, group=None, compression_settings=None, **k
 
     # Allows saving both NetCDF and Zarr files from an xarray dataset
     if engine == "netcdf4":
-        ds.to_netcdf(path=path, mode=mode, group=group, encoding=encoding, **kwargs)
+        ds.to_netcdf(
+            path=path, mode=mode, group=group, encoding=encoding, engine="netcdf4", **kwargs
+        )
     elif engine == "zarr":
         # Ensure that encoding and chunks match
         for var, enc in encoding.items():


### PR DESCRIPTION
This PR updates two lines to be compatible with the latest xarray release v2025.9.1.

- Dataset.update() now returns None (in-place only).
- The default netCDF engine preference changed to h5netcdf/scipy, which breaks grouped writes unless we explicitly use netcdf4.

Maybe there are other changes to make too?
Mentions: #1549