### PR TITLE
Pad parameters with different lengths across channel in vendor group

### DIFF
--- a/echopype/convert/set_groups_ek80.py
+++ b/echopype/convert/set_groups_ek80.py
@@ -1263,7 +1263,17 @@ class SetGroupsEK80(SetGroupsBase):
 
         # make values into numpy arrays
         for p in param_dict.keys():
-            param_dict[p] = np.array(param_dict[p])
+            values = [np.atleast_1d(value) for value in param_dict[p]]
+            lengths = {len(value) for value in values}
+            if len(lengths) == 1:
+                param_dict[p] = np.array(param_dict[p])
+            else:  # pad NaN for parameters that have different lengths across channel
+                max_len = max(lengths)
+                padded = np.full((len(values), max_len), np.nan)
+                for i, value in enumerate(values):
+                    value_array = np.asarray(value, dtype=float).reshape(-1)
+                    padded[i, : len(value_array)] = value_array
+                param_dict[p] = padded
 
         # Param size check
         if (


### PR DESCRIPTION
This PR adds a short code section to pad parameters with different lengths across channel in the vendor group.

This was only encountered so far in an EA640 setup in which the lower freq channels contain a smaller number of pulse length choices than the higher freq channels.
