### PR TITLE
Fix deprecations and warnings in tests

### DIFF
--- a/echopype/tests/calibrate/test_calibrate_ek80.py
+++ b/echopype/tests/calibrate/test_calibrate_ek80.py
@@ -252,7 +252,10 @@ def test_ek80_BB_power_from_complex(
 
     # Power: only compare non-Nan, non-Inf values
     pyel_vals = pyel_BB_p_data["power"]
-    ep_vals = 10 * np.log10(prx.sel(channel=ch_sel).data)
+    ep_vals = prx.sel(channel=ch_sel).data.astype(float)
+    # Set non-positive values to NaN before log10 to avoid warnings
+    ep_vals[ep_vals <= 0] = np.nan
+    ep_vals = 10 * np.log10(ep_vals)
     assert pyel_vals.shape == ep_vals.shape
     idx_to_cmp = ~(
         np.isinf(pyel_vals) | np.isnan(pyel_vals) | np.isinf(ep_vals) | np.isnan(ep_vals)

--- a/echopype/tests/clean/test_transient_noise.py
+++ b/echopype/tests/clean/test_transient_noise.py
@@ -148,7 +148,7 @@ def test_matecho_bottom_var_optional(ds_small):
 
     # Provide a synthetic shallow bottom to exercise the code path
     shallow = xr.DataArray(
-        np.full(ds_small.dims["ping_time"], 300.0),
+        np.full(ds_small.sizes["ping_time"], 300.0),
         dims=["ping_time"],
         coords=[ds_small["ping_time"]],
         name="bottom",

--- a/echopype/tests/commongrid/conftest.py
+++ b/echopype/tests/commongrid/conftest.py
@@ -79,7 +79,7 @@ def mock_parameters():
         "channel_len": 2,
         "ping_time_len": 10,
         "depth_len": 20,
-        "ping_time_interval": "0.3S",
+        "ping_time_interval": "0.3s",
     }
 
 
@@ -389,7 +389,7 @@ def ds_Sv_echo_range_irregular(random_number_generator):
     depth_interval = [0.5, 0.32, 0.13]
     depth_ping_time_len = [100, 300, 200]
     ping_time_len = 600
-    ping_time_interval = "0.3S"
+    ping_time_interval = "0.3s"
     return _gen_Sv_echo_range_irregular(
         depth_interval=depth_interval,
         depth_ping_time_len=depth_ping_time_len,


### PR DESCRIPTION
- use ds.sizes instead of ds.dims (xarray deprecation)
- use lowercase time units ("0.3s") for pandas compatibility
- mask non-positive values before log10 in calibration test