### PR TITLE
docs: Update copyright year and institute name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ NOAA Ocean Exploration, NOAA Fisheries,
 and the VOTO Foundation.
 We also acknowledge software engineering support from
 the University of Washington Scientific Software Engineering Center (SSEC),
-as part of the Schmidt Futures Virtual Institute for Scientific Software (VISS) in 2023.
+as part of the Schmidt Sciences Virtual Institute for Scientific Software (VISS) in 2023.
 
 <table align="center" border="0" cellpadding="12" cellspacing="0" style="border-collapse: collapse;">
   <tr>
@@ -153,4 +153,4 @@ Echopype is licensed under the open source [Apache 2.0 license](https://opensour
 
 ---------------
 
-Copyright (c) 2018-2024, Echopype Developers.
+Copyright (c) 2018-2026, Echopype Developers.


### PR DESCRIPTION
This pull request makes minor updates to the `README.md` file, correcting an organizational name and updating the copyright year.

- Documentation updates:
  * Corrected "Schmidt Futures" to "Schmidt Sciences" in the list of supporting organizations.
  * Updated the copyright year from 2024 to 2026.