### PR TITLE
Pin xarray to 2025.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ requests
 s3fs
 scipy
 typing-extensions
-xarray>=2024.11.0
+xarray==2025.10.1
 zarr>=3


### PR DESCRIPTION
Pinning xarray because the latest release (xarray 2025.11.0) changes the default for `keep_attrs`, causing attributes to be preserved by default (https://newreleases.io/project/pypi/xarray/release/2025.11.0). This introduces differences in DataArray metadata and makes several ECS-related tests fail (e.g., test_ecs_intake_ek80_CW_power). We need to check attribute propagation before unpinning!