### PR TITLE
ci: adopt Scientific Python SPEC 0

### DIFF
--- a/.github/workflows/update-spec0.yml
+++ b/.github/workflows/update-spec0.yml
@@ -1,0 +1,23 @@
+name: Update dependency versions to meet SPEC 0
+
+on:
+  schedule:
+    # Day 3 of each quarter, after the quarterly SPEC 0 update
+    - cron: "0 0 3 1,4,7,10 *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: scientific-python/spec0-action@6d7df2702c1dfc225a7ce5918616db9a6a652901 # v1.4
+        with:
+          update_all: 2

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@
   </a>
 </div>
 
+<a href="https://scientific-python.org/specs/spec-0000/">
+  <img
+    src="https://img.shields.io/badge/SPEC-0-green?labelColor=%23004811&color=%235CA038"
+    alt="SPEC 0 — Minimum Supported Dependencies"
+  >
+</a>
+
 <div>
   <a href="https://github.com/echostack-org/echopype/actions/workflows/build.yaml">
     <img src="https://github.com/echostack-org/echopype/actions/workflows/build.yaml/badge.svg"/>
@@ -54,6 +61,9 @@ at SciPy 2019 for background, discussions and a quick demo!
 
 Learn more about echopype in the official documentation at https://echopype.readthedocs.io. Check out executable examples in the companion repository https://github.com/echostack-org/echopype-examples.
 
+## Dependency support policy
+
+Echopype follows [Scientific Python SPEC 0](https://scientific-python.org/specs/spec-0000/) for its minimum supported Python and core dependency versions.
 
 ## Contributing
 


### PR DESCRIPTION
we adopts Scientific Python SPEC 0:

- documenting the dependency support policy
- adding the official SPEC 0 badge
- adding a quarterly workflow to update Python and dependency lower bounds

Closes #1712