### PR TITLE
ci: add pip caching, concurrency groups, and auto worker count

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,8 +7,12 @@ on:
     paths-ignore: ["**/docker.yaml"]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
-  NUM_WORKERS: 2
+  NUM_WORKERS: auto
   USE_POOCH: "True"
   ECHOPYPE_DATA_VERSION: v0.11.1a2
   ECHOPYPE_DATA_BASEURL: https://github.com/OSOceanAcoustics/echopype/releases/download/{version}/
@@ -67,6 +71,7 @@ jobs:
         uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
       - name: System usage (baseline)
         if: runner.os == 'Linux'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,9 +8,12 @@ on:
       - ci/*
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 env:
-  NUM_WORKERS: 2
+  NUM_WORKERS: auto
   USE_POOCH: "True"
   ECHOPYPE_DATA_VERSION: v0.11.1a2
   ECHOPYPE_DATA_BASEURL: https://github.com/OSOceanAcoustics/echopype/releases/download/{version}/
@@ -71,7 +74,7 @@ jobs:
         uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-
+          cache: pip
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
@@ -168,6 +171,7 @@ jobs:
       - uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip


### PR DESCRIPTION
## Overview
Small CI quality-of-life improvements for pr.yaml and build.yaml:
- adding `cache: pip` to all setup-python steps (Linux and Windows) avoids re-downloading ~200 MB of wheels on every run;
- concurrency groups with cancel-in-progress helps when a new commit is pushed to a PR (or to main) and there's already a workflow running
- `NUM_WORKERS: auto` help pytest-xdist detect the optimal parallelism at runtime (GitHub-hosted ubuntu-latest and windows-latest runners have 4 vCPUs)  

## Changes:
- Add cache: pip to all setup-python steps (pr.yaml Linux+Windows, build.yaml)
- Add concurrency groups with cancel-in-progress to both workflows
- Change NUM_WORKERS from 2 to auto (pytest-xdist detects optimal count)

Also, I noticed that pytest.ini defines unit and integration markers, very few tests are currently marked. The majority run unmarked in a single undifferentiated pass. I'd be happy to put together a PR that marks the existing test suite:
- unit: tests that use only synthetic/in-memory data, no Pooch downloads, no Docker services
- integration: tests that fetch real data via Pooch, require MinIO/HTTP services, or do end-to-end file round-trips

@leewujung @LOCEANlloydizard Let me know if you'd consider this valuable. It would help us to run more "unit testable" tests locally during development.