### PR TITLE
chore: group EK60 and EK80 model families

### DIFF
--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -92,7 +92,7 @@ def _compute_cal(
 
     # Calibrate as a single dataset if not Ex80
     model_family = SONAR_MODELS[echodata.sonar_model]["family"]
-    if model_family not in ["EX80"]:
+    if model_family not in ["Ex80"]:
         cal_ds = _compute_cal_ds(echodata, slice_dict={})
 
     # If Ex80

--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -1,6 +1,7 @@
 import numpy as np
 import xarray as xr
 
+from ..core import SONAR_MODELS
 from ..echodata import EchoData
 from ..echodata.simrad import check_input_args_combination, retrieve_correct_beam_group
 from ..utils.log import _init_logger
@@ -90,7 +91,8 @@ def _compute_cal(
         return cal_ds
 
     # Calibrate as a single dataset if not Ex80
-    if echodata.sonar_model not in ["EK80", "ES80", "EA640"]:
+    model_family = SONAR_MODELS[echodata.sonar_model]["family"]
+    if model_family not in ["EX80"]:
         cal_ds = _compute_cal_ds(echodata, slice_dict={})
 
     # If Ex80

--- a/echopype/calibrate/range.py
+++ b/echopype/calibrate/range.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 import xarray as xr
 
+from ..core import SONAR_MODELS
 from ..echodata import EchoData
 from .env_params import harmonize_env_param_time
 
@@ -119,17 +120,14 @@ def compute_range_EK(
         The range (``echo_range``) of the data in meters.
     """
     # sound_speed should exist already
-    if sonar_model in ("EK60", "ES70"):
-        ek_str = "EK60"
-    elif sonar_model in ("EK80", "ES80", "EA640"):
-        ek_str = "EK80"
-    else:
-        raise ValueError("The specified sonar_model is not supported!")
+    model_family = SONAR_MODELS[sonar_model]["family"]
+    if model_family not in ["EX60", "EX80"]:
+        raise ValueError(f"The specified sonar_model {sonar_model} is not supported!")
 
     if "sound_speed" not in env_params:
         raise RuntimeError(
             "sounds_speed not included in env_params, "
-            f"use echopype.calibrate.env_params.get_env_params_{ek_str}() to compute env_params "
+            "use echopype.calibrate.env_params.get_env_params_EK() to compute env_params "
         )
     else:
         sound_speed = env_params["sound_speed"]
@@ -183,14 +181,15 @@ def range_mod_TVG_EK(
             mod = mod.squeeze().drop_vars("time1")
         return mod
 
+    model_family = SONAR_MODELS[sonar_model]["family"]
     # If EK60
-    if sonar_model in ["EK60", "ES70"]:
+    if model_family == "EX60":
         range_meter = range_meter - mod_Ex60()
 
     # If EK80:
     # - compute range first assuming all channels have Ex80 style hardware
     # - change range for channels with Ex60 style hardware (GPT)
-    elif sonar_model in ["EK80", "ES80", "EA640"]:
+    elif model_family == "EX80":
         range_meter = range_meter - mod_Ex80()
 
         # Change range for all channels with GPT

--- a/echopype/calibrate/range.py
+++ b/echopype/calibrate/range.py
@@ -121,7 +121,7 @@ def compute_range_EK(
     """
     # sound_speed should exist already
     model_family = SONAR_MODELS[sonar_model]["family"]
-    if model_family not in ["EX60", "EX80"]:
+    if model_family not in ["Ex60", "Ex80"]:
         raise ValueError(f"The specified sonar_model {sonar_model} is not supported!")
 
     if "sound_speed" not in env_params:
@@ -183,13 +183,13 @@ def range_mod_TVG_EK(
 
     model_family = SONAR_MODELS[sonar_model]["family"]
     # If EK60
-    if model_family == "EX60":
+    if model_family == "Ex60":
         range_meter = range_meter - mod_Ex60()
 
     # If EK80:
     # - compute range first assuming all channels have Ex80 style hardware
     # - change range for channels with Ex60 style hardware (GPT)
-    elif model_family == "EX80":
+    elif model_family == "Ex80":
         range_meter = range_meter - mod_Ex80()
 
         # Change range for all channels with GPT

--- a/echopype/consolidate/api.py
+++ b/echopype/consolidate/api.py
@@ -9,6 +9,7 @@ import numpy as np
 import xarray as xr
 
 from ..calibrate.ek80_complex import get_filter_coeff
+from ..core import SONAR_MODELS
 from ..echodata import EchoData
 from ..echodata.simrad import retrieve_correct_beam_group
 from ..utils.align import align_to_ping_time
@@ -476,7 +477,8 @@ def add_splitbeam_angle(
     echodata = open_source(echodata, "echodata", storage_options)
 
     # ensure that echodata was produced by EK60 or EK80-like sensors
-    if echodata.sonar_model not in ["EK60", "ES70", "EK80", "ES80", "EA640"]:
+    model_family = SONAR_MODELS[echodata.sonar_model]["family"]
+    if model_family not in ["EX60", "EX80"]:
         raise ValueError(
             "The sonar model that produced echodata does not have split-beam "
             "transducers, split-beam angles cannot be added to source_Sv!"

--- a/echopype/consolidate/api.py
+++ b/echopype/consolidate/api.py
@@ -478,7 +478,7 @@ def add_splitbeam_angle(
 
     # ensure that echodata was produced by EK60 or EK80-like sensors
     model_family = SONAR_MODELS[echodata.sonar_model]["family"]
-    if model_family not in ["EX60", "EX80"]:
+    if model_family not in ["Ex60", "Ex80"]:
         raise ValueError(
             "The sonar model that produced echodata does not have split-beam "
             "transducers, split-beam angles cannot be added to source_Sv!"

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -9,7 +9,7 @@ from xarray import DataTree
 from ..core import SONAR_MODELS
 
 if TYPE_CHECKING:
-    from ..core import SONAR_MODELS, EngineHint, PathHint, SonarModelsHint
+    from ..core import EngineHint, PathHint, SonarModelsHint
 # fmt: on
 from ..echodata.echodata import XARRAY_ENGINE_MAP, EchoData
 from ..utils import io

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -473,7 +473,7 @@ def open_raw(
     # Direct offload to zarr and rectangularization only available for some sonar models
     # No rectangularization for other sonar models not listed below
     model_family = SONAR_MODELS[sonar_model]["family"]
-    if model_family in ["EX60", "EX80"]:
+    if model_family in ["Ex60", "Ex80"]:
         # Perform rectangularization and offload to zarr
         # if the data expansion is too large to fit in memory
         parser.rectangularize_data(
@@ -495,7 +495,7 @@ def open_raw(
 
     # Top-level date_created varies depending on sonar model
     # Top-level is called "root" within tree
-    if model_family in ["EX60", "EX80"]:
+    if model_family in ["Ex60", "Ex80"]:
         tree_dict["/"] = setgrouper.set_toplevel(
             sonar_model=sonar_model,
             date_created=parser.config_datagram["timestamp"],
@@ -506,7 +506,7 @@ def open_raw(
         )
     tree_dict["Environment"] = setgrouper.set_env()
     tree_dict["Platform"] = setgrouper.set_platform()
-    if model_family in ["EX60", "EX80"]:
+    if model_family in ["Ex60", "Ex80"]:
         tree_dict["Platform/NMEA"] = setgrouper.set_nmea()
     tree_dict["Provenance"] = setgrouper.set_provenance()
     # Allocate a tree_dict entry for Sonar? Otherwise, a DataTree error occurs
@@ -531,7 +531,7 @@ def open_raw(
             tree_dict[f"Sonar/Beam_group{idx}"] = beam_group
 
     model_family = SONAR_MODELS[sonar_model]["family"]
-    if model_family == "EX80":
+    if model_family == "Ex80":
         tree_dict["Sonar"] = setgrouper.set_sonar(beam_group_type=beam_group_type)
     else:
         tree_dict["Sonar"] = setgrouper.set_sonar()

--- a/echopype/convert/api.py
+++ b/echopype/convert/api.py
@@ -9,7 +9,7 @@ from xarray import DataTree
 from ..core import SONAR_MODELS
 
 if TYPE_CHECKING:
-    from ..core import EngineHint, PathHint, SonarModelsHint
+    from ..core import SONAR_MODELS, EngineHint, PathHint, SonarModelsHint
 # fmt: on
 from ..echodata.echodata import XARRAY_ENGINE_MAP, EchoData
 from ..utils import io
@@ -472,7 +472,8 @@ def open_raw(
 
     # Direct offload to zarr and rectangularization only available for some sonar models
     # No rectangularization for other sonar models not listed below
-    if sonar_model in ["EK60", "ES70", "EK80", "ES80", "EA640"]:
+    model_family = SONAR_MODELS[sonar_model]["family"]
+    if model_family in ["EX60", "EX80"]:
         # Perform rectangularization and offload to zarr
         # if the data expansion is too large to fit in memory
         parser.rectangularize_data(
@@ -494,7 +495,7 @@ def open_raw(
 
     # Top-level date_created varies depending on sonar model
     # Top-level is called "root" within tree
-    if sonar_model in ["EK60", "ES70", "EK80", "ES80", "EA640"]:
+    if model_family in ["EX60", "EX80"]:
         tree_dict["/"] = setgrouper.set_toplevel(
             sonar_model=sonar_model,
             date_created=parser.config_datagram["timestamp"],
@@ -505,7 +506,7 @@ def open_raw(
         )
     tree_dict["Environment"] = setgrouper.set_env()
     tree_dict["Platform"] = setgrouper.set_platform()
-    if sonar_model in ["EK60", "ES70", "EK80", "ES80", "EA640"]:
+    if model_family in ["EX60", "EX80"]:
         tree_dict["Platform/NMEA"] = setgrouper.set_nmea()
     tree_dict["Provenance"] = setgrouper.set_provenance()
     # Allocate a tree_dict entry for Sonar? Otherwise, a DataTree error occurs
@@ -529,7 +530,8 @@ def open_raw(
 
             tree_dict[f"Sonar/Beam_group{idx}"] = beam_group
 
-    if sonar_model in ["EK80", "ES80", "EA640"]:
+    model_family = SONAR_MODELS[sonar_model]["family"]
+    if model_family == "EX80":
         tree_dict["Sonar"] = setgrouper.set_sonar(beam_group_type=beam_group_type)
     else:
         tree_dict["Sonar"] = setgrouper.set_sonar()

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -6,7 +6,6 @@ import numpy as np
 import pynmea2
 import xarray as xr
 
-from ..core import SONAR_MODELS
 from ..echodata.convention import sonarnetcdf_1
 from ..utils.coding import COMPRESSION_SETTINGS, DEFAULT_TIME_ENCODING, set_time_encodings
 from ..utils.prov import echopype_prov_attrs, source_files_vars
@@ -113,6 +112,8 @@ class SetGroupsBase(abc.ABC):
         Replace nan in time coordinate to avoid xarray warning.
         """
         if len(time_val) == 1 and np.isnan(time_val[0]):
+            from ..core import SONAR_MODELS
+
             model_family = SONAR_MODELS[self.sonar_model]["family"]
             # set time_val to earliest ping_time among all channels
             if model_family in ["EX60", "EX80"]:

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -6,6 +6,7 @@ import numpy as np
 import pynmea2
 import xarray as xr
 
+from ..core import SONAR_MODELS
 from ..echodata.convention import sonarnetcdf_1
 from ..utils.coding import COMPRESSION_SETTINGS, DEFAULT_TIME_ENCODING, set_time_encodings
 from ..utils.prov import echopype_prov_attrs, source_files_vars
@@ -112,10 +113,11 @@ class SetGroupsBase(abc.ABC):
         Replace nan in time coordinate to avoid xarray warning.
         """
         if len(time_val) == 1 and np.isnan(time_val[0]):
+            model_family = SONAR_MODELS[self.sonar_model]["family"]
             # set time_val to earliest ping_time among all channels
-            if self.sonar_model in ["EK60", "ES70", "EK80", "ES80", "EA640"]:
+            if model_family in ["EX60", "EX80"]:
                 return [np.array([v[0] for v in self.parser_obj.ping_time.values()]).min()]
-            elif self.sonar_model in ["AZFP", "AZFP6"]:
+            elif model_family in ["AZFP", "AZFP6"]:
                 return [self.parser_obj.ping_time[0]]
             else:
                 return NotImplementedError(

--- a/echopype/convert/set_groups_base.py
+++ b/echopype/convert/set_groups_base.py
@@ -116,9 +116,9 @@ class SetGroupsBase(abc.ABC):
 
             model_family = SONAR_MODELS[self.sonar_model]["family"]
             # set time_val to earliest ping_time among all channels
-            if model_family in ["EX60", "EX80"]:
+            if model_family in ["Ex60", "Ex80"]:
                 return [np.array([v[0] for v in self.parser_obj.ping_time.values()]).min()]
-            elif model_family in ["AZFP", "AZFP6"]:
+            elif model_family == "AZFP":
                 return [self.parser_obj.ping_time[0]]
             else:
                 return NotImplementedError(

--- a/echopype/core.py
+++ b/echopype/core.py
@@ -67,7 +67,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "parser": ParseULS6,
         "parsed2zarr": None,
         "set_groups": SetGroupsAZFP6,
-        "family": "AZFP6",
+        "family": "AZFP",
     },
     "EK60": {
         "validate_ext": validate_ext(".raw"),
@@ -76,7 +76,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "accepts_idx": True,
         "parser": ParseEK60,
         "set_groups": SetGroupsEK60,
-        "family": "EX60",
+        "family": "Ex60",
     },
     "ES70": {
         "validate_ext": validate_ext(".raw"),
@@ -85,7 +85,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "accepts_idx": False,
         "parser": ParseEK60,
         "set_groups": SetGroupsEK60,
-        "family": "EX60",
+        "family": "Ex60",
     },
     "EK80": {
         "validate_ext": validate_ext(".raw"),
@@ -94,7 +94,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "accepts_idx": True,
         "parser": ParseEK80,
         "set_groups": SetGroupsEK80,
-        "family": "EX80",
+        "family": "Ex80",
     },
     "ES80": {
         "validate_ext": validate_ext(".raw"),
@@ -103,7 +103,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "accepts_idx": False,
         "parser": ParseEK80,
         "set_groups": SetGroupsEK80,
-        "family": "EX80",
+        "family": "Ex80",
     },
     "EA640": {
         "validate_ext": validate_ext(".raw"),
@@ -112,7 +112,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "accepts_idx": False,
         "parser": ParseEK80,
         "set_groups": SetGroupsEK80,
-        "family": "EX80",
+        "family": "Ex80",
     },
     "AD2CP": {
         "validate_ext": validate_ext(".ad2cp"),

--- a/echopype/core.py
+++ b/echopype/core.py
@@ -57,6 +57,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "parser": ParseULS5,
         "parsed2zarr": None,
         "set_groups": SetGroupsAZFP,
+        "family": "AZFP",
     },
     "AZFP6": {
         "validate_ext": validate_azfp_ext,
@@ -66,6 +67,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "parser": ParseULS6,
         "parsed2zarr": None,
         "set_groups": SetGroupsAZFP6,
+        "family": "AZFP6",
     },
     "EK60": {
         "validate_ext": validate_ext(".raw"),
@@ -74,6 +76,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "accepts_idx": True,
         "parser": ParseEK60,
         "set_groups": SetGroupsEK60,
+        "family": "EX60",
     },
     "ES70": {
         "validate_ext": validate_ext(".raw"),
@@ -82,6 +85,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "accepts_idx": False,
         "parser": ParseEK60,
         "set_groups": SetGroupsEK60,
+        "family": "EX60",
     },
     "EK80": {
         "validate_ext": validate_ext(".raw"),
@@ -90,6 +94,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "accepts_idx": True,
         "parser": ParseEK80,
         "set_groups": SetGroupsEK80,
+        "family": "EX80",
     },
     "ES80": {
         "validate_ext": validate_ext(".raw"),
@@ -98,6 +103,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "accepts_idx": False,
         "parser": ParseEK80,
         "set_groups": SetGroupsEK80,
+        "family": "EX80",
     },
     "EA640": {
         "validate_ext": validate_ext(".raw"),
@@ -106,6 +112,7 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "accepts_idx": False,
         "parser": ParseEK80,
         "set_groups": SetGroupsEK80,
+        "family": "EX80",
     },
     "AD2CP": {
         "validate_ext": validate_ext(".ad2cp"),
@@ -115,5 +122,6 @@ SONAR_MODELS: Dict["SonarModelsHint", Dict[str, Any]] = {
         "parser": ParseAd2cp,
         "parsed2zarr": None,
         "set_groups": SetGroupsAd2cp,
+        "family": "AD2CP",
     },
 }

--- a/echopype/echodata/sensor_ep_version_mapping/v05x_to_v06x.py
+++ b/echopype/echodata/sensor_ep_version_mapping/v05x_to_v06x.py
@@ -25,9 +25,9 @@ def _get_sensor(sensor_model):
     """
 
     model_family = SONAR_MODELS[sensor_model]["family"]
-    if model_family == "EX60":
+    if model_family == "Ex60":
         return "EK60"
-    elif model_family == "EX80":
+    elif model_family == "Ex80":
         return "EK80"
     else:
         return sensor_model

--- a/echopype/echodata/sensor_ep_version_mapping/v05x_to_v06x.py
+++ b/echopype/echodata/sensor_ep_version_mapping/v05x_to_v06x.py
@@ -24,9 +24,10 @@ def _get_sensor(sensor_model):
         Sensor model name provided in ``ed['Top-level'].keywords``
     """
 
-    if sensor_model in ["EK60", "ES70"]:
+    model_family = SONAR_MODELS[sensor_model]["family"]
+    if model_family == "EX60":
         return "EK60"
-    elif sensor_model in ["EK80", "ES80", "EA640"]:
+    elif model_family == "EX80":
         return "EK80"
     else:
         return sensor_model

--- a/echopype/echodata/simrad.py
+++ b/echopype/echodata/simrad.py
@@ -170,11 +170,11 @@ def retrieve_correct_beam_group(echodata: EchoData, waveform_mode: str, encode_m
     #       2) only power data would exist for EK60-like data
     #          and we have echodata["Sonar"]["waveform_encode_descr"] now
     model_family = SONAR_MODELS[echodata.sonar_model]["family"]
-    if model_family == "EX60":
+    if model_family == "Ex60":
         # check modes against data for EK60 and get power EchoData group
         return _retrieve_correct_beam_group_EK60(echodata, waveform_mode, encode_mode)
 
-    elif model_family == "EX80":
+    elif model_family == "Ex80":
         return _retrieve_correct_beam_group_EK80(echodata, waveform_mode, encode_mode)
     else:
         # raise error for unknown or unaccounted for sonar model

--- a/echopype/echodata/simrad.py
+++ b/echopype/echodata/simrad.py
@@ -6,6 +6,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
+from ..core import SONAR_MODELS
 from .echodata import EchoData
 
 
@@ -168,11 +169,12 @@ def retrieve_correct_beam_group(echodata: EchoData, waveform_mode: str, encode_m
     #       1) checks under _retrieve_correct_beam_group_EK60 are redundant, and
     #       2) only power data would exist for EK60-like data
     #          and we have echodata["Sonar"]["waveform_encode_descr"] now
-    if echodata.sonar_model in ["EK60", "ES70"]:
+    model_family = SONAR_MODELS[echodata.sonar_model]["family"]
+    if model_family == "EX60":
         # check modes against data for EK60 and get power EchoData group
         return _retrieve_correct_beam_group_EK60(echodata, waveform_mode, encode_mode)
 
-    elif echodata.sonar_model in ["EK80", "ES80", "EA640"]:
+    elif model_family == "EX80":
         return _retrieve_correct_beam_group_EK80(echodata, waveform_mode, encode_mode)
     else:
         # raise error for unknown or unaccounted for sonar model


### PR DESCRIPTION
Closes https://github.com/echostack-org/echopype/issues/1729.

Groups `EK60` and `EK80` model into different families to avoid `if else` across the code.