### PR TITLE
Change compressor (zarr v2) to compressors (zarr v3)

### DIFF
--- a/echopype/tests/echodata/test_echodata_combine.py
+++ b/echopype/tests/echodata/test_echodata_combine.py
@@ -402,7 +402,8 @@ def test_combined_encodings(ek60_test_data):
 
     combined = echopype.combine_echodata(eds)
 
-    encodings_to_drop = {'chunks', 'preferred_chunks', 'compressor', 'filters'}
+    # TODO: lazy_encodings is empty in this current test, so test not actually functioning?
+    encodings_to_drop = {'chunks', 'preferred_chunks', 'compressors', 'filters'}
 
     group_checks = []
     for _, value in combined.group_map.items():

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -17,10 +17,10 @@ DEFAULT_TIME_ENCODING = {
 COMPRESSION_SETTINGS = {
     "netcdf4": {"zlib": True, "complevel": 4},
     "zarr": {
-        "float": {"compressor": BloscCodec(cname="zstd", clevel=3, shuffle="bitshuffle")},
-        "int": {"compressor": BloscCodec(cname="lz4", clevel=5, shuffle="shuffle", blocksize=0)},
-        "string": {"compressor": BloscCodec(cname="lz4", clevel=5, shuffle="shuffle", blocksize=0)},
-        "time": {"compressor": BloscCodec(cname="lz4", clevel=5, shuffle="shuffle", blocksize=0)},
+        "float": {"compressors": [BloscCodec(cname="zstd", clevel=3, shuffle="bitshuffle")]},
+        "int": {"compressors": [BloscCodec(cname="lz4", clevel=5, shuffle="shuffle", blocksize=0)]},
+        "string": {"compressors": [BloscCodec(cname="lz4", clevel=5, shuffle="shuffle", blocksize=0)]},
+        "time": {"compressors": [BloscCodec(cname="lz4", clevel=5, shuffle="shuffle", blocksize=0)]},
     },
 }
 

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -19,8 +19,12 @@ COMPRESSION_SETTINGS = {
     "zarr": {
         "float": {"compressors": [BloscCodec(cname="zstd", clevel=3, shuffle="bitshuffle")]},
         "int": {"compressors": [BloscCodec(cname="lz4", clevel=5, shuffle="shuffle", blocksize=0)]},
-        "string": {"compressors": [BloscCodec(cname="lz4", clevel=5, shuffle="shuffle", blocksize=0)]},
-        "time": {"compressors": [BloscCodec(cname="lz4", clevel=5, shuffle="shuffle", blocksize=0)]},
+        "string": {
+            "compressors": [BloscCodec(cname="lz4", clevel=5, shuffle="shuffle", blocksize=0)]
+        },
+        "time": {
+            "compressors": [BloscCodec(cname="lz4", clevel=5, shuffle="shuffle", blocksize=0)]
+        },
     },
 }
 


### PR DESCRIPTION
This is a bug surfaced in running the krill_freq_diff.pynb notebook on echopype-examples: https://github.com/OSOceanAcoustics/echopype-examples/issues/92

It turns out Zarr v3 supports condec chaining so instead of compressor, it uses compressors (plural)! The example is given in the Zarr documentation: https://docs.xarray.dev/en/stable/user-guide/io.html#zarr-compressors-and-filters

I also found this test is not doing anything. It might be something that was functioning but then something got changed so the test is no longer needed -- @LOCEANlloydizard if you have a moment could you confirm I am not mistaking, that the `lazy_encodings` is indeed empty? If so, maybe we drop it?

@ctuguinay : I think this is why your temp fix to do `compress=False` worked in https://github.com/OSOceanAcoustics/echopype-examples/pull/89, but it's not the root of the problem.