### PR TITLE
Fix docstring sections that weren't getting into the rendered docs

### DIFF
--- a/echopype/clean/api.py
+++ b/echopype/clean/api.py
@@ -526,18 +526,12 @@ def detect_transient(ds: xr.Dataset, method: str, params: dict) -> xr.DataArray:
     (e.g. ``"fielding"``, ``"matecho"``). Any optional arguments omitted in
     ``params`` are filled by that method’s own defaults.
 
-    Common expectations
-    -------------------
-    - ``ds`` must contain Sv in dB (default variable name ``"Sv"``).
-    - Sv should include at least ``ping_time`` and a vertical/range coordinate
-      (e.g. ``range_sample`` or a ``depth``).
-    - Returned mask is aligned to Sv (same dims/order) with semantics
-      **True = VALID (keep)**, **False = transient noise**.
-
     Parameters
     ----------
     ds : xr.Dataset
-        Acoustic dataset with Sv and required coordinates.
+        Acoustic dataset with Sv and required coordinates. Must contain Sv in dB
+        (default variable name ``"Sv"``) and include at least ``ping_time`` and a vertical/range
+        coordinate (e.g. ``range_sample`` or a ``depth``).
     method : str
         Name of the detection method. Supported:
           - ``"fielding"``  → modified Fielding-style deep transient detector
@@ -547,9 +541,7 @@ def detect_transient(ds: xr.Dataset, method: str, params: dict) -> xr.DataArray:
         Method-specific keyword arguments (see below). Omitted keys fall back to
         the method’s defaults.
 
-    Method-specific arguments
-    -------------------------
-    fielding
+    When method == "fielding", params can contain:
         var_name : str, default "Sv"
             Name of the Sv variable (dB).
         range_var : str, default "depth"
@@ -570,7 +562,7 @@ def detect_transient(ds: xr.Dataset, method: str, params: dict) -> xr.DataArray:
             Number of initial pings treated as uncomputable in the auxiliary mask
             (note: they are still kept/VALID unless you decide otherwise).
 
-    matecho
+    When method == "matecho", params can contain:
         var_name : str, default "Sv"
             Name of the Sv variable (dB).
         range_var : str, default "depth"
@@ -594,7 +586,8 @@ def detect_transient(ds: xr.Dataset, method: str, params: dict) -> xr.DataArray:
         min_window : float, default 20
             Minimum usable window height (m); skip if smaller.
 
-    ryan (**TODO**)
+    When method == "ryan", params can contain:
+        ryan (**TODO**)
 
 
     Returns

--- a/echopype/mask/api.py
+++ b/echopype/mask/api.py
@@ -896,9 +896,7 @@ def detect_seafloor(
         Method-specific keyword arguments (see below). Unspecified keys use
         the method's defaults.
 
-    Method-specific arguments
-    -------------------------
-    basic
+    When method == "basic", params can contain:
         var_name : str
             Name of Sv variable (dB), e.g. ``"Sv"``.
         channel : str
@@ -913,7 +911,7 @@ def detect_seafloor(
         bin_skip_from_surface : int, default 200
             Number of shallow range bins to ignore before searching.
 
-    blackwell
+    When method == "blackwell", params can contain:
         var_name : str
             Name of the Sv variable to use (e.g., ``"Sv"``).
         channel : str


### PR DESCRIPTION
Part of the docstrings for `clean/api.py` and `mask/api.py` use unsupported section names (`Common expectations` and `Method-specific arguments`) that are not rendered in the final documentation.

This PR moves the text in those sections to be under sections that are rendered in the documentation.