### PR TITLE
Remove duplicate EK80 multiplex fixture

### DIFF
--- a/echopype/tests/calibrate/test_calibrate_ek80.py
+++ b/echopype/tests/calibrate/test_calibrate_ek80.py
@@ -27,11 +27,6 @@ def ek80_ext_path(test_path):
 def ek80_multiplex_path(test_path):
     return test_path["EK80_MULTIPLEX"]
 
-@pytest.fixture
-def ek80_multiplex_path(test_path):  # noqa: F811
-    return test_path["EK80_MULTI"]
-
-
 @pytest.mark.integration
 def test_ek80_transmit_chirp(ek80_cal_path, ek80_ext_path):
     """

--- a/echopype/tests/conftest.py
+++ b/echopype/tests/conftest.py
@@ -179,7 +179,6 @@ def test_path():
         "EK80_SEQUENCE": TEST_DATA_FOLDER / "ek80_sequence",
         "EK80_CAL": TEST_DATA_FOLDER / "ek80_bb_with_calibration",
         "EK80_EXT": TEST_DATA_FOLDER / "ek80_ext",
-        "EK80_MULTI": TEST_DATA_FOLDER / "ek80_bb_complex_multiplex",
         "ECS": TEST_DATA_FOLDER / "ecs",
         "LEGACY_DATATREE": TEST_DATA_FOLDER / "legacy_datatree",
         "RESAMPLE_GEOMETRY": TEST_DATA_FOLDER / "resample_to_geometry_example_data",


### PR DESCRIPTION
Removes the duplicate `ek80_multiplex_path` fixture and the redundant `EK80_MULTI` test-data alias.

Closes #1675