### PR TITLE
Update azfp6 test data

### DIFF
--- a/.ci_helpers/docker/setup-services.py
+++ b/.ci_helpers/docker/setup-services.py
@@ -29,7 +29,7 @@ COMPOSE_FILE = BASE / "docker-compose.yaml"
 
 def get_pooch_data_path() -> Path:
     """Return path to the Pooch test data cache."""
-    ver = os.getenv("ECHOPYPE_DATA_VERSION", "v0.11.0")
+    ver = os.getenv("ECHOPYPE_DATA_VERSION", "v0.11.1a1")
     cache_dir = Path(pooch.os_cache("echopype")) / ver
     if not cache_dir.exists():
         raise FileNotFoundError(

--- a/.ci_helpers/setup-services-windows.py
+++ b/.ci_helpers/setup-services-windows.py
@@ -38,7 +38,7 @@ MINIO_PASS = "minioadmin"
 
 def get_pooch_cache() -> pathlib.Path:
     """Return the Pooch cache dir for the configured dataset version."""
-    ver = os.getenv("ECHOPYPE_DATA_VERSION", "v0.11.0")
+    ver = os.getenv("ECHOPYPE_DATA_VERSION", "v0.11.1a1")
     root = pathlib.Path(pooch.os_cache("echopype"))
     path = root / ver
     path.mkdir(parents=True, exist_ok=True)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
 env:
   NUM_WORKERS: 2
   USE_POOCH: "True"
-  ECHOPYPE_DATA_VERSION: v0.11.0
+  ECHOPYPE_DATA_VERSION: v0.11.1a1
   ECHOPYPE_DATA_BASEURL: https://github.com/OSOceanAcoustics/echopype/releases/download/{version}/
   XDG_CACHE_HOME: ${{ github.workspace }}/.cache
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ on:
 env:
   NUM_WORKERS: 2
   USE_POOCH: "True"
-  ECHOPYPE_DATA_VERSION: v0.11.0
+  ECHOPYPE_DATA_VERSION: v0.11.1a1
   ECHOPYPE_DATA_BASEURL: https://github.com/OSOceanAcoustics/echopype/releases/download/{version}/
   XDG_CACHE_HOME: ${{ github.workspace }}/.cache
 

--- a/echopype/tests/conftest.py
+++ b/echopype/tests/conftest.py
@@ -8,7 +8,7 @@ if os.getenv("USE_POOCH") == "True":
     import pooch
 
     # Lock to the known-good assets release (can be overridden via env if needed)
-    ver = os.getenv("ECHOPYPE_DATA_VERSION", "v0.11.0")
+    ver = os.getenv("ECHOPYPE_DATA_VERSION", "v0.11.1a1")
     base = os.getenv(
         "ECHOPYPE_DATA_BASEURL",
         "https://github.com/OSOceanAcoustics/echopype/releases/download/{version}/",
@@ -24,11 +24,11 @@ if os.getenv("USE_POOCH") == "True":
         "es60.zip", "es70.zip", "es80.zip", "legacy_datatree.zip",
     ]
 
-    # v0.11.0 checksums (GitHub release assets)
+    # v0.11.1a1 checksums (GitHub release assets)
     registry = {
         "ad2cp.zip": "sha256:78c634c7345991177b267c4cbb31f391990d2629b7f4a546da20d5126978b98a",
         "azfp.zip": "sha256:5f6a57c5dce323d4cb280c72f0d64c15f79be69b02f4f3a1228fc519d48b690f",
-        "azfp6.zip": "sha256:81b4e5cc11ede8fc67af63a7c7688a63f30a35fcd78fd02b6d36ee4c1eb64404",
+        "azfp6.zip": "sha256:98228329333064fb4b44d3044296c79d58ac22f6d81f7f22cf770bacf0e882fd",
         "ea640.zip": "sha256:49f70bd6f2355cb3c4c7a5b31fc00f7ae8c8a9ae888f0df1efe759032f9580df",
         "ecs.zip": "sha256:dcc312baa1e9da4488f33bef625b1f86c8a92e3262e34fc90ccd0a4f90d1e313",
         "ek60.zip": "sha256:66735de0ac584ec8a150b54b1a54024a92195f64036134ffdc9d472d7e155bb2",
@@ -180,4 +180,3 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
             tr.write_line(f"  … and {len(xfailed) - 20} more", yellow=True)
 
     tr.write_line("")  # trailing newline
-


### PR DESCRIPTION
Update azfp6 sha256 and version tag for pooch data, since the new files are in a pre-release v0.11.1a1.