### PR TITLE
CI: cap pandas <3 to avoid regression with flox/xarray grouping

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ jinja2
 netCDF4>1.6
 numpy
 pandas<3
-pyarrow<23
 psutil>=5.9.1
 pynmea2
 pytz


### PR DESCRIPTION
Temporary changes to investigate pandas 3.0 and flox errors