### PR TITLE
fix: correct SNR_threshold type annotation and xarray scalar extraction

### DIFF
--- a/echopype/calibrate/cal_params.py
+++ b/echopype/calibrate/cal_params.py
@@ -410,7 +410,7 @@ def get_cal_params_EK(
             # loop through channel since transceiver can vary
             fs = []
             for ch in vend["channel"]:
-                tcvr_type = vend["transceiver_type"].sel(channel=ch).data.tolist().upper()
+                tcvr_type = vend["transceiver_type"].sel(channel=ch).values.item().upper()
                 fs.append(default_params["receiver_sampling_frequency"][tcvr_type])
             return xr.DataArray(fs, dims=["channel"], coords={"channel": vend["channel"]})
 

--- a/echopype/clean/api.py
+++ b/echopype/clean/api.py
@@ -439,7 +439,7 @@ def remove_background_noise(
     ping_num: int,
     range_sample_num: int,
     background_noise_max: str = None,
-    SNR_threshold: float = "3.0dB",
+    SNR_threshold: str = "3.0dB",
 ) -> xr.Dataset:
     """
     Remove noise by using estimates of background noise


### PR DESCRIPTION
- clean/api.py: Change SNR_threshold parameter type hint from float to str to match its default value '3.0dB'
- calibrate/cal_params.py: Use .values.item() instead of .data.tolist() for xarray scalar extraction (forward-compatible API)